### PR TITLE
Updated ammopacks to contain correct amount of cartridges

### DIFF
--- a/db/traders/6765fbd20fdc7eb79b00000a/assort.json
+++ b/db/traders/6765fbd20fdc7eb79b00000a/assort.json
@@ -1,1232 +1,1067 @@
 {
     "barter_scheme": {
         "296cd34e1df0ea5f7c78eda1": [
-            [
-                {
+            [{
                     "_tpl": "57347c93245977448d35f6e3",
                     "count": 1
                 }
             ]
         ],
         "b3f674dcd7994f90a068e5e1": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1400
                 }
             ]
         ],
         "fe478372be29ef2e6fea6c8e": [
-            [
-                {
+            [{
                     "_tpl": "5c13cd2486f774072c757944",
                     "count": 1
                 }
             ]
         ],
         "0c67b04a47b6ab56302fef17": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2750
                 }
             ]
         ],
         "236ae5cd9fac1b13c4b0a230": [
-            [
-                {
+            [{
                     "_tpl": "544fb37f4bdc2dee738b4567",
                     "count": 2
-                },
-                {
+                }, {
                     "_tpl": "5755356824597772cb798962",
                     "count": 2
                 }
             ]
         ],
         "e965c7ec4cae4adbdd47be35": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24000
                 }
             ]
         ],
         "18fb4faa79dfab8cf109b8bf": [
-            [
-                {
+            [{
                     "_tpl": "590c661e86f7741e566b646a",
                     "count": 2
-                },
-                {
+                }, {
                     "_tpl": "544fb3f34bdc2d03748b456a",
                     "count": 1
-                },
-                {
+                }, {
                     "_tpl": "5e831507ea0a7c419c2f9bd9",
                     "count": 2
                 }
             ]
         ],
         "ec046ceec0607178aafcc540": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 18000
                 }
             ]
         ],
         "ca43ddb7a2ff58ee0b73b5b6": [
-            [
-                {
+            [{
                     "_tpl": "5c052f6886f7746b1e3db148",
                     "count": 3
                 }
             ]
         ],
         "5dffcffcb8cbba35c04b9dea": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 380000
                 }
             ]
         ],
         "31beb3ddfdc9ddaebfabb0f9": [
-            [
-                {
+            [{
                     "_tpl": "590c5c9f86f77477c91c36e7",
                     "count": 2
                 }
             ]
         ],
         "d7bd663d561e682fa66d579e": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24000
                 }
             ]
         ],
         "e1d9ef8f6a27ed0bad99d282": [
-            [
-                {
+            [{
                     "_tpl": "544fb25a4bdc2dfb738b4567",
                     "count": 1
-                },
-                {
+                }, {
                     "_tpl": "5c13cd2486f774072c757944",
                     "count": 1
                 }
             ]
         ],
         "9d8ec61fcbc51ec43f4d406f": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1950
                 }
             ]
         ],
         "edaa85667ccaa7d314460fa8": [
-            [
-                {
+            [{
                     "_tpl": "5af0548586f7743a532b7e99",
                     "count": 2
-                },
-                {
+                }, {
                     "_tpl": "5755383e24597772cb798966",
                     "count": 2
-                },
-                {
+                }, {
                     "_tpl": "590c695186f7741e566b64a2",
                     "count": 2
                 }
             ]
         ],
         "432016db2ae30eea29d0926d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24300
                 }
             ]
         ],
         "6caeda234b7dad5b3d5a1c5d": [
-            [
-                {
+            [{
                     "_tpl": "5d1b3f2d86f774253763b735",
                     "count": 2
                 }
             ]
         ],
         "664ccbdb08411483d983ff3d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 4900
                 }
             ]
         ],
         "97af3a0012e7150115892e74": [
-            [
-                {
+            [{
                     "_tpl": "590c695186f7741e566b64a2",
                     "count": 2
-                },
-                {
+                }, {
                     "_tpl": "544fb3f34bdc2d03748b456a",
                     "count": 1
                 }
             ]
         ],
         "d64ea3eb1ff99bff4b8dd7c5": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 14000
                 }
             ]
         ],
         "3d0cb29b9bee9a3ad426a2b2": [
-            [
-                {
+            [{
                     "_tpl": "5d02778e86f774203e7dedbe",
                     "count": 1
-                },
-                {
+                }, {
                     "_tpl": "590c678286f77426c9660122",
                     "count": 1
                 }
             ]
         ],
         "b50d2dbfd9fd7280dae6b23c": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 33000
                 }
             ]
         ],
         "ab95e89890d374edf6d804fd": [
-            [
-                {
+            [{
                     "_tpl": "544fb25a4bdc2dfb738b4567",
                     "count": 1
-                },
-                {
+                }, {
                     "_tpl": "5755356824597772cb798962",
                     "count": 2
-                },
-                {
+                }, {
                     "_tpl": "544fb37f4bdc2dee738b4567",
                     "count": 1
                 }
             ]
         ],
         "bde835c87ddeb15baa6a2667": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 9000
                 }
             ]
         ],
         "1d6cedd407aded383cd3f1d0": [
-            [
-                {
+            [{
                     "_tpl": "590c661e86f7741e566b646a",
                     "count": 2
-                },
-                {
+                }, {
                     "_tpl": "544fb3f34bdc2d03748b456a",
                     "count": 1
                 }
             ]
         ],
         "963fe9c5ef3b5fbbecfac0ae": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 22500
                 }
             ]
         ],
         "f6fd5f1b37c5fac4b77b5c8e": [
-            [
-                {
+            [{
                     "_tpl": "544fb3f34bdc2d03748b456a",
                     "count": 1
-                },
-                {
+                }, {
                     "_tpl": "544fb37f4bdc2dee738b4567",
                     "count": 4
                 }
             ]
         ],
         "0b6b65ec76753edaccf2da71": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 13000
                 }
             ]
         ],
         "07de2dd8f7af7ea3ca49dea6": [
-            [
-                {
+            [{
                     "_tpl": "57e26fc7245977162a14b800",
                     "count": 4
                 }
             ]
         ],
         "9eecaffa0cb6ddbccddb47fd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 20000
                 }
             ]
         ],
         "bf08bee90ce2d85bdbbd7591": [
-            [
-                {
+            [{
                     "_tpl": "5d1b392c86f77425243e98fe",
                     "count": 5
                 }
             ]
         ],
         "cc36008c3a9e5e48aaf90e46": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 32000
                 }
             ]
         ],
         "e6128dcefb016c69c572b79f": [
-            [
-                {
+            [{
                     "_tpl": "590c621186f774138d11ea29",
                     "count": 4
                 }
             ]
         ],
         "26de8c2b1dd68b5cedcd781a": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 138000
                 }
             ]
         ],
         "fc7ef60ac378aa2ee2fe4ce1": [
-            [
-                {
+            [{
                     "_tpl": "544fb3364bdc2d34748b456a",
                     "count": 2
-                },
-                {
+                }, {
                     "_tpl": "5751a25924597722c463c472",
                     "count": 2
-                },
-                {
+                }, {
                     "_tpl": "544fb37f4bdc2dee738b4567",
                     "count": 2
                 }
             ]
         ],
         "e63cba7f17cba8bec5d0df6a": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 8000
                 }
             ]
         ],
         "dc7bb11a67b4bebccedccaca": [
-            [
-                {
+            [{
                     "_tpl": "5755383e24597772cb798966",
                     "count": 3
-                },
-                {
+                }, {
                     "_tpl": "544fb37f4bdc2dee738b4567",
                     "count": 2
                 }
             ]
         ],
         "c1daddee7aead2ece4b7e2ca": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24000
                 }
             ]
         ],
         "c82ba4f25cd0586effdcbbf8": [
-            [
-                {
+            [{
                     "_tpl": "5d0377ce86f774186372f689",
                     "count": 3
                 }
             ]
         ],
         "462cefd5ddae8f6bab381b6e": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 185000
                 }
             ]
         ],
         "8ca7ba8c24bdfc361baacede": [
-            [
-                {
+            [{
                     "_tpl": "5d0375ff86f774186372f685",
                     "count": 5
                 }
             ]
         ],
         "b8ebacd89ab4fb24c4398dfd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 172000
                 }
             ]
         ],
         "fe4dddeecbba6d79cfdbabf7": [
-            [
-                {
+            [{
                     "_tpl": "590c392f86f77444754deb29",
                     "count": 3
                 }
             ]
         ],
         "81dcbbdcb9a6ef6752fe0fbb": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 152000
                 }
             ]
         ],
         "d11cfa4b99c1cfa92ccef995": [
-            [
-                {
+            [{
                     "_tpl": "5d1b309586f77425227d1676",
                     "count": 4
                 }
             ]
         ],
         "ba4b5efd1ab3e2bf0a547f51": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 43000
                 }
             ]
         ],
         "cab6fe7beb5c6efc23e8c34c": [
-            [
-                {
+            [{
                     "_tpl": "590a3d9c86f774385926e510",
                     "count": 5
                 }
             ]
         ],
         "bac2f080b35e85006ea3d7fd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 54000
                 }
             ]
         ],
         "933c0dfc0bab0c90210fc51e": [
-            [
-                {
+            [{
                     "_tpl": "5c052e6986f7746b207bc3c9",
                     "count": 2
                 }
             ]
         ],
         "2c6c79dfc30c4b8c56b1d1d8": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 256500
                 }
             ]
         ],
         "02adbe49c3da3ff3dedfbca2": [
-            [
-                {
+            [{
                     "_tpl": "590a373286f774287540368b",
                     "count": 3
                 }
             ]
         ],
         "e74bd4c8e8aad54ff7edf993": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 57000
                 }
             ]
         ],
         "fe44ffb6bf2550b2253286ee": [
-            [
-                {
+            [{
                     "_tpl": "590a3c0a86f774385a33c450",
                     "count": 5
                 }
             ]
         ],
         "fbfecbe8e8eff4585ad5be8f": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 36000
                 }
             ]
         ],
         "401d47ba10d19c030dd6c7eb": [
-            [
-                {
+            [{
                     "_tpl": "5d1b2ffd86f77425243e8d17",
                     "count": 3
                 }
             ]
         ],
         "4064dfe7bdfb2dcbb588ebef": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 36000
                 }
             ]
         ],
         "65ba7f61c561d8d4dca8287a": [
-            [
-                {
+            [{
                     "_tpl": "5c05300686f7746dce784e5d",
                     "count": 2
                 }
             ]
         ],
         "cddf2eedaaee1ed855325aa6": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 270000
                 }
             ]
         ],
         "255e685a05fe46fd6b46af5a": [
-            [
-                {
+            [{
                     "_tpl": "5c12613b86f7743bbe2c3f76",
                     "count": 3
                 }
             ]
         ],
         "df1baddd98542ee14eefefde": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 105000
                 }
             ]
         ],
         "eacba9139ba71c848ba0a4fa": [
-            [
-                {
+            [{
                     "_tpl": "5d403f9186f7743cac3f229b",
                     "count": 4
                 }
             ]
         ],
         "fac9bb2ff1bdd55c5d09f9ae": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 180000
                 }
             ]
         ],
         "aabde64d37dfb52e19841177": [
-            [
-                {
+            [{
                     "_tpl": "59faff1d86f7746c51718c9c",
                     "count": 1
                 }
             ]
         ],
         "b99f84c0c89cc0a0a71af70a": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 235000
                 }
             ]
         ],
         "c4cab056ec93fe0f1106c6dd": [
-            [
-                {
+            [{
                     "_tpl": "5751a25924597722c463c472",
                     "count": 1
-                },
-                {
+                }, {
                     "_tpl": "590c661e86f7741e566b646a",
                     "count": 2
-                },
-                {
+                }, {
                     "_tpl": "5e831507ea0a7c419c2f9bd9",
                     "count": 1
-                },
-                {
+                }, {
                     "_tpl": "5b4335ba86f7744d2837a264",
                     "count": 1
                 }
             ]
         ],
         "4c4d5d5c1126affe5ac8988b": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 34000
                 }
             ]
         ],
         "ba9aa88df8f0d8ea9b3f5ed3": [
-            [
-                {
+            [{
                     "_tpl": "5d02778e86f774203e7dedbe",
                     "count": 2
                 }
             ]
         ],
         "19cffd9e3ef6dbc9df27ebcb": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 69000
                 }
             ]
         ],
         "d46cef7809dbab9d538eafe5": [
-            [
-                {
+            [{
                     "_tpl": "56742c2e4bdc2d95058b456d",
                     "count": 3
                 }
             ]
         ],
         "35b94ceab1afe0fefec81fef": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 17000
                 }
             ]
         ],
         "64fbabbcca7e3bacb54d0ca5": [
-            [
-                {
+            [{
                     "_tpl": "57347ca924597744596b4e71",
                     "count": 2
                 }
             ]
         ],
         "1b29b4cdaeab7e690c4d3f5b": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 335000
                 }
             ]
         ],
         "1ebbadac895befe6b0de8aba": [
-            [
-                {
+            [{
                     "_tpl": "577e1c9d2459773cd707c525",
                     "count": 1
                 }
             ]
         ],
         "8cb5decc6f5dca9af262ed95": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1800
                 }
             ]
         ],
         "6fcdfa6e5e380f594ffeb4ce": [
-            [
-                {
+            [{
                     "_tpl": "5e831507ea0a7c419c2f9bd9",
                     "count": 1
-                },
-                {
+                }, {
                     "_tpl": "544fb37f4bdc2dee738b4567",
                     "count": 1
-                },
-                {
+                }, {
                     "_tpl": "5755356824597772cb798962",
                     "count": 3
                 }
             ]
         ],
         "acd2dfc926c090fe46b6eadd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5400
                 }
             ]
         ],
         "f8f0addd93bf96dc3fa8baa8": [
-            [
-                {
+            [{
                     "_tpl": "5d0376a486f7747d8050965c",
                     "count": 5
                 }
             ]
         ],
         "dda4fa330f096da94e9d81c3": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 148000
                 }
             ]
         ],
         "c6fe4ce275de1bf2eec3bc00": [
-            [
-                {
+            [{
                     "_tpl": "5f745ee30acaeb0d490d8c5b",
                     "count": 3
                 }
             ]
         ],
         "b9e2213c9da4adb80f18edee": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 126000
                 }
             ]
         ],
         "ea92d8455606338f534fbe2b": [
-            [
-                {
+            [{
                     "_tpl": "59e3639286f7741777737013",
                     "count": 2
                 }
             ]
         ],
         "b300dea5d6b91e0c9fdcdcfa": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 300000
                 }
             ]
         ],
         "8488c3505d05ab8c0e2dca7c": [
-            [
-                {
+            [{
                     "_tpl": "590c661e86f7741e566b646a",
                     "count": 2
-                },
-                {
+                }, {
                     "_tpl": "544fb37f4bdc2dee738b4567",
                     "count": 2
-                },
-                {
+                }, {
                     "_tpl": "5755356824597772cb798962",
                     "count": 3
                 }
             ]
         ],
         "4879f30eb43ccc1faecd0559": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 39300
                 }
             ]
         ],
         "60acc13a1d3e277eab7defbc": [
-            [
-                {
+            [{
                     "_tpl": "5e831507ea0a7c419c2f9bd9",
                     "count": 2
                 }
             ]
         ],
         "1abaf5adec1d2848cc09daec": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3000
                 }
             ]
         ],
         "013b74e2e962eb5b342cacb6": [
-            [
-                {
+            [{
                     "_tpl": "60391a8b3364dc22b04d0ce5",
                     "count": 3
                 }
             ]
         ],
         "cb5b71abe2b3433cb9c8cd13": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 58000
                 }
             ]
         ],
         "a21ba7c59fac6611daa459ee": [
-            [
-                {
+            [{
                     "_tpl": "59faff1d86f7746c51718c9c",
                     "count": 3
                 }
             ]
         ],
         "f863fc6d0eacccc5ad5535a7": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 369000
                 }
             ]
         ],
         "1cb2484a08e5db3b5e37af41": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "154867c34e24b23072b2dee0": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 52000
                 }
             ]
         ],
         "c4882a61d8b2be239c13b494": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "786036fd29bfaf00bec5c5b0": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 40000
                 }
             ]
         ],
         "4b9d28e454a4ff3aa33dcefb": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "b7fcc99b5cf753b5b6d400d8": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 40000
                 }
             ]
         ],
         "b12dd7656cc4faeb35a31e09": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "1d012074183a599d7c149ebb": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 150000
                 }
             ]
         ],
         "3b7fc4abf4ff9f74f620bec3": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "a029bbfb9b058bc8f25be586": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60000
                 }
             ]
         ],
         "51e9afbdfa34bc6bb1cc99f1": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 6000
                 }
             ]
         ],
         "af0fa3c7caa391e4f1f8b2fe": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 4500
                 }
             ]
         ],
         "f7e74aada5a556a9efcc70dd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 6000
                 }
             ]
         ],
         "d5ea7d470070ebca5a3caed9": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5000
                 }
             ]
         ],
         "ef68ad9bedb14eb19acebf53": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 4200
                 }
             ]
         ],
         "1b3d8cf6ebae7d9f4d2fafb3": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 6900
                 }
             ]
         ],
         "371fc0d3c86cba2c6df4abe9": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3600
                 }
             ]
         ],
         "965ef27a553a8dca26a27e2b": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2700
                 }
             ]
         ],
         "e9bfe4e91a92dade9ae3a1b1": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 20000
                 }
             ]
         ],
         "cfcd0a82f66efd3ae7c186fa": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 20000
                 }
             ]
         ],
         "42012fa6ebfe98bd4c68f59b": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 6600
                 }
             ]
         ],
         "6aafbeb9d48cd79ed4a5157b": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 7000
                 }
             ]
         ],
         "2d3ddc9a8fad6f28f6d586af": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 8000
                 }
             ]
         ],
         "2bc5e8b73c0a14ffd4bcdfa5": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5000
                 }
             ]
         ],
         "2911812d0dfde86e08d8a18a": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 8000
                 }
             ]
         ],
         "cc2a0f5dae0bd5cfc5d49fbf": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1800
                 }
             ]
         ],
         "da3a35d7ad7a4c4a0c7aec83": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5000
                 }
             ]
         ],
         "a22bd6adfbfc9e8b80a5a5ae": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 6000
                 }
             ]
         ],
         "3c93ad820a8e6f71b3a8b7dd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3000
                 }
             ]
         ],
         "b332cbbb14b269ce47da8385": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "fcbd64c5c9a5a04d6b7133b7": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 48000
                 }
             ]
         ],
         "654d5a9a9ac241d57dae9f42": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "34addfbc85983915bdbfe81c": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 58000
                 }
             ]
         ],
         "58ccadceea47bbf0ea9b9f10": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "5f1baa301eec2977d2b0cb39": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 56000
                 }
             ]
         ],
         "9ec426bc5e7602c678b9ddba": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "8dbb6bab779b4fdd61d8bb5b": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 58000
                 }
             ]
         ],
         "a2ce4ec5eabbd4fec171608a": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "ed68b0ac5e0cc0ba3133f3b8": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 54000
                 }
             ]
         ],
         "eeede87b52ac49e9fdf9d468": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "d6f7b2ca4be1152dd1bb926c": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 96000
                 }
             ]
         ],
         "cb9f4f04ef7beaded110f66b": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "3ab5dccaebc37dc6fae577be": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 120000
                 }
             ]
         ],
         "c0decbecaf6fce0fbdd427db": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "b000b8ffd5b1dbde2e1ed6d3": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 94000
                 }
             ]
         ],
         "dbb341b7b258fca356bd2fbb": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "53b1055578a15514d03a03b7": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 215000
                 }
             ]
         ],
         "c4fe6deebbf6b03a0fdcd0ae": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 20000
                 }
             ]
         ],
         "7cfb1b2dde615b4919acde0e": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 14500
                 }
             ]
         ],
         "eb2ebbffaa3c02d63decedc1": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 33000
                 }
             ]
         ],
         "cb891bbafd04990faa96f5fa": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "d58df4c39db7eb63abcf330d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5500
                 }
             ]
         ]
     },
-    "items": [
-        {
+    "items": [{
             "_id": "1ebbadac895befe6b0de8aba",
             "_tpl": "5e831507ea0a7c419c2f9bd9",
             "parentId": "hideout",
@@ -1237,8 +1072,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "296cd34e1df0ea5f7c78eda1",
             "_tpl": "544fb25a4bdc2dfb738b4567",
             "parentId": "hideout",
@@ -1249,8 +1083,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fe478372be29ef2e6fea6c8e",
             "_tpl": "544fb3364bdc2d34748b456a",
             "parentId": "hideout",
@@ -1261,8 +1094,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "6caeda234b7dad5b3d5a1c5d",
             "_tpl": "5755356824597772cb798962",
             "parentId": "hideout",
@@ -1273,8 +1105,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "60acc13a1d3e277eab7defbc",
             "_tpl": "60098af40accd37ef2175f27",
             "parentId": "hideout",
@@ -1285,8 +1116,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ab95e89890d374edf6d804fd",
             "_tpl": "590c661e86f7741e566b646a",
             "parentId": "hideout",
@@ -1297,8 +1127,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e1d9ef8f6a27ed0bad99d282",
             "_tpl": "5751a25924597722c463c472",
             "parentId": "hideout",
@@ -1309,8 +1138,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "236ae5cd9fac1b13c4b0a230",
             "_tpl": "544fb3f34bdc2d03748b456a",
             "parentId": "hideout",
@@ -1321,8 +1149,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "6fcdfa6e5e380f594ffeb4ce",
             "_tpl": "5e8488fa988a8701445df1e4",
             "parentId": "hideout",
@@ -1333,8 +1160,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fc7ef60ac378aa2ee2fe4ce1",
             "_tpl": "5af0454c86f7746bf20992e8",
             "parentId": "hideout",
@@ -1345,8 +1171,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f6fd5f1b37c5fac4b77b5c8e",
             "_tpl": "590c695186f7741e566b64a2",
             "parentId": "hideout",
@@ -1357,8 +1182,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "18fb4faa79dfab8cf109b8bf",
             "_tpl": "544fb45d4bdc2dee738b4568",
             "parentId": "hideout",
@@ -1369,8 +1193,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c4cab056ec93fe0f1106c6dd",
             "_tpl": "5d02778e86f774203e7dedbe",
             "parentId": "hideout",
@@ -1381,8 +1204,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "1d6cedd407aded383cd3f1d0",
             "_tpl": "590c678286f77426c9660122",
             "parentId": "hideout",
@@ -1393,8 +1215,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "97af3a0012e7150115892e74",
             "_tpl": "5755383e24597772cb798966",
             "parentId": "hideout",
@@ -1405,8 +1226,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "8488c3505d05ab8c0e2dca7c",
             "_tpl": "60098ad7c2240c0fe85c570a",
             "parentId": "hideout",
@@ -1417,8 +1237,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "dc7bb11a67b4bebccedccaca",
             "_tpl": "5af0548586f7743a532b7e99",
             "parentId": "hideout",
@@ -1429,8 +1248,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "3d0cb29b9bee9a3ad426a2b2",
             "_tpl": "590c657e86f77412b013051d",
             "parentId": "hideout",
@@ -1441,8 +1259,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ba9aa88df8f0d8ea9b3f5ed3",
             "_tpl": "5d02797c86f774203f38e30a",
             "parentId": "hideout",
@@ -1453,8 +1270,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "edaa85667ccaa7d314460fa8",
             "_tpl": "5751a89d24597722aa0e8db0",
             "parentId": "hideout",
@@ -1465,8 +1281,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "8cb5decc6f5dca9af262ed95",
             "_tpl": "5e831507ea0a7c419c2f9bd9",
             "parentId": "hideout",
@@ -1477,8 +1292,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b3f674dcd7994f90a068e5e1",
             "_tpl": "544fb25a4bdc2dfb738b4567",
             "parentId": "hideout",
@@ -1489,8 +1303,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "0c67b04a47b6ab56302fef17",
             "_tpl": "544fb3364bdc2d34748b456a",
             "parentId": "hideout",
@@ -1501,8 +1314,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "664ccbdb08411483d983ff3d",
             "_tpl": "5755356824597772cb798962",
             "parentId": "hideout",
@@ -1513,8 +1325,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "1abaf5adec1d2848cc09daec",
             "_tpl": "60098af40accd37ef2175f27",
             "parentId": "hideout",
@@ -1525,8 +1336,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bde835c87ddeb15baa6a2667",
             "_tpl": "590c661e86f7741e566b646a",
             "parentId": "hideout",
@@ -1537,8 +1347,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "9d8ec61fcbc51ec43f4d406f",
             "_tpl": "5751a25924597722c463c472",
             "parentId": "hideout",
@@ -1549,8 +1358,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e965c7ec4cae4adbdd47be35",
             "_tpl": "544fb3f34bdc2d03748b456a",
             "parentId": "hideout",
@@ -1561,8 +1369,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "acd2dfc926c090fe46b6eadd",
             "_tpl": "5e8488fa988a8701445df1e4",
             "parentId": "hideout",
@@ -1573,8 +1380,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e63cba7f17cba8bec5d0df6a",
             "_tpl": "5af0454c86f7746bf20992e8",
             "parentId": "hideout",
@@ -1585,8 +1391,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "0b6b65ec76753edaccf2da71",
             "_tpl": "590c695186f7741e566b64a2",
             "parentId": "hideout",
@@ -1597,8 +1402,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ec046ceec0607178aafcc540",
             "_tpl": "544fb45d4bdc2dee738b4568",
             "parentId": "hideout",
@@ -1609,8 +1413,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "4c4d5d5c1126affe5ac8988b",
             "_tpl": "5d02778e86f774203e7dedbe",
             "parentId": "hideout",
@@ -1621,8 +1424,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "963fe9c5ef3b5fbbecfac0ae",
             "_tpl": "590c678286f77426c9660122",
             "parentId": "hideout",
@@ -1633,8 +1435,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d64ea3eb1ff99bff4b8dd7c5",
             "_tpl": "5755383e24597772cb798966",
             "parentId": "hideout",
@@ -1645,8 +1446,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "4879f30eb43ccc1faecd0559",
             "_tpl": "60098ad7c2240c0fe85c570a",
             "parentId": "hideout",
@@ -1657,8 +1457,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c1daddee7aead2ece4b7e2ca",
             "_tpl": "5af0548586f7743a532b7e99",
             "parentId": "hideout",
@@ -1669,8 +1468,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b50d2dbfd9fd7280dae6b23c",
             "_tpl": "590c657e86f77412b013051d",
             "parentId": "hideout",
@@ -1681,8 +1479,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "19cffd9e3ef6dbc9df27ebcb",
             "_tpl": "5d02797c86f774203f38e30a",
             "parentId": "hideout",
@@ -1693,8 +1490,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "432016db2ae30eea29d0926d",
             "_tpl": "5751a89d24597722aa0e8db0",
             "parentId": "hideout",
@@ -1705,8 +1501,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "07de2dd8f7af7ea3ca49dea6",
             "_tpl": "59e7635f86f7742cbf2c1095",
             "parentId": "hideout",
@@ -1717,32 +1512,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065ef7",
             "_tpl": "65702f87722744627e05cdb8",
             "parentId": "07de2dd8f7af7ea3ca49dea6",
             "slotId": "Soft_armor_front"
-        },
-          {
+        }, {
             "_id": "666e47393142970f96065ef8",
             "_tpl": "65702fe593b7ea9c330f4ce8",
             "parentId": "07de2dd8f7af7ea3ca49dea6",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065ef9",
             "_tpl": "6570305d93b7ea9c330f4ced",
             "parentId": "07de2dd8f7af7ea3ca49dea6",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065efa",
             "_tpl": "65703472c9030b928a0a8a78",
             "parentId": "07de2dd8f7af7ea3ca49dea6",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "d46cef7809dbab9d538eafe5",
             "_tpl": "5df8a2ca86f7740bfe6df777",
             "parentId": "hideout",
@@ -1753,20 +1543,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065efb",
             "_tpl": "656fd7c32668ef0402028fb9",
             "parentId": "d46cef7809dbab9d538eafe5",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065efc",
             "_tpl": "656fd89bf5a9631d4e042575",
             "parentId": "d46cef7809dbab9d538eafe5",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "31beb3ddfdc9ddaebfabb0f9",
             "_tpl": "5648a7494bdc2d9d488b4583",
             "parentId": "hideout",
@@ -1777,32 +1564,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065efd",
             "_tpl": "65703d866584602f7d057a8a",
             "parentId": "31beb3ddfdc9ddaebfabb0f9",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065efe",
             "_tpl": "65703fa06584602f7d057a8e",
             "parentId": "31beb3ddfdc9ddaebfabb0f9",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065eff",
             "_tpl": "65703fe46a912c8b5c03468b",
             "parentId": "31beb3ddfdc9ddaebfabb0f9",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f00",
             "_tpl": "657040374e67e8ec7a0d261c",
             "parentId": "31beb3ddfdc9ddaebfabb0f9",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "d11cfa4b99c1cfa92ccef995",
             "_tpl": "5b44d22286f774172b0c9de8",
             "parentId": "hideout",
@@ -1813,50 +1595,42 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f01",
             "_tpl": "65704de13e7bba58ea0285c8",
             "parentId": "d11cfa4b99c1cfa92ccef995",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f02",
             "_tpl": "65705c3c14f2ed6d7d0b7738",
             "parentId": "d11cfa4b99c1cfa92ccef995",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f03",
             "_tpl": "65705c777260e1139e091408",
             "parentId": "d11cfa4b99c1cfa92ccef995",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f04",
             "_tpl": "65705cb314f2ed6d7d0b773c",
             "parentId": "d11cfa4b99c1cfa92ccef995",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f05",
             "_tpl": "65705cea4916448ae1050897",
             "parentId": "d11cfa4b99c1cfa92ccef995",
             "slotId": "Collar"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f06",
             "_tpl": "656f9d5900d62bcd2e02407c",
             "parentId": "d11cfa4b99c1cfa92ccef995",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f07",
             "_tpl": "656f9d5900d62bcd2e02407c",
             "parentId": "d11cfa4b99c1cfa92ccef995",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "bf08bee90ce2d85bdbbd7591",
             "_tpl": "5ab8e4ed86f7742d8e50c7fa",
             "parentId": "hideout",
@@ -1867,32 +1641,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f08",
             "_tpl": "657044e971369562b300ce9b",
             "parentId": "bf08bee90ce2d85bdbbd7591",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f09",
             "_tpl": "657045741bd9beedc40b7299",
             "parentId": "bf08bee90ce2d85bdbbd7591",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f0a",
             "_tpl": "657045b97e80617cee095bda",
             "parentId": "bf08bee90ce2d85bdbbd7591",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f0b",
             "_tpl": "6570460471369562b300ce9f",
             "parentId": "bf08bee90ce2d85bdbbd7591",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "401d47ba10d19c030dd6c7eb",
             "_tpl": "5c0e5edb86f77461f55ed1f7",
             "parentId": "hideout",
@@ -1903,50 +1672,42 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f0c",
             "_tpl": "6571dbd388ead79fcf091d71",
             "parentId": "401d47ba10d19c030dd6c7eb",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f0d",
             "_tpl": "6571dbda88ead79fcf091d75",
             "parentId": "401d47ba10d19c030dd6c7eb",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f0e",
             "_tpl": "6571dbe07c02ae206002502e",
             "parentId": "401d47ba10d19c030dd6c7eb",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f0f",
             "_tpl": "6571dbeaee8ec43d520cf89e",
             "parentId": "401d47ba10d19c030dd6c7eb",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f10",
             "_tpl": "6571dbef88ead79fcf091d79",
             "parentId": "401d47ba10d19c030dd6c7eb",
             "slotId": "Collar"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f11",
             "_tpl": "656f57dc27aed95beb08f628",
             "parentId": "401d47ba10d19c030dd6c7eb",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f12",
             "_tpl": "656fac30c6baea13cd07e10c",
             "parentId": "401d47ba10d19c030dd6c7eb",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "fe44ffb6bf2550b2253286ee",
             "_tpl": "5c0e5bab86f77461f55ed1f3",
             "parentId": "hideout",
@@ -1957,56 +1718,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f13",
             "_tpl": "6571b27a6d84a2b8b6007f92",
             "parentId": "fe44ffb6bf2550b2253286ee",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f14",
             "_tpl": "6571baa74cb80d995d0a1490",
             "parentId": "fe44ffb6bf2550b2253286ee",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f15",
             "_tpl": "6571baac6d84a2b8b6007fa3",
             "parentId": "fe44ffb6bf2550b2253286ee",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f16",
             "_tpl": "6571bab0f41985531a038091",
             "parentId": "fe44ffb6bf2550b2253286ee",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f17",
             "_tpl": "6571babb4076795e5e07383f",
             "parentId": "fe44ffb6bf2550b2253286ee",
             "slotId": "Collar"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f18",
             "_tpl": "6571bac34076795e5e073843",
             "parentId": "fe44ffb6bf2550b2253286ee",
             "slotId": "Groin"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f19",
             "_tpl": "6571babf4cb80d995d0a1494",
             "parentId": "fe44ffb6bf2550b2253286ee",
             "slotId": "Groin_back"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f1a",
             "_tpl": "654a4dea7c17dec2f50cc86a",
             "parentId": "fe44ffb6bf2550b2253286ee",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "013b74e2e962eb5b342cacb6",
             "_tpl": "609e8540d5c319764c2bc2e9",
             "parentId": "hideout",
@@ -2017,44 +1769,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f1b",
             "_tpl": "6572e5221b5bc1185508c24f",
             "parentId": "013b74e2e962eb5b342cacb6",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f1c",
             "_tpl": "6572e52f73c0eabb700109a0",
             "parentId": "013b74e2e962eb5b342cacb6",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f1d",
             "_tpl": "6572e53c73c0eabb700109a4",
             "parentId": "013b74e2e962eb5b342cacb6",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f1e",
             "_tpl": "6572e54873c0eabb700109a8",
             "parentId": "013b74e2e962eb5b342cacb6",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f1f",
             "_tpl": "656f9fa0498d1b7e3e071d98",
             "parentId": "013b74e2e962eb5b342cacb6",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f20",
             "_tpl": "656f9fa0498d1b7e3e071d98",
             "parentId": "013b74e2e962eb5b342cacb6",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "cab6fe7beb5c6efc23e8c34c",
             "_tpl": "5c0e53c886f7747fa54205c7",
             "parentId": "hideout",
@@ -2065,56 +1810,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f21",
             "_tpl": "654a8b0b0337d53f9102c2ae",
             "parentId": "cab6fe7beb5c6efc23e8c34c",
             "slotId": "soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f22",
             "_tpl": "654a8976f414fcea4004d78b",
             "parentId": "cab6fe7beb5c6efc23e8c34c",
             "slotId": "soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f23",
             "_tpl": "654a8b3df414fcea4004d78f",
             "parentId": "cab6fe7beb5c6efc23e8c34c",
             "slotId": "soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f24",
             "_tpl": "654a8b80f414fcea4004d797",
             "parentId": "cab6fe7beb5c6efc23e8c34c",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f25",
             "_tpl": "654a8ae00337d53f9102c2aa",
             "parentId": "cab6fe7beb5c6efc23e8c34c",
             "slotId": "Collar"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f26",
             "_tpl": "654a8bc5f414fcea4004d79b",
             "parentId": "cab6fe7beb5c6efc23e8c34c",
             "slotId": "Groin"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f27",
             "_tpl": "656f603f94b480b8a500c0d6",
             "parentId": "cab6fe7beb5c6efc23e8c34c",
             "slotId": "front_plate"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f28",
             "_tpl": "656efd66034e8e01c407f35c",
             "parentId": "cab6fe7beb5c6efc23e8c34c",
             "slotId": "back_plate"
-        },
-        {
+        }, {
             "_id": "02adbe49c3da3ff3dedfbca2",
             "_tpl": "5c0e57ba86f7747fa141986d",
             "parentId": "hideout",
@@ -2125,62 +1861,52 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f29",
             "_tpl": "65707fc348c7a887f2010432",
             "parentId": "02adbe49c3da3ff3dedfbca2",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f2a",
             "_tpl": "6570800612755ae0d907acf8",
             "parentId": "02adbe49c3da3ff3dedfbca2",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f2b",
             "_tpl": "65708070f65e2491bf00972c",
             "parentId": "02adbe49c3da3ff3dedfbca2",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f2c",
             "_tpl": "657080a212755ae0d907ad04",
             "parentId": "02adbe49c3da3ff3dedfbca2",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f2d",
             "_tpl": "657080ca12755ae0d907ad5e",
             "parentId": "02adbe49c3da3ff3dedfbca2",
             "slotId": "Collar"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f2e",
             "_tpl": "65708122f65e2491bf009755",
             "parentId": "02adbe49c3da3ff3dedfbca2",
             "slotId": "Groin"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f2f",
             "_tpl": "65708165696fe382cf073255",
             "parentId": "02adbe49c3da3ff3dedfbca2",
             "slotId": "Groin_back"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f30",
             "_tpl": "656f603f94b480b8a500c0d6",
             "parentId": "02adbe49c3da3ff3dedfbca2",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f31",
             "_tpl": "657b22485f444d6dff0c6c2f",
             "parentId": "02adbe49c3da3ff3dedfbca2",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "255e685a05fe46fd6b46af5a",
             "_tpl": "5c0e655586f774045612eeb2",
             "parentId": "hideout",
@@ -2191,32 +1917,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f32",
             "_tpl": "6570e025615f54368b04fcb0",
             "parentId": "255e685a05fe46fd6b46af5a",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f33",
             "_tpl": "6570e0610b57c03ec90b96ef",
             "parentId": "255e685a05fe46fd6b46af5a",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f34",
             "_tpl": "656fad8c498d1b7e3e071da0",
             "parentId": "255e685a05fe46fd6b46af5a",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f35",
             "_tpl": "656fad8c498d1b7e3e071da0",
             "parentId": "255e685a05fe46fd6b46af5a",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "e6128dcefb016c69c572b79f",
             "_tpl": "5ab8e79e86f7742d8b372e78",
             "parentId": "hideout",
@@ -2227,50 +1948,42 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f36",
             "_tpl": "65732688d9d89ff7ac0d9c4c",
             "parentId": "e6128dcefb016c69c572b79f",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f37",
             "_tpl": "657326978c1cc6dcd9098b56",
             "parentId": "e6128dcefb016c69c572b79f",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f38",
             "_tpl": "657326a28c1cc6dcd9098b5a",
             "parentId": "e6128dcefb016c69c572b79f",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f39",
             "_tpl": "657326b08c1cc6dcd9098b5e",
             "parentId": "e6128dcefb016c69c572b79f",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f3a",
             "_tpl": "657326bc5d3a3129fb05f36b",
             "parentId": "e6128dcefb016c69c572b79f",
             "slotId": "Collar"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f3b",
             "_tpl": "656f611f94b480b8a500c0db",
             "parentId": "e6128dcefb016c69c572b79f",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f3c",
             "_tpl": "65573fa5655447403702a816",
             "parentId": "e6128dcefb016c69c572b79f",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "fe4dddeecbba6d79cfdbabf7",
             "_tpl": "5b44d0de86f774503d30cba8",
             "parentId": "hideout",
@@ -2281,62 +1994,52 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f3f",
             "_tpl": "6575c342efc786cd9101a5e5",
             "parentId": "fe4dddeecbba6d79cfdbabf7",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f3d",
             "_tpl": "6575c34bc6700bd6b40e8a84",
             "parentId": "fe4dddeecbba6d79cfdbabf7",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f3e",
             "_tpl": "6575c35bc6700bd6b40e8a88",
             "parentId": "fe4dddeecbba6d79cfdbabf7",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f40",
             "_tpl": "6575c366c6700bd6b40e8a8c",
             "parentId": "fe4dddeecbba6d79cfdbabf7",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f41",
             "_tpl": "6575c373dc9932aed601c5ec",
             "parentId": "fe4dddeecbba6d79cfdbabf7",
             "slotId": "Collar"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f42",
             "_tpl": "6575c385dc9932aed601c5f0",
             "parentId": "fe4dddeecbba6d79cfdbabf7",
             "slotId": "Groin"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f43",
             "_tpl": "6575c390efc786cd9101a5e9",
             "parentId": "fe4dddeecbba6d79cfdbabf7",
             "slotId": "Groin_back"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f44",
             "_tpl": "656fa8d700d62bcd2e024084",
             "parentId": "fe4dddeecbba6d79cfdbabf7",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f45",
             "_tpl": "656fa8d700d62bcd2e024084",
             "parentId": "fe4dddeecbba6d79cfdbabf7",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "eacba9139ba71c848ba0a4fa",
             "_tpl": "5ca2151486f774244a3b8d30",
             "parentId": "hideout",
@@ -2347,62 +2050,52 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f46",
             "_tpl": "6575dd3e9e27f4a85e081142",
             "parentId": "eacba9139ba71c848ba0a4fa",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f47",
             "_tpl": "6575dd519e27f4a85e081146",
             "parentId": "eacba9139ba71c848ba0a4fa",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f48",
             "_tpl": "6575dd64945bf78edd04c438",
             "parentId": "eacba9139ba71c848ba0a4fa",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f49",
             "_tpl": "6575dd6e9d3a0ddf660b9047",
             "parentId": "eacba9139ba71c848ba0a4fa",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f4a",
             "_tpl": "6575dd769d3a0ddf660b904b",
             "parentId": "eacba9139ba71c848ba0a4fa",
             "slotId": "Collar"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f4b",
             "_tpl": "6575dd800546f8b1de093df6",
             "parentId": "eacba9139ba71c848ba0a4fa",
             "slotId": "Groin"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f4c",
             "_tpl": "6575dd94945bf78edd04c43c",
             "parentId": "eacba9139ba71c848ba0a4fa",
             "slotId": "Groin_back"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f4d",
             "_tpl": "65573fa5655447403702a816",
             "parentId": "eacba9139ba71c848ba0a4fa",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f4e",
             "_tpl": "65573fa5655447403702a816",
             "parentId": "eacba9139ba71c848ba0a4fa",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "8ca7ba8c24bdfc361baacede",
             "_tpl": "5b44cf1486f77431723e3d05",
             "parentId": "hideout",
@@ -2413,74 +2106,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f4f",
             "_tpl": "6575c3b3dc9932aed601c5f4",
             "parentId": "8ca7ba8c24bdfc361baacede",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f50",
             "_tpl": "6575c3beefc786cd9101a5ed",
             "parentId": "8ca7ba8c24bdfc361baacede",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f51",
             "_tpl": "6575c3cdc6700bd6b40e8a90",
             "parentId": "8ca7ba8c24bdfc361baacede",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f52",
             "_tpl": "6575c3dfdc9932aed601c5f8",
             "parentId": "8ca7ba8c24bdfc361baacede",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f53",
             "_tpl": "6575c3ec52b7f8c76a05ee39",
             "parentId": "8ca7ba8c24bdfc361baacede",
             "slotId": "Collar"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f54",
             "_tpl": "6575c3fd52b7f8c76a05ee3d",
             "parentId": "8ca7ba8c24bdfc361baacede",
             "slotId": "Shoulder_l"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f55",
             "_tpl": "6575c40c52b7f8c76a05ee41",
             "parentId": "8ca7ba8c24bdfc361baacede",
             "slotId": "Shoulder_r"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f56",
             "_tpl": "656fa8d700d62bcd2e024084",
             "parentId": "8ca7ba8c24bdfc361baacede",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f57",
             "_tpl": "656fa8d700d62bcd2e024084",
             "parentId": "8ca7ba8c24bdfc361baacede",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f58",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "8ca7ba8c24bdfc361baacede",
             "slotId": "Left_side_plate"
-        },
-        {
+        }, {
             "_id": "666e47393142970f96065f59",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "8ca7ba8c24bdfc361baacede",
             "slotId": "Right_side_plate"
-        },
-        {
+        }, {
             "_id": "c82ba4f25cd0586effdcbbf8",
             "_tpl": "5b44cd8b86f774503d30cba2",
             "parentId": "hideout",
@@ -2491,86 +2172,72 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f5b",
             "_tpl": "6575c2adefc786cd9101a5d9",
             "parentId": "c82ba4f25cd0586effdcbbf8",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f5c",
             "_tpl": "6575c2be52b7f8c76a05ee25",
             "parentId": "c82ba4f25cd0586effdcbbf8",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f5d",
             "_tpl": "6575c2cd52b7f8c76a05ee29",
             "parentId": "c82ba4f25cd0586effdcbbf8",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f5e",
             "_tpl": "6575c2d852b7f8c76a05ee2d",
             "parentId": "c82ba4f25cd0586effdcbbf8",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f60",
             "_tpl": "6575c2e4efc786cd9101a5dd",
             "parentId": "c82ba4f25cd0586effdcbbf8",
             "slotId": "Collar"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f61",
             "_tpl": "6575c2f7efc786cd9101a5e1",
             "parentId": "c82ba4f25cd0586effdcbbf8",
             "slotId": "Shoulder_l"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f62",
             "_tpl": "6575c30352b7f8c76a05ee31",
             "parentId": "c82ba4f25cd0586effdcbbf8",
             "slotId": "Shoulder_r"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f63",
             "_tpl": "6575c31b52b7f8c76a05ee35",
             "parentId": "c82ba4f25cd0586effdcbbf8",
             "slotId": "Groin"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f64",
             "_tpl": "6575c326c6700bd6b40e8a80",
             "parentId": "c82ba4f25cd0586effdcbbf8",
             "slotId": "Groin_back"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f65",
             "_tpl": "656fa8d700d62bcd2e024084",
             "parentId": "c82ba4f25cd0586effdcbbf8",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f66",
             "_tpl": "656fa8d700d62bcd2e024084",
             "parentId": "c82ba4f25cd0586effdcbbf8",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f67",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "c82ba4f25cd0586effdcbbf8",
             "slotId": "Left_side_plate"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f68",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "c82ba4f25cd0586effdcbbf8",
             "slotId": "Right_side_plate"
-        },
-        {
+        }, {
             "_id": "c6fe4ce275de1bf2eec3bc00",
             "_tpl": "5f5f41476bdad616ad46d631",
             "parentId": "hideout",
@@ -2581,74 +2248,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f69",
             "_tpl": "65731b46cea9255e2102360a",
             "parentId": "c6fe4ce275de1bf2eec3bc00",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f6a",
             "_tpl": "65731b4fcea9255e2102360e",
             "parentId": "c6fe4ce275de1bf2eec3bc00",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f6b",
             "_tpl": "65731b576e709cddd001ec3f",
             "parentId": "c6fe4ce275de1bf2eec3bc00",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f6c",
             "_tpl": "65731b60ff6dc44a7d068c4a",
             "parentId": "c6fe4ce275de1bf2eec3bc00",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f6d",
             "_tpl": "65731b666e709cddd001ec43",
             "parentId": "c6fe4ce275de1bf2eec3bc00",
             "slotId": "Collar"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f6e",
             "_tpl": "65731b716e709cddd001ec47",
             "parentId": "c6fe4ce275de1bf2eec3bc00",
             "slotId": "Groin"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f6f",
             "_tpl": "65731b6b6042b0f210020ef6",
             "parentId": "c6fe4ce275de1bf2eec3bc00",
             "slotId": "Groin_back"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f70",
             "_tpl": "656f664200d62bcd2e024077",
             "parentId": "c6fe4ce275de1bf2eec3bc00",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f71",
             "_tpl": "654a4f8bc721968a4404ef18",
             "parentId": "c6fe4ce275de1bf2eec3bc00",
             "slotId": "Left_side_plate"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f72",
             "_tpl": "654a4f8bc721968a4404ef18",
             "parentId": "c6fe4ce275de1bf2eec3bc00",
             "slotId": "Right_side_plate"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f73",
             "_tpl": "657b2797c3dbcb01d60c35ea",
             "parentId": "c6fe4ce275de1bf2eec3bc00",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "f8f0addd93bf96dc3fa8baa8",
             "_tpl": "5e9dacf986f774054d6b89f4",
             "parentId": "hideout",
@@ -2659,56 +2314,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f74",
             "_tpl": "65732de75d3a3129fb05f3dd",
             "parentId": "f8f0addd93bf96dc3fa8baa8",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f75",
             "_tpl": "65732df4d0acf75aea06c87b",
             "parentId": "f8f0addd93bf96dc3fa8baa8",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f76",
             "_tpl": "65732e05d0acf75aea06c87f",
             "parentId": "f8f0addd93bf96dc3fa8baa8",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f77",
             "_tpl": "65732e0f6784ca384b0167ad",
             "parentId": "f8f0addd93bf96dc3fa8baa8",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f78",
             "_tpl": "65732e215d3a3129fb05f3e1",
             "parentId": "f8f0addd93bf96dc3fa8baa8",
             "slotId": "Collar"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f79",
             "_tpl": "65732e30dd8739f6440ef383",
             "parentId": "f8f0addd93bf96dc3fa8baa8",
             "slotId": "Groin"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f7a",
             "_tpl": "65573fa5655447403702a816",
             "parentId": "f8f0addd93bf96dc3fa8baa8",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f7b",
             "_tpl": "65573fa5655447403702a816",
             "parentId": "f8f0addd93bf96dc3fa8baa8",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "933c0dfc0bab0c90210fc51e",
             "_tpl": "5c0e541586f7747fa54205c9",
             "parentId": "hideout",
@@ -2719,56 +2365,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f7c",
             "_tpl": "6575ea3060703324250610da",
             "parentId": "933c0dfc0bab0c90210fc51e",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f7d",
             "_tpl": "6575ea4cf6a13a7b7100adc4",
             "parentId": "933c0dfc0bab0c90210fc51e",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f7e",
             "_tpl": "6575ea5cf6a13a7b7100adc8",
             "parentId": "933c0dfc0bab0c90210fc51e",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f7f",
             "_tpl": "6575ea6760703324250610de",
             "parentId": "933c0dfc0bab0c90210fc51e",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f80",
             "_tpl": "6575ea719c7cad336508e418",
             "parentId": "933c0dfc0bab0c90210fc51e",
             "slotId": "Collar"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f81",
             "_tpl": "6575ea7c60703324250610e2",
             "parentId": "933c0dfc0bab0c90210fc51e",
             "slotId": "Groin"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f82",
             "_tpl": "656f611f94b480b8a500c0db",
             "parentId": "933c0dfc0bab0c90210fc51e",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f83",
             "_tpl": "656efaf54772930db4031ff5",
             "parentId": "933c0dfc0bab0c90210fc51e",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "aabde64d37dfb52e19841177",
             "_tpl": "5ca21c6986f77479963115a7",
             "parentId": "hideout",
@@ -2779,86 +2416,72 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f84",
             "_tpl": "6575d9a79e27f4a85e08112d",
             "parentId": "aabde64d37dfb52e19841177",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f85",
             "_tpl": "6575d9b8945bf78edd04c427",
             "parentId": "aabde64d37dfb52e19841177",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f86",
             "_tpl": "6575d9c40546f8b1de093dee",
             "parentId": "aabde64d37dfb52e19841177",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f87",
             "_tpl": "6575d9cf0546f8b1de093df2",
             "parentId": "aabde64d37dfb52e19841177",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f88",
             "_tpl": "6575d9d8945bf78edd04c42b",
             "parentId": "aabde64d37dfb52e19841177",
             "slotId": "Collar"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f89",
             "_tpl": "6575da07945bf78edd04c433",
             "parentId": "aabde64d37dfb52e19841177",
             "slotId": "Shoulder_l"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f8a",
             "_tpl": "6575da159e27f4a85e081131",
             "parentId": "aabde64d37dfb52e19841177",
             "slotId": "Shoulder_r"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f8b",
             "_tpl": "6575d9e7945bf78edd04c42f",
             "parentId": "aabde64d37dfb52e19841177",
             "slotId": "Groin"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f8c",
             "_tpl": "6575d9f816c2762fba00588d",
             "parentId": "aabde64d37dfb52e19841177",
             "slotId": "Groin_back"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f8d",
             "_tpl": "65573fa5655447403702a816",
             "parentId": "aabde64d37dfb52e19841177",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f8e",
             "_tpl": "65573fa5655447403702a816",
             "parentId": "aabde64d37dfb52e19841177",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f8f",
             "_tpl": "64afd81707e2cf40e903a316",
             "parentId": "aabde64d37dfb52e19841177",
             "slotId": "Left_side_plate"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f90",
             "_tpl": "64afd81707e2cf40e903a316",
             "parentId": "aabde64d37dfb52e19841177",
             "slotId": "Right_side_plate"
-        },
-        {
+        }, {
             "_id": "65ba7f61c561d8d4dca8287a",
             "_tpl": "5c0e625a86f7742d77340f62",
             "parentId": "hideout",
@@ -2869,62 +2492,52 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f91",
             "_tpl": "65764275d8537eb26a0355e9",
             "parentId": "65ba7f61c561d8d4dca8287a",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f92",
             "_tpl": "657642b0e6d5dd75f40688a5",
             "parentId": "65ba7f61c561d8d4dca8287a",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f93",
             "_tpl": "6576434820cc24d17102b148",
             "parentId": "65ba7f61c561d8d4dca8287a",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f94",
             "_tpl": "657643732bc38ef78e076477",
             "parentId": "65ba7f61c561d8d4dca8287a",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f95",
             "_tpl": "657643a220cc24d17102b14c",
             "parentId": "65ba7f61c561d8d4dca8287a",
             "slotId": "Collar"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f96",
             "_tpl": "656f63c027aed95beb08f62c",
             "parentId": "65ba7f61c561d8d4dca8287a",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f97",
             "_tpl": "656fafe3498d1b7e3e071da4",
             "parentId": "65ba7f61c561d8d4dca8287a",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f98",
             "_tpl": "64afd81707e2cf40e903a316",
             "parentId": "65ba7f61c561d8d4dca8287a",
             "slotId": "Left_side_plate"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f99",
             "_tpl": "64afd81707e2cf40e903a316",
             "parentId": "65ba7f61c561d8d4dca8287a",
             "slotId": "Right_side_plate"
-        },
-        {
+        }, {
             "_id": "ea92d8455606338f534fbe2b",
             "_tpl": "5fd4c474dd870108a754b241",
             "parentId": "hideout",
@@ -2935,20 +2548,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f9a",
             "_tpl": "656faf0ca0dce000a2020f77",
             "parentId": "ea92d8455606338f534fbe2b",
             "slotId": "front_plate"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f9b",
             "_tpl": "656faf0ca0dce000a2020f77",
             "parentId": "ea92d8455606338f534fbe2b",
             "slotId": "back_plate"
-        },
-        {
+        }, {
             "_id": "64fbabbcca7e3bacb54d0ca5",
             "_tpl": "5e4abb5086f77406975c9342",
             "parentId": "hideout",
@@ -2959,32 +2569,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f9c",
             "_tpl": "6575e71760703324250610c3",
             "parentId": "64fbabbcca7e3bacb54d0ca5",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f9d",
             "_tpl": "6575e72660703324250610c7",
             "parentId": "64fbabbcca7e3bacb54d0ca5",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f9e",
             "_tpl": "656fa76500d62bcd2e024080",
             "parentId": "64fbabbcca7e3bacb54d0ca5",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065f9f",
             "_tpl": "656fa76500d62bcd2e024080",
             "parentId": "64fbabbcca7e3bacb54d0ca5",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "a21ba7c59fac6611daa459ee",
             "_tpl": "60a283193cb70855c43a381d",
             "parentId": "hideout",
@@ -2995,80 +2600,67 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065fa0",
             "_tpl": "6575d561b15fef3dd4051670",
             "parentId": "a21ba7c59fac6611daa459ee",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065fa1",
             "_tpl": "6575d56b16c2762fba005818",
             "parentId": "a21ba7c59fac6611daa459ee",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065fa2",
             "_tpl": "6575d57a16c2762fba00581c",
             "parentId": "a21ba7c59fac6611daa459ee",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065fa3",
             "_tpl": "6575d589b15fef3dd4051674",
             "parentId": "a21ba7c59fac6611daa459ee",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065fa4",
             "_tpl": "6575d598b15fef3dd4051678",
             "parentId": "a21ba7c59fac6611daa459ee",
             "slotId": "Collar"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065fa5",
             "_tpl": "6575d5b316c2762fba005824",
             "parentId": "a21ba7c59fac6611daa459ee",
             "slotId": "Shoulder_l"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065fa6",
             "_tpl": "6575d5bd16c2762fba005828",
             "parentId": "a21ba7c59fac6611daa459ee",
             "slotId": "Shoulder_r"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065fa7",
             "_tpl": "6575d5a616c2762fba005820",
             "parentId": "a21ba7c59fac6611daa459ee",
             "slotId": "Groin"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065fa8",
             "_tpl": "656fa61e94b480b8a500c0e8",
             "parentId": "a21ba7c59fac6611daa459ee",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065fa9",
             "_tpl": "656fa61e94b480b8a500c0e8",
             "parentId": "a21ba7c59fac6611daa459ee",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065faa",
             "_tpl": "64afdb577bb3bfe8fe03fd1d",
             "parentId": "a21ba7c59fac6611daa459ee",
             "slotId": "Left_side_plate"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065fab",
             "_tpl": "64afdb577bb3bfe8fe03fd1d",
             "parentId": "a21ba7c59fac6611daa459ee",
             "slotId": "Right_side_plate"
-        },
-        {
+        }, {
             "_id": "ca43ddb7a2ff58ee0b73b5b6",
             "_tpl": "545cdb794bdc2d3a198b456a",
             "parentId": "hideout",
@@ -3079,80 +2671,67 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065fac",
             "_tpl": "6575ce3716c2762fba0057fd",
             "parentId": "ca43ddb7a2ff58ee0b73b5b6",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065fad",
             "_tpl": "6575ce45dc9932aed601c616",
             "parentId": "ca43ddb7a2ff58ee0b73b5b6",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065fae",
             "_tpl": "6575ce5016c2762fba005802",
             "parentId": "ca43ddb7a2ff58ee0b73b5b6",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065faf",
             "_tpl": "6575ce5befc786cd9101a671",
             "parentId": "ca43ddb7a2ff58ee0b73b5b6",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065fb0",
             "_tpl": "6575ce6f16c2762fba005806",
             "parentId": "ca43ddb7a2ff58ee0b73b5b6",
             "slotId": "Collar"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065fb1",
             "_tpl": "6575ce9db15fef3dd4051628",
             "parentId": "ca43ddb7a2ff58ee0b73b5b6",
             "slotId": "Shoulder_l"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065fb2",
             "_tpl": "6575cea8b15fef3dd405162c",
             "parentId": "ca43ddb7a2ff58ee0b73b5b6",
             "slotId": "Shoulder_r"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065fb3",
             "_tpl": "6575ce8bdc9932aed601c61e",
             "parentId": "ca43ddb7a2ff58ee0b73b5b6",
             "slotId": "Groin"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065fb4",
             "_tpl": "64afc71497cf3a403c01ff38",
             "parentId": "ca43ddb7a2ff58ee0b73b5b6",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065fb5",
             "_tpl": "64afc71497cf3a403c01ff38",
             "parentId": "ca43ddb7a2ff58ee0b73b5b6",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065fb6",
             "_tpl": "64afd81707e2cf40e903a316",
             "parentId": "ca43ddb7a2ff58ee0b73b5b6",
             "slotId": "Left_side_plate"
-        },
-        {
+        }, {
             "_id": "666e4a6e3142970f96065fb7",
             "_tpl": "64afd81707e2cf40e903a316",
             "parentId": "ca43ddb7a2ff58ee0b73b5b6",
             "slotId": "Right_side_plate"
-        },
-        {
+        }, {
             "_id": "9eecaffa0cb6ddbccddb47fd",
             "_tpl": "59e7635f86f7742cbf2c1095",
             "parentId": "hideout",
@@ -3163,32 +2742,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fbf",
             "_tpl": "65702f87722744627e05cdb8",
             "parentId": "9eecaffa0cb6ddbccddb47fd",
             "slotId": "Soft_armor_front"
-        },
-          {
+        }, {
             "_id": "666e4c253142970f96065fc0",
             "_tpl": "65702fe593b7ea9c330f4ce8",
             "parentId": "9eecaffa0cb6ddbccddb47fd",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fc1",
             "_tpl": "6570305d93b7ea9c330f4ced",
             "parentId": "9eecaffa0cb6ddbccddb47fd",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fc2",
             "_tpl": "65703472c9030b928a0a8a78",
             "parentId": "9eecaffa0cb6ddbccddb47fd",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "35b94ceab1afe0fefec81fef",
             "_tpl": "5df8a2ca86f7740bfe6df777",
             "parentId": "hideout",
@@ -3199,20 +2773,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fc3",
             "_tpl": "656fd7c32668ef0402028fb9",
             "parentId": "35b94ceab1afe0fefec81fef",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fc4",
             "_tpl": "656fd89bf5a9631d4e042575",
             "parentId": "35b94ceab1afe0fefec81fef",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "d7bd663d561e682fa66d579e",
             "_tpl": "5648a7494bdc2d9d488b4583",
             "parentId": "hideout",
@@ -3223,32 +2794,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fc5",
             "_tpl": "65703d866584602f7d057a8a",
             "parentId": "d7bd663d561e682fa66d579e",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fc6",
             "_tpl": "65703fa06584602f7d057a8e",
             "parentId": "d7bd663d561e682fa66d579e",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fc7",
             "_tpl": "65703fe46a912c8b5c03468b",
             "parentId": "d7bd663d561e682fa66d579e",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fc8",
             "_tpl": "657040374e67e8ec7a0d261c",
             "parentId": "d7bd663d561e682fa66d579e",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "ba4b5efd1ab3e2bf0a547f51",
             "_tpl": "5b44d22286f774172b0c9de8",
             "parentId": "hideout",
@@ -3259,50 +2825,42 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fc9",
             "_tpl": "65704de13e7bba58ea0285c8",
             "parentId": "ba4b5efd1ab3e2bf0a547f51",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fca",
             "_tpl": "65705c3c14f2ed6d7d0b7738",
             "parentId": "ba4b5efd1ab3e2bf0a547f51",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fcb",
             "_tpl": "65705c777260e1139e091408",
             "parentId": "ba4b5efd1ab3e2bf0a547f51",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fcc",
             "_tpl": "65705cb314f2ed6d7d0b773c",
             "parentId": "ba4b5efd1ab3e2bf0a547f51",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fcd",
             "_tpl": "65705cea4916448ae1050897",
             "parentId": "ba4b5efd1ab3e2bf0a547f51",
             "slotId": "Collar"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fce",
             "_tpl": "656f9d5900d62bcd2e02407c",
             "parentId": "ba4b5efd1ab3e2bf0a547f51",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fcf",
             "_tpl": "656f9d5900d62bcd2e02407c",
             "parentId": "ba4b5efd1ab3e2bf0a547f51",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "cc36008c3a9e5e48aaf90e46",
             "_tpl": "5ab8e4ed86f7742d8e50c7fa",
             "parentId": "hideout",
@@ -3313,32 +2871,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fd0",
             "_tpl": "657044e971369562b300ce9b",
             "parentId": "cc36008c3a9e5e48aaf90e46",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fd1",
             "_tpl": "657045741bd9beedc40b7299",
             "parentId": "cc36008c3a9e5e48aaf90e46",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fd2",
             "_tpl": "657045b97e80617cee095bda",
             "parentId": "cc36008c3a9e5e48aaf90e46",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fd3",
             "_tpl": "6570460471369562b300ce9f",
             "parentId": "cc36008c3a9e5e48aaf90e46",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "4064dfe7bdfb2dcbb588ebef",
             "_tpl": "5c0e5edb86f77461f55ed1f7",
             "parentId": "hideout",
@@ -3349,50 +2902,42 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fd4",
             "_tpl": "6571dbd388ead79fcf091d71",
             "parentId": "4064dfe7bdfb2dcbb588ebef",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fd5",
             "_tpl": "6571dbda88ead79fcf091d75",
             "parentId": "4064dfe7bdfb2dcbb588ebef",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fd6",
             "_tpl": "6571dbe07c02ae206002502e",
             "parentId": "4064dfe7bdfb2dcbb588ebef",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fd7",
             "_tpl": "6571dbeaee8ec43d520cf89e",
             "parentId": "4064dfe7bdfb2dcbb588ebef",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fd8",
             "_tpl": "6571dbef88ead79fcf091d79",
             "parentId": "4064dfe7bdfb2dcbb588ebef",
             "slotId": "Collar"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fd9",
             "_tpl": "656f57dc27aed95beb08f628",
             "parentId": "4064dfe7bdfb2dcbb588ebef",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fda",
             "_tpl": "656fac30c6baea13cd07e10c",
             "parentId": "4064dfe7bdfb2dcbb588ebef",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "fbfecbe8e8eff4585ad5be8f",
             "_tpl": "5c0e5bab86f77461f55ed1f3",
             "parentId": "hideout",
@@ -3403,56 +2948,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fdb",
             "_tpl": "6571b27a6d84a2b8b6007f92",
             "parentId": "fbfecbe8e8eff4585ad5be8f",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fdc",
             "_tpl": "6571baa74cb80d995d0a1490",
             "parentId": "fbfecbe8e8eff4585ad5be8f",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fdd",
             "_tpl": "6571baac6d84a2b8b6007fa3",
             "parentId": "fbfecbe8e8eff4585ad5be8f",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fde",
             "_tpl": "6571bab0f41985531a038091",
             "parentId": "fbfecbe8e8eff4585ad5be8f",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fdf",
             "_tpl": "6571babb4076795e5e07383f",
             "parentId": "fbfecbe8e8eff4585ad5be8f",
             "slotId": "Collar"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fe0",
             "_tpl": "6571bac34076795e5e073843",
             "parentId": "fbfecbe8e8eff4585ad5be8f",
             "slotId": "Groin"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fe1",
             "_tpl": "6571babf4cb80d995d0a1494",
             "parentId": "fbfecbe8e8eff4585ad5be8f",
             "slotId": "Groin_back"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fe2",
             "_tpl": "654a4dea7c17dec2f50cc86a",
             "parentId": "fbfecbe8e8eff4585ad5be8f",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "cb5b71abe2b3433cb9c8cd13",
             "_tpl": "609e8540d5c319764c2bc2e9",
             "parentId": "hideout",
@@ -3463,44 +2999,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fe3",
             "_tpl": "6572e5221b5bc1185508c24f",
             "parentId": "cb5b71abe2b3433cb9c8cd13",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fe4",
             "_tpl": "6572e52f73c0eabb700109a0",
             "parentId": "cb5b71abe2b3433cb9c8cd13",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fe5",
             "_tpl": "6572e53c73c0eabb700109a4",
             "parentId": "cb5b71abe2b3433cb9c8cd13",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fe6",
             "_tpl": "6572e54873c0eabb700109a8",
             "parentId": "cb5b71abe2b3433cb9c8cd13",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fe7",
             "_tpl": "656f9fa0498d1b7e3e071d98",
             "parentId": "cb5b71abe2b3433cb9c8cd13",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fe8",
             "_tpl": "656f9fa0498d1b7e3e071d98",
             "parentId": "cb5b71abe2b3433cb9c8cd13",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "bac2f080b35e85006ea3d7fd",
             "_tpl": "5c0e53c886f7747fa54205c7",
             "parentId": "hideout",
@@ -3511,56 +3040,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fe9",
             "_tpl": "654a8b0b0337d53f9102c2ae",
             "parentId": "bac2f080b35e85006ea3d7fd",
             "slotId": "soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fea",
             "_tpl": "654a8976f414fcea4004d78b",
             "parentId": "bac2f080b35e85006ea3d7fd",
             "slotId": "soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065feb",
             "_tpl": "654a8b3df414fcea4004d78f",
             "parentId": "bac2f080b35e85006ea3d7fd",
             "slotId": "soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fec",
             "_tpl": "654a8b80f414fcea4004d797",
             "parentId": "bac2f080b35e85006ea3d7fd",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fed",
             "_tpl": "654a8ae00337d53f9102c2aa",
             "parentId": "bac2f080b35e85006ea3d7fd",
             "slotId": "Collar"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fee",
             "_tpl": "654a8bc5f414fcea4004d79b",
             "parentId": "bac2f080b35e85006ea3d7fd",
             "slotId": "Groin"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fef",
             "_tpl": "656f603f94b480b8a500c0d6",
             "parentId": "bac2f080b35e85006ea3d7fd",
             "slotId": "front_plate"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065ff0",
             "_tpl": "656efd66034e8e01c407f35c",
             "parentId": "bac2f080b35e85006ea3d7fd",
             "slotId": "back_plate"
-        },
-        {
+        }, {
             "_id": "e74bd4c8e8aad54ff7edf993",
             "_tpl": "5c0e57ba86f7747fa141986d",
             "parentId": "hideout",
@@ -3571,62 +3091,52 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065ff1",
             "_tpl": "65707fc348c7a887f2010432",
             "parentId": "e74bd4c8e8aad54ff7edf993",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065ff2",
             "_tpl": "6570800612755ae0d907acf8",
             "parentId": "e74bd4c8e8aad54ff7edf993",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065ff3",
             "_tpl": "65708070f65e2491bf00972c",
             "parentId": "e74bd4c8e8aad54ff7edf993",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065ff4",
             "_tpl": "657080a212755ae0d907ad04",
             "parentId": "e74bd4c8e8aad54ff7edf993",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065ff5",
             "_tpl": "657080ca12755ae0d907ad5e",
             "parentId": "e74bd4c8e8aad54ff7edf993",
             "slotId": "Collar"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065ff6",
             "_tpl": "65708122f65e2491bf009755",
             "parentId": "e74bd4c8e8aad54ff7edf993",
             "slotId": "Groin"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065ff7",
             "_tpl": "65708165696fe382cf073255",
             "parentId": "e74bd4c8e8aad54ff7edf993",
             "slotId": "Groin_back"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065ff8",
             "_tpl": "656f603f94b480b8a500c0d6",
             "parentId": "e74bd4c8e8aad54ff7edf993",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065ff9",
             "_tpl": "657b22485f444d6dff0c6c2f",
             "parentId": "e74bd4c8e8aad54ff7edf993",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "df1baddd98542ee14eefefde",
             "_tpl": "5c0e655586f774045612eeb2",
             "parentId": "hideout",
@@ -3637,32 +3147,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065ffa",
             "_tpl": "6570e025615f54368b04fcb0",
             "parentId": "df1baddd98542ee14eefefde",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065ffb",
             "_tpl": "6570e0610b57c03ec90b96ef",
             "parentId": "df1baddd98542ee14eefefde",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065ffc",
             "_tpl": "656fad8c498d1b7e3e071da0",
             "parentId": "df1baddd98542ee14eefefde",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065ffd",
             "_tpl": "656fad8c498d1b7e3e071da0",
             "parentId": "df1baddd98542ee14eefefde",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "26de8c2b1dd68b5cedcd781a",
             "_tpl": "5ab8e79e86f7742d8b372e78",
             "parentId": "hideout",
@@ -3673,50 +3178,42 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065ffe",
             "_tpl": "65732688d9d89ff7ac0d9c4c",
             "parentId": "26de8c2b1dd68b5cedcd781a",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96065fff",
             "_tpl": "657326978c1cc6dcd9098b56",
             "parentId": "26de8c2b1dd68b5cedcd781a",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066000",
             "_tpl": "657326a28c1cc6dcd9098b5a",
             "parentId": "26de8c2b1dd68b5cedcd781a",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066001",
             "_tpl": "657326b08c1cc6dcd9098b5e",
             "parentId": "26de8c2b1dd68b5cedcd781a",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066002",
             "_tpl": "657326bc5d3a3129fb05f36b",
             "parentId": "26de8c2b1dd68b5cedcd781a",
             "slotId": "Collar"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066003",
             "_tpl": "656f611f94b480b8a500c0db",
             "parentId": "26de8c2b1dd68b5cedcd781a",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066004",
             "_tpl": "65573fa5655447403702a816",
             "parentId": "26de8c2b1dd68b5cedcd781a",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "81dcbbdcb9a6ef6752fe0fbb",
             "_tpl": "5b44d0de86f774503d30cba8",
             "parentId": "hideout",
@@ -3727,62 +3224,52 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066005",
             "_tpl": "6575c342efc786cd9101a5e5",
             "parentId": "81dcbbdcb9a6ef6752fe0fbb",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066006",
             "_tpl": "6575c34bc6700bd6b40e8a84",
             "parentId": "81dcbbdcb9a6ef6752fe0fbb",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066007",
             "_tpl": "6575c35bc6700bd6b40e8a88",
             "parentId": "81dcbbdcb9a6ef6752fe0fbb",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066008",
             "_tpl": "6575c366c6700bd6b40e8a8c",
             "parentId": "81dcbbdcb9a6ef6752fe0fbb",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066009",
             "_tpl": "6575c373dc9932aed601c5ec",
             "parentId": "81dcbbdcb9a6ef6752fe0fbb",
             "slotId": "Collar"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606600a",
             "_tpl": "6575c385dc9932aed601c5f0",
             "parentId": "81dcbbdcb9a6ef6752fe0fbb",
             "slotId": "Groin"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606600b",
             "_tpl": "6575c390efc786cd9101a5e9",
             "parentId": "81dcbbdcb9a6ef6752fe0fbb",
             "slotId": "Groin_back"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606600c",
             "_tpl": "656fa8d700d62bcd2e024084",
             "parentId": "81dcbbdcb9a6ef6752fe0fbb",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606600d",
             "_tpl": "656fa8d700d62bcd2e024084",
             "parentId": "81dcbbdcb9a6ef6752fe0fbb",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "fac9bb2ff1bdd55c5d09f9ae",
             "_tpl": "5ca2151486f774244a3b8d30",
             "parentId": "hideout",
@@ -3793,62 +3280,52 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606600e",
             "_tpl": "6575dd3e9e27f4a85e081142",
             "parentId": "fac9bb2ff1bdd55c5d09f9ae",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606600f",
             "_tpl": "6575dd519e27f4a85e081146",
             "parentId": "fac9bb2ff1bdd55c5d09f9ae",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066010",
             "_tpl": "6575dd64945bf78edd04c438",
             "parentId": "fac9bb2ff1bdd55c5d09f9ae",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066011",
             "_tpl": "6575dd6e9d3a0ddf660b9047",
             "parentId": "fac9bb2ff1bdd55c5d09f9ae",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066012",
             "_tpl": "6575dd769d3a0ddf660b904b",
             "parentId": "fac9bb2ff1bdd55c5d09f9ae",
             "slotId": "Collar"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066013",
             "_tpl": "6575dd800546f8b1de093df6",
             "parentId": "fac9bb2ff1bdd55c5d09f9ae",
             "slotId": "Groin"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066014",
             "_tpl": "6575dd94945bf78edd04c43c",
             "parentId": "fac9bb2ff1bdd55c5d09f9ae",
             "slotId": "Groin_back"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066015",
             "_tpl": "65573fa5655447403702a816",
             "parentId": "fac9bb2ff1bdd55c5d09f9ae",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066016",
             "_tpl": "65573fa5655447403702a816",
             "parentId": "fac9bb2ff1bdd55c5d09f9ae",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "b8ebacd89ab4fb24c4398dfd",
             "_tpl": "5b44cf1486f77431723e3d05",
             "parentId": "hideout",
@@ -3859,74 +3336,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066017",
             "_tpl": "6575c3b3dc9932aed601c5f4",
             "parentId": "b8ebacd89ab4fb24c4398dfd",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066018",
             "_tpl": "6575c3beefc786cd9101a5ed",
             "parentId": "b8ebacd89ab4fb24c4398dfd",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066019",
             "_tpl": "6575c3cdc6700bd6b40e8a90",
             "parentId": "b8ebacd89ab4fb24c4398dfd",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606601a",
             "_tpl": "6575c3dfdc9932aed601c5f8",
             "parentId": "b8ebacd89ab4fb24c4398dfd",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606601b",
             "_tpl": "6575c3ec52b7f8c76a05ee39",
             "parentId": "b8ebacd89ab4fb24c4398dfd",
             "slotId": "Collar"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606601c",
             "_tpl": "6575c3fd52b7f8c76a05ee3d",
             "parentId": "b8ebacd89ab4fb24c4398dfd",
             "slotId": "Shoulder_l"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606601d",
             "_tpl": "6575c40c52b7f8c76a05ee41",
             "parentId": "b8ebacd89ab4fb24c4398dfd",
             "slotId": "Shoulder_r"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606601e",
             "_tpl": "656fa8d700d62bcd2e024084",
             "parentId": "b8ebacd89ab4fb24c4398dfd",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606601f",
             "_tpl": "656fa8d700d62bcd2e024084",
             "parentId": "b8ebacd89ab4fb24c4398dfd",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066020",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "b8ebacd89ab4fb24c4398dfd",
             "slotId": "Left_side_plate"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066021",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "b8ebacd89ab4fb24c4398dfd",
             "slotId": "Right_side_plate"
-        },
-        {
+        }, {
             "_id": "462cefd5ddae8f6bab381b6e",
             "_tpl": "5b44cd8b86f774503d30cba2",
             "parentId": "hideout",
@@ -3937,86 +3402,72 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066022",
             "_tpl": "6575c2adefc786cd9101a5d9",
             "parentId": "462cefd5ddae8f6bab381b6e",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066023",
             "_tpl": "6575c2be52b7f8c76a05ee25",
             "parentId": "462cefd5ddae8f6bab381b6e",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066024",
             "_tpl": "6575c2cd52b7f8c76a05ee29",
             "parentId": "462cefd5ddae8f6bab381b6e",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066025",
             "_tpl": "6575c2d852b7f8c76a05ee2d",
             "parentId": "462cefd5ddae8f6bab381b6e",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066026",
             "_tpl": "6575c2e4efc786cd9101a5dd",
             "parentId": "462cefd5ddae8f6bab381b6e",
             "slotId": "Collar"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066027",
             "_tpl": "6575c2f7efc786cd9101a5e1",
             "parentId": "462cefd5ddae8f6bab381b6e",
             "slotId": "Shoulder_l"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066028",
             "_tpl": "6575c30352b7f8c76a05ee31",
             "parentId": "462cefd5ddae8f6bab381b6e",
             "slotId": "Shoulder_r"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066029",
             "_tpl": "6575c31b52b7f8c76a05ee35",
             "parentId": "462cefd5ddae8f6bab381b6e",
             "slotId": "Groin"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606602a",
             "_tpl": "6575c326c6700bd6b40e8a80",
             "parentId": "462cefd5ddae8f6bab381b6e",
             "slotId": "Groin_back"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606602b",
             "_tpl": "656fa8d700d62bcd2e024084",
             "parentId": "462cefd5ddae8f6bab381b6e",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606602c",
             "_tpl": "656fa8d700d62bcd2e024084",
             "parentId": "462cefd5ddae8f6bab381b6e",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606602d",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "462cefd5ddae8f6bab381b6e",
             "slotId": "Left_side_plate"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606602e",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "462cefd5ddae8f6bab381b6e",
             "slotId": "Right_side_plate"
-        },
-        {
+        }, {
             "_id": "b9e2213c9da4adb80f18edee",
             "_tpl": "5f5f41476bdad616ad46d631",
             "parentId": "hideout",
@@ -4027,74 +3478,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606602f",
             "_tpl": "65731b46cea9255e2102360a",
             "parentId": "b9e2213c9da4adb80f18edee",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066030",
             "_tpl": "65731b4fcea9255e2102360e",
             "parentId": "b9e2213c9da4adb80f18edee",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066031",
             "_tpl": "65731b576e709cddd001ec3f",
             "parentId": "b9e2213c9da4adb80f18edee",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066032",
             "_tpl": "65731b60ff6dc44a7d068c4a",
             "parentId": "b9e2213c9da4adb80f18edee",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066033",
             "_tpl": "65731b666e709cddd001ec43",
             "parentId": "b9e2213c9da4adb80f18edee",
             "slotId": "Collar"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066034",
             "_tpl": "65731b716e709cddd001ec47",
             "parentId": "b9e2213c9da4adb80f18edee",
             "slotId": "Groin"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066035",
             "_tpl": "65731b6b6042b0f210020ef6",
             "parentId": "b9e2213c9da4adb80f18edee",
             "slotId": "Groin_back"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066036",
             "_tpl": "656f664200d62bcd2e024077",
             "parentId": "b9e2213c9da4adb80f18edee",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066037",
             "_tpl": "654a4f8bc721968a4404ef18",
             "parentId": "b9e2213c9da4adb80f18edee",
             "slotId": "Left_side_plate"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066038",
             "_tpl": "654a4f8bc721968a4404ef18",
             "parentId": "b9e2213c9da4adb80f18edee",
             "slotId": "Right_side_plate"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066039",
             "_tpl": "657b2797c3dbcb01d60c35ea",
             "parentId": "b9e2213c9da4adb80f18edee",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "dda4fa330f096da94e9d81c3",
             "_tpl": "5e9dacf986f774054d6b89f4",
             "parentId": "hideout",
@@ -4105,56 +3544,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606603a",
             "_tpl": "65732de75d3a3129fb05f3dd",
             "parentId": "dda4fa330f096da94e9d81c3",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606603b",
             "_tpl": "65732df4d0acf75aea06c87b",
             "parentId": "dda4fa330f096da94e9d81c3",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606603c",
             "_tpl": "65732e05d0acf75aea06c87f",
             "parentId": "dda4fa330f096da94e9d81c3",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606603d",
             "_tpl": "65732e0f6784ca384b0167ad",
             "parentId": "dda4fa330f096da94e9d81c3",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606603e",
             "_tpl": "65732e215d3a3129fb05f3e1",
             "parentId": "dda4fa330f096da94e9d81c3",
             "slotId": "Collar"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606603f",
             "_tpl": "65732e30dd8739f6440ef383",
             "parentId": "dda4fa330f096da94e9d81c3",
             "slotId": "Groin"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066040",
             "_tpl": "65573fa5655447403702a816",
             "parentId": "dda4fa330f096da94e9d81c3",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066041",
             "_tpl": "65573fa5655447403702a816",
             "parentId": "dda4fa330f096da94e9d81c3",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "2c6c79dfc30c4b8c56b1d1d8",
             "_tpl": "5c0e541586f7747fa54205c9",
             "parentId": "hideout",
@@ -4165,56 +3595,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066042",
             "_tpl": "6575ea3060703324250610da",
             "parentId": "2c6c79dfc30c4b8c56b1d1d8",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066043",
             "_tpl": "6575ea4cf6a13a7b7100adc4",
             "parentId": "2c6c79dfc30c4b8c56b1d1d8",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066044",
             "_tpl": "6575ea5cf6a13a7b7100adc8",
             "parentId": "2c6c79dfc30c4b8c56b1d1d8",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066045",
             "_tpl": "6575ea6760703324250610de",
             "parentId": "2c6c79dfc30c4b8c56b1d1d8",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066046",
             "_tpl": "6575ea719c7cad336508e418",
             "parentId": "2c6c79dfc30c4b8c56b1d1d8",
             "slotId": "Collar"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066047",
             "_tpl": "6575ea7c60703324250610e2",
             "parentId": "2c6c79dfc30c4b8c56b1d1d8",
             "slotId": "Groin"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066048",
             "_tpl": "656f611f94b480b8a500c0db",
             "parentId": "2c6c79dfc30c4b8c56b1d1d8",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066049",
             "_tpl": "656efaf54772930db4031ff5",
             "parentId": "2c6c79dfc30c4b8c56b1d1d8",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "b99f84c0c89cc0a0a71af70a",
             "_tpl": "5ca21c6986f77479963115a7",
             "parentId": "hideout",
@@ -4225,86 +3646,72 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606604a",
             "_tpl": "6575d9a79e27f4a85e08112d",
             "parentId": "b99f84c0c89cc0a0a71af70a",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606604b",
             "_tpl": "6575d9b8945bf78edd04c427",
             "parentId": "b99f84c0c89cc0a0a71af70a",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606604c",
             "_tpl": "6575d9c40546f8b1de093dee",
             "parentId": "b99f84c0c89cc0a0a71af70a",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606604d",
             "_tpl": "6575d9cf0546f8b1de093df2",
             "parentId": "b99f84c0c89cc0a0a71af70a",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606604e",
             "_tpl": "6575d9d8945bf78edd04c42b",
             "parentId": "b99f84c0c89cc0a0a71af70a",
             "slotId": "Collar"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066050",
             "_tpl": "6575da07945bf78edd04c433",
             "parentId": "b99f84c0c89cc0a0a71af70a",
             "slotId": "Shoulder_l"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066051",
             "_tpl": "6575da159e27f4a85e081131",
             "parentId": "b99f84c0c89cc0a0a71af70a",
             "slotId": "Shoulder_r"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066052",
             "_tpl": "6575d9e7945bf78edd04c42f",
             "parentId": "b99f84c0c89cc0a0a71af70a",
             "slotId": "Groin"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066053",
             "_tpl": "6575d9f816c2762fba00588d",
             "parentId": "b99f84c0c89cc0a0a71af70a",
             "slotId": "Groin_back"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066054",
             "_tpl": "65573fa5655447403702a816",
             "parentId": "b99f84c0c89cc0a0a71af70a",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066055",
             "_tpl": "65573fa5655447403702a816",
             "parentId": "b99f84c0c89cc0a0a71af70a",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066056",
             "_tpl": "64afd81707e2cf40e903a316",
             "parentId": "b99f84c0c89cc0a0a71af70a",
             "slotId": "Left_side_plate"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066057",
             "_tpl": "64afd81707e2cf40e903a316",
             "parentId": "b99f84c0c89cc0a0a71af70a",
             "slotId": "Right_side_plate"
-        },
-        {
+        }, {
             "_id": "cddf2eedaaee1ed855325aa6",
             "_tpl": "5c0e625a86f7742d77340f62",
             "parentId": "hideout",
@@ -4315,62 +3722,52 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066058",
             "_tpl": "65764275d8537eb26a0355e9",
             "parentId": "cddf2eedaaee1ed855325aa6",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066059",
             "_tpl": "657642b0e6d5dd75f40688a5",
             "parentId": "cddf2eedaaee1ed855325aa6",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606605a",
             "_tpl": "6576434820cc24d17102b148",
             "parentId": "cddf2eedaaee1ed855325aa6",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606605b",
             "_tpl": "657643732bc38ef78e076477",
             "parentId": "cddf2eedaaee1ed855325aa6",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606605c",
             "_tpl": "657643a220cc24d17102b14c",
             "parentId": "cddf2eedaaee1ed855325aa6",
             "slotId": "Collar"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606605d",
             "_tpl": "656f63c027aed95beb08f62c",
             "parentId": "cddf2eedaaee1ed855325aa6",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606605e",
             "_tpl": "656fafe3498d1b7e3e071da4",
             "parentId": "cddf2eedaaee1ed855325aa6",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606605f",
             "_tpl": "64afd81707e2cf40e903a316",
             "parentId": "cddf2eedaaee1ed855325aa6",
             "slotId": "Left_side_plate"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066060",
             "_tpl": "64afd81707e2cf40e903a316",
             "parentId": "cddf2eedaaee1ed855325aa6",
             "slotId": "Right_side_plate"
-        },
-        {
+        }, {
             "_id": "b300dea5d6b91e0c9fdcdcfa",
             "_tpl": "5fd4c474dd870108a754b241",
             "parentId": "hideout",
@@ -4381,20 +3778,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066061",
             "_tpl": "656faf0ca0dce000a2020f77",
             "parentId": "b300dea5d6b91e0c9fdcdcfa",
             "slotId": "front_plate"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066062",
             "_tpl": "656faf0ca0dce000a2020f77",
             "parentId": "b300dea5d6b91e0c9fdcdcfa",
             "slotId": "back_plate"
-        },
-        {
+        }, {
             "_id": "1b29b4cdaeab7e690c4d3f5b",
             "_tpl": "5e4abb5086f77406975c9342",
             "parentId": "hideout",
@@ -4405,32 +3799,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066063",
             "_tpl": "6575e71760703324250610c3",
             "parentId": "1b29b4cdaeab7e690c4d3f5b",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066064",
             "_tpl": "6575e72660703324250610c7",
             "parentId": "1b29b4cdaeab7e690c4d3f5b",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066065",
             "_tpl": "656fa76500d62bcd2e024080",
             "parentId": "1b29b4cdaeab7e690c4d3f5b",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066066",
             "_tpl": "656fa76500d62bcd2e024080",
             "parentId": "1b29b4cdaeab7e690c4d3f5b",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "f863fc6d0eacccc5ad5535a7",
             "_tpl": "60a283193cb70855c43a381d",
             "parentId": "hideout",
@@ -4441,80 +3830,67 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066067",
             "_tpl": "6575d561b15fef3dd4051670",
             "parentId": "f863fc6d0eacccc5ad5535a7",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066068",
             "_tpl": "6575d56b16c2762fba005818",
             "parentId": "f863fc6d0eacccc5ad5535a7",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066069",
             "_tpl": "6575d57a16c2762fba00581c",
             "parentId": "f863fc6d0eacccc5ad5535a7",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606606a",
             "_tpl": "6575d589b15fef3dd4051674",
             "parentId": "f863fc6d0eacccc5ad5535a7",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606606b",
             "_tpl": "6575d598b15fef3dd4051678",
             "parentId": "f863fc6d0eacccc5ad5535a7",
             "slotId": "Collar"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606606c",
             "_tpl": "6575d5b316c2762fba005824",
             "parentId": "f863fc6d0eacccc5ad5535a7",
             "slotId": "Shoulder_l"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606606d",
             "_tpl": "6575d5bd16c2762fba005828",
             "parentId": "f863fc6d0eacccc5ad5535a7",
             "slotId": "Shoulder_r"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606606e",
             "_tpl": "6575d5a616c2762fba005820",
             "parentId": "f863fc6d0eacccc5ad5535a7",
             "slotId": "Groin"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606606f",
             "_tpl": "656fa61e94b480b8a500c0e8",
             "parentId": "f863fc6d0eacccc5ad5535a7",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066070",
             "_tpl": "656fa61e94b480b8a500c0e8",
             "parentId": "f863fc6d0eacccc5ad5535a7",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066071",
             "_tpl": "64afdb577bb3bfe8fe03fd1d",
             "parentId": "f863fc6d0eacccc5ad5535a7",
             "slotId": "Left_side_plate"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066072",
             "_tpl": "64afdb577bb3bfe8fe03fd1d",
             "parentId": "f863fc6d0eacccc5ad5535a7",
             "slotId": "Right_side_plate"
-        },
-        {
+        }, {
             "_id": "5dffcffcb8cbba35c04b9dea",
             "_tpl": "545cdb794bdc2d3a198b456a",
             "parentId": "hideout",
@@ -4525,80 +3901,67 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066073",
             "_tpl": "6575ce3716c2762fba0057fd",
             "parentId": "5dffcffcb8cbba35c04b9dea",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066074",
             "_tpl": "6575ce45dc9932aed601c616",
             "parentId": "5dffcffcb8cbba35c04b9dea",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066075",
             "_tpl": "6575ce5016c2762fba005802",
             "parentId": "5dffcffcb8cbba35c04b9dea",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066076",
             "_tpl": "6575ce5befc786cd9101a671",
             "parentId": "5dffcffcb8cbba35c04b9dea",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066077",
             "_tpl": "6575ce6f16c2762fba005806",
             "parentId": "5dffcffcb8cbba35c04b9dea",
             "slotId": "Collar"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066078",
             "_tpl": "6575ce9db15fef3dd4051628",
             "parentId": "5dffcffcb8cbba35c04b9dea",
             "slotId": "Shoulder_l"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f96066079",
             "_tpl": "6575cea8b15fef3dd405162c",
             "parentId": "5dffcffcb8cbba35c04b9dea",
             "slotId": "Shoulder_r"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606607a",
             "_tpl": "6575ce8bdc9932aed601c61e",
             "parentId": "5dffcffcb8cbba35c04b9dea",
             "slotId": "Groin"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606607b",
             "_tpl": "64afc71497cf3a403c01ff38",
             "parentId": "5dffcffcb8cbba35c04b9dea",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606607c",
             "_tpl": "64afc71497cf3a403c01ff38",
             "parentId": "5dffcffcb8cbba35c04b9dea",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606607d",
             "_tpl": "64afd81707e2cf40e903a316",
             "parentId": "5dffcffcb8cbba35c04b9dea",
             "slotId": "Left_side_plate"
-        },
-        {
+        }, {
             "_id": "666e4c253142970f9606607e",
             "_tpl": "64afd81707e2cf40e903a316",
             "parentId": "5dffcffcb8cbba35c04b9dea",
             "slotId": "Right_side_plate"
-        },
-        {
+        }, {
             "_id": "154867c34e24b23072b2dee0",
             "_tpl": "62a09d79de7ac81993580530",
             "parentId": "hideout",
@@ -4609,32 +3972,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "abe4b9adc0ac7bd2fc9cfaee",
             "_tpl": "6572e048371fccfbf909d5d8",
             "parentId": "154867c34e24b23072b2dee0",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "6cc7db64eba7d5efef3e6d2d",
             "_tpl": "6572e059371fccfbf909d5dc",
             "parentId": "154867c34e24b23072b2dee0",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "f01a0edded13685d6ec9f4f8",
             "_tpl": "6572e06219b4b511af012f89",
             "parentId": "154867c34e24b23072b2dee0",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "6dd4ab3fb3b7bd327c81e1c6",
             "_tpl": "6572e06819b4b511af012f8d",
             "parentId": "154867c34e24b23072b2dee0",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "1cb2484a08e5db3b5e37af41",
             "_tpl": "62a09d79de7ac81993580530",
             "parentId": "hideout",
@@ -4645,32 +4003,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "52da2da11875b17ae1cd14e9",
             "_tpl": "6572e048371fccfbf909d5d8",
             "parentId": "1cb2484a08e5db3b5e37af41",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "90dce0cb2d351efaebc15924",
             "_tpl": "6572e059371fccfbf909d5dc",
             "parentId": "1cb2484a08e5db3b5e37af41",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "682d8cc0b0d9c12ece67bf25",
             "_tpl": "6572e06219b4b511af012f89",
             "parentId": "1cb2484a08e5db3b5e37af41",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "fb0df1e5ef99a9f879216b17",
             "_tpl": "6572e06819b4b511af012f8d",
             "parentId": "1cb2484a08e5db3b5e37af41",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "c4882a61d8b2be239c13b494",
             "_tpl": "64be79c487d1510151095552",
             "parentId": "hideout",
@@ -4681,20 +4034,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "4b99ee7ab7bd2ffa6c3fbdbb",
             "_tpl": "6570495b45d573133d0d6adb",
             "parentId": "c4882a61d8b2be239c13b494",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "eecab7aeb9b7243bef78efdf",
             "_tpl": "657049d23425b19bbc0502f0",
             "parentId": "c4882a61d8b2be239c13b494",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "786036fd29bfaf00bec5c5b0",
             "_tpl": "64be79c487d1510151095552",
             "parentId": "hideout",
@@ -4705,20 +4055,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "3fceea7a4fdb5786da1eaab1",
             "_tpl": "6570495b45d573133d0d6adb",
             "parentId": "786036fd29bfaf00bec5c5b0",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "938cc6f9bed1fcf32c91dd25",
             "_tpl": "657049d23425b19bbc0502f0",
             "parentId": "786036fd29bfaf00bec5c5b0",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "4b9d28e454a4ff3aa33dcefb",
             "_tpl": "64be79e2bf8412471d0d9bcc",
             "parentId": "hideout",
@@ -4729,20 +4076,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "3ee56c7a2e5d91bf6fd61eef",
             "_tpl": "6570495b45d573133d0d6adb",
             "parentId": "4b9d28e454a4ff3aa33dcefb",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "f7f2bd230bbba8c8baf5b1ca",
             "_tpl": "657049d23425b19bbc0502f0",
             "parentId": "4b9d28e454a4ff3aa33dcefb",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "b7fcc99b5cf753b5b6d400d8",
             "_tpl": "64be79e2bf8412471d0d9bcc",
             "parentId": "hideout",
@@ -4753,20 +4097,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "abfccf886dfd7ea60b9cd2b5",
             "_tpl": "6570495b45d573133d0d6adb",
             "parentId": "b7fcc99b5cf753b5b6d400d8",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "fffae5aaac86ba8b3dc6ba84",
             "_tpl": "657049d23425b19bbc0502f0",
             "parentId": "b7fcc99b5cf753b5b6d400d8",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "1d012074183a599d7c149ebb",
             "_tpl": "63737f448b28897f2802b874",
             "parentId": "hideout",
@@ -4777,20 +4118,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "dab5846b7a51222bfe8db62f",
             "_tpl": "656fae5f7c2d57afe200c0d7",
             "parentId": "1d012074183a599d7c149ebb",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "9b7fbfbd7b8d8aaa46192aad",
             "_tpl": "656fae5f7c2d57afe200c0d7",
             "parentId": "1d012074183a599d7c149ebb",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "b12dd7656cc4faeb35a31e09",
             "_tpl": "63737f448b28897f2802b874",
             "parentId": "hideout",
@@ -4801,20 +4139,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "69fa66aee2b4f23e9917c6ef",
             "_tpl": "656fae5f7c2d57afe200c0d7",
             "parentId": "b12dd7656cc4faeb35a31e09",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "6ae9e1a4eaefec0ee340e304",
             "_tpl": "656fae5f7c2d57afe200c0d7",
             "parentId": "b12dd7656cc4faeb35a31e09",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "a029bbfb9b058bc8f25be586",
             "_tpl": "64abd93857958b4249003418",
             "parentId": "hideout",
@@ -4825,44 +4160,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c3cedb464bab0733b5bc7ebc",
             "_tpl": "6570f30b0921c914bf07964c",
             "parentId": "a029bbfb9b058bc8f25be586",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "ce25dec839b11dead1ee292b",
             "_tpl": "6570f35cd67d0309980a7acb",
             "parentId": "a029bbfb9b058bc8f25be586",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "b2cccec63ee0bcced1ac962e",
             "_tpl": "6570f3890b4ae5847f060dad",
             "parentId": "a029bbfb9b058bc8f25be586",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "e0eddc6bde02fbbfb694ec52",
             "_tpl": "6570f3bb0b4ae5847f060db2",
             "parentId": "a029bbfb9b058bc8f25be586",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "d4e0db0ffbf62bdccf0edfcf",
             "_tpl": "656fb0bd7c2d57afe200c0dc",
             "parentId": "a029bbfb9b058bc8f25be586",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "b6ffbfe10cddcfe270bfaf8a",
             "_tpl": "656fb0bd7c2d57afe200c0dc",
             "parentId": "a029bbfb9b058bc8f25be586",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "3b7fc4abf4ff9f74f620bec3",
             "_tpl": "64abd93857958b4249003418",
             "parentId": "hideout",
@@ -4873,44 +4201,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "af37f4d0cd267a29d85574ca",
             "_tpl": "6570f30b0921c914bf07964c",
             "parentId": "3b7fc4abf4ff9f74f620bec3",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "fd81b7dbf4b737a388cacd6a",
             "_tpl": "6570f35cd67d0309980a7acb",
             "parentId": "3b7fc4abf4ff9f74f620bec3",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "ee9e5adbebf5b28c1b6ed7a8",
             "_tpl": "6570f3890b4ae5847f060dad",
             "parentId": "3b7fc4abf4ff9f74f620bec3",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "dbcec0ee8c5d2eb3cb089549",
             "_tpl": "6570f3bb0b4ae5847f060db2",
             "parentId": "3b7fc4abf4ff9f74f620bec3",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "d99c85a4102be9ddf7c3bc7e",
             "_tpl": "656fb0bd7c2d57afe200c0dc",
             "parentId": "3b7fc4abf4ff9f74f620bec3",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "acfedbdfce6ddb21d2cb534b",
             "_tpl": "656fb0bd7c2d57afe200c0dc",
             "parentId": "3b7fc4abf4ff9f74f620bec3",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "51e9afbdfa34bc6bb1cc99f1",
             "_tpl": "5448be9a4bdc2dfd2f8b456a",
             "parentId": "hideout",
@@ -4921,8 +4242,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "af0fa3c7caa391e4f1f8b2fe",
             "_tpl": "5710c24ad2720bc3458b45a3",
             "parentId": "hideout",
@@ -4933,8 +4253,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f7e74aada5a556a9efcc70dd",
             "_tpl": "58d3db5386f77426186285a0",
             "parentId": "hideout",
@@ -4945,8 +4264,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d5ea7d470070ebca5a3caed9",
             "_tpl": "5a0c27731526d80618476ac4",
             "parentId": "hideout",
@@ -4957,8 +4275,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ef68ad9bedb14eb19acebf53",
             "_tpl": "5a2a57cfc4a2826c6e06d44a",
             "parentId": "hideout",
@@ -4969,8 +4286,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "1b3d8cf6ebae7d9f4d2fafb3",
             "_tpl": "5e32f56fcb6d5863cc5e5ee4",
             "parentId": "hideout",
@@ -4981,8 +4297,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "371fc0d3c86cba2c6df4abe9",
             "_tpl": "5e340dcdcb6d5863cc5e5efb",
             "parentId": "hideout",
@@ -4993,8 +4308,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "965ef27a553a8dca26a27e2b",
             "_tpl": "617aa4dd8166f034d57de9c5",
             "parentId": "hideout",
@@ -5005,8 +4319,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e9bfe4e91a92dade9ae3a1b1",
             "_tpl": "617fd91e5539a84ec44ce155",
             "parentId": "hideout",
@@ -5017,8 +4330,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "cfcd0a82f66efd3ae7c186fa",
             "_tpl": "618a431df1eb8e24b8741deb",
             "parentId": "hideout",
@@ -5029,8 +4341,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "42012fa6ebfe98bd4c68f59b",
             "_tpl": "619256e5f8af2c1a4e1f5d92",
             "parentId": "hideout",
@@ -5041,8 +4352,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "6aafbeb9d48cd79ed4a5157b",
             "_tpl": "5656eb674bdc2d35148b457c",
             "parentId": "hideout",
@@ -5053,8 +4363,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "2d3ddc9a8fad6f28f6d586af",
             "_tpl": "620109578d82e67e7911abf2",
             "parentId": "hideout",
@@ -5065,8 +4374,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "2bc5e8b73c0a14ffd4bcdfa5",
             "_tpl": "6217726288ed9f0845317459",
             "parentId": "hideout",
@@ -5077,8 +4385,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "2911812d0dfde86e08d8a18a",
             "_tpl": "62178be9d0050232da3485d9",
             "parentId": "hideout",
@@ -5089,8 +4396,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "cc2a0f5dae0bd5cfc5d49fbf",
             "_tpl": "624c0b3340357b5f566e8766",
             "parentId": "hideout",
@@ -5101,8 +4407,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "da3a35d7ad7a4c4a0c7aec83",
             "_tpl": "62389aaba63f32501b1b444f",
             "parentId": "hideout",
@@ -5113,8 +4418,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a22bd6adfbfc9e8b80a5a5ae",
             "_tpl": "62389bc9423ed1685422dc57",
             "parentId": "hideout",
@@ -5125,8 +4429,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "3c93ad820a8e6f71b3a8b7dd",
             "_tpl": "62389be94d5d474bf712e709",
             "parentId": "hideout",
@@ -5137,8 +4440,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a2ce4ec5eabbd4fec171608a",
             "_tpl": "5beed0f50db834001c062b12",
             "parentId": "hideout",
@@ -5149,74 +4451,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a7219bcece79c354f8b8f3b6",
             "_tpl": "5beec1bd0db834001e6006f3",
             "parentId": "a2ce4ec5eabbd4fec171608a",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "0cca1bcbcb283346a0edbcac",
             "_tpl": "5beec3420db834001b095429",
             "parentId": "a7219bcece79c354f8b8f3b6",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "8e87cf0fb94c739e22fa83ec",
             "_tpl": "5beec3e30db8340019619424",
             "parentId": "a2ce4ec5eabbd4fec171608a",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "0c51fe3910eee76fab87a7f9",
             "_tpl": "5beecbb80db834001d2c465e",
             "parentId": "8e87cf0fb94c739e22fa83ec",
             "slotId": "mod_mount_001"
-        },
-        {
+        }, {
             "_id": "2a2adedddf94a99506bfcb1e",
             "_tpl": "5beecbb80db834001d2c465e",
             "parentId": "8e87cf0fb94c739e22fa83ec",
             "slotId": "mod_mount_000"
-        },
-        {
+        }, {
             "_id": "801ab23c985f2af8cce3fb48",
             "_tpl": "5beec8b20db834001961942a",
             "parentId": "a2ce4ec5eabbd4fec171608a",
             "slotId": "mod_stock_001"
-        },
-        {
+        }, {
             "_id": "10d1ed9a6133e12baf7ffe8d",
             "_tpl": "5beec8c20db834001d2c465c",
             "parentId": "801ab23c985f2af8cce3fb48",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "6302e4954ab0c84d550f6f7c",
             "_tpl": "5beec91a0db834001961942d",
             "parentId": "a2ce4ec5eabbd4fec171608a",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "c0e86e6257c84b3cfb7e6440",
             "_tpl": "5beec9450db83400970084fd",
             "parentId": "6302e4954ab0c84d550f6f7c",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "adb4edf4b7f980c76f5ec19c",
             "_tpl": "5bf3f59f0db834001a6fa060",
             "parentId": "c0e86e6257c84b3cfb7e6440",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "eccf73bc7bba6f71afbeaf8a",
             "_tpl": "5beec8ea0db834001a6f9dbf",
             "parentId": "a2ce4ec5eabbd4fec171608a",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "eeede87b52ac49e9fdf9d468",
             "_tpl": "64637076203536ad5600c990",
             "parentId": "hideout",
@@ -5227,50 +4517,42 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fadaefcaadf7cdd94a3802aa",
             "_tpl": "6492fb8253acae0af00a29b6",
             "parentId": "eeede87b52ac49e9fdf9d468",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "6e9a37bf9f6dffddcdcc053c",
             "_tpl": "6464d870bb2c580352070cc4",
             "parentId": "eeede87b52ac49e9fdf9d468",
             "slotId": "mod_bipod"
-        },
-        {
+        }, {
             "_id": "cc327c5b3dfcd847c93aa460",
             "_tpl": "646371a9f2404ab67905c8e6",
             "parentId": "eeede87b52ac49e9fdf9d468",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "ad980c0a2ff3c54f7b05f5ac",
             "_tpl": "646372518610c40fc20204e8",
             "parentId": "eeede87b52ac49e9fdf9d468",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "f05088706fe4a589cbd5f8cc",
             "_tpl": "646371faf2404ab67905c8e9",
             "parentId": "eeede87b52ac49e9fdf9d468",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "88c3a361c2c62fb25d90bea5",
             "_tpl": "6492efb8cfcf7c89e701abf3",
             "parentId": "f05088706fe4a589cbd5f8cc",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "2fadbd2fd62aafa2d19db4e3",
             "_tpl": "646371779f5f0ea59a04c204",
             "parentId": "eeede87b52ac49e9fdf9d468",
             "slotId": "mod_pistolgrip"
-        },
-        {
+        }, {
             "_id": "cb9f4f04ef7beaded110f66b",
             "_tpl": "64ca3d3954fc657e230529cc",
             "parentId": "hideout",
@@ -5281,44 +4563,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f0acdf0e0503a767bd3c7ae9",
             "_tpl": "6492fb8253acae0af00a29b6",
             "parentId": "cb9f4f04ef7beaded110f66b",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "291a2dc9b7b9afa7939c4132",
             "_tpl": "6464d870bb2c580352070cc4",
             "parentId": "cb9f4f04ef7beaded110f66b",
             "slotId": "mod_bipod"
-        },
-        {
+        }, {
             "_id": "d9eedcf64d2a2d373debec8b",
             "_tpl": "6492e3a97df7d749100e29ee",
             "parentId": "cb9f4f04ef7beaded110f66b",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "fd6eaad3efc77bfccd04eb7a",
             "_tpl": "646372518610c40fc20204e8",
             "parentId": "cb9f4f04ef7beaded110f66b",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "b86b37dcea3cab4abccd73ea",
             "_tpl": "64639a9aab86f8fd4300146c",
             "parentId": "cb9f4f04ef7beaded110f66b",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "bcefaaeb0c68ec5beac67bbd",
             "_tpl": "64cbad529f7cf7f75c077fd5",
             "parentId": "cb9f4f04ef7beaded110f66b",
             "slotId": "mod_pistolgrip"
-        },
-        {
+        }, {
             "_id": "58ccadceea47bbf0ea9b9f10",
             "_tpl": "6513ef33e06849f06c0957ca",
             "parentId": "hideout",
@@ -5329,56 +4604,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d48b5bb9ab4fa480d2f3a3a7",
             "_tpl": "6513f153e63f29908d0ffaba",
             "parentId": "58ccadceea47bbf0ea9b9f10",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "feaabe7bef0b9d438c5be9bf",
             "_tpl": "6513f05a94c72326990a3866",
             "parentId": "58ccadceea47bbf0ea9b9f10",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "cc1c6fc5ea4beeb0ee7beeda",
             "_tpl": "6513eff1e06849f06c0957d4",
             "parentId": "58ccadceea47bbf0ea9b9f10",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "ab5cd1da5a74fa485d515955",
             "_tpl": "6513f0f5e63f29908d0ffab8",
             "parentId": "cc1c6fc5ea4beeb0ee7beeda",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "c6cc7c828fbeddfaa2232e3a",
             "_tpl": "6513f037e06849f06c0957d7",
             "parentId": "cc1c6fc5ea4beeb0ee7beeda",
             "slotId": "mod_bipod"
-        },
-        {
+        }, {
             "_id": "4c5beaf35eb9148feba992ee",
             "_tpl": "6513f1798cb24472490ee331",
             "parentId": "58ccadceea47bbf0ea9b9f10",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "7e1ed0fcca87f87bf63afbac",
             "_tpl": "6513f13a8cb24472490ee32f",
             "parentId": "4c5beaf35eb9148feba992ee",
             "slotId": "mod_pistolgrip"
-        },
-        {
+        }, {
             "_id": "eabc55bd5bfe12e73a35f20d",
             "_tpl": "6513f0a194c72326990a3868",
             "parentId": "58ccadceea47bbf0ea9b9f10",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "9ec426bc5e7602c678b9ddba",
             "_tpl": "65268d8ecb944ff1e90ea385",
             "parentId": "hideout",
@@ -5389,56 +4655,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ed1f61d7f1e82cbc882fa7ce",
             "_tpl": "6513f153e63f29908d0ffaba",
             "parentId": "9ec426bc5e7602c678b9ddba",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "ceafbed9b85a8aeaeabbfc72",
             "_tpl": "6513f05a94c72326990a3866",
             "parentId": "9ec426bc5e7602c678b9ddba",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "868b1e8b1b2f3bec8d98e416",
             "_tpl": "6513eff1e06849f06c0957d4",
             "parentId": "9ec426bc5e7602c678b9ddba",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "a37142d8da97aa3fbcf49abd",
             "_tpl": "6513f0f5e63f29908d0ffab8",
             "parentId": "868b1e8b1b2f3bec8d98e416",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "335b0ecbbbeddaeff3ecf47c",
             "_tpl": "6513f037e06849f06c0957d7",
             "parentId": "868b1e8b1b2f3bec8d98e416",
             "slotId": "mod_bipod"
-        },
-        {
+        }, {
             "_id": "afbd6a34d1fe795669c3d02a",
             "_tpl": "6513f1798cb24472490ee331",
             "parentId": "9ec426bc5e7602c678b9ddba",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "2ff41aa47bfced7fde5dd118",
             "_tpl": "6513f13a8cb24472490ee32f",
             "parentId": "afbd6a34d1fe795669c3d02a",
             "slotId": "mod_pistolgrip"
-        },
-        {
+        }, {
             "_id": "a1da7ebef3dd67a0cbe0f9dc",
             "_tpl": "6513f0a194c72326990a3868",
             "parentId": "9ec426bc5e7602c678b9ddba",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "c0decbecaf6fce0fbdd427db",
             "_tpl": "5e81ebcd8e146c7080625e15",
             "parentId": "hideout",
@@ -5449,14 +4706,12 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "baf6fcce92dd41bca8e0fcac",
             "_tpl": "571659bb2459771fb2755a12",
             "parentId": "c0decbecaf6fce0fbdd427db",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "dbb341b7b258fca356bd2fbb",
             "_tpl": "6275303a9f372d6ea97f9ec7",
             "parentId": "hideout",
@@ -5467,32 +4722,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "1e6be8ff0713adff3e57ff1d",
             "_tpl": "6284bd5f95250a29bc628a30",
             "parentId": "dbb341b7b258fca356bd2fbb",
             "slotId": "mod_scope"
-        },
-        {
+        }, {
             "_id": "61e23eac8d7ca568e6ca4ba5",
             "_tpl": "627bce33f21bc425b06ab967",
             "parentId": "dbb341b7b258fca356bd2fbb",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "7937ce310fb5bf8dba73590f",
             "_tpl": "55d4ae6c4bdc2d8b2f8b456e",
             "parentId": "dbb341b7b258fca356bd2fbb",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "ee6f4a9e0bd36eacbe2abd6f",
             "_tpl": "571659bb2459771fb2755a12",
             "parentId": "dbb341b7b258fca356bd2fbb",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "ed68b0ac5e0cc0ba3133f3b8",
             "_tpl": "5beed0f50db834001c062b12",
             "parentId": "hideout",
@@ -5503,74 +4753,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "92d3f4caba80a41f554fa4ea",
             "_tpl": "5beec1bd0db834001e6006f3",
             "parentId": "ed68b0ac5e0cc0ba3133f3b8",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "cfca7a0e251e9a2e047c02bf",
             "_tpl": "5beec3420db834001b095429",
             "parentId": "92d3f4caba80a41f554fa4ea",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "0f8adcd635b7485abbfadffa",
             "_tpl": "5beec3e30db8340019619424",
             "parentId": "ed68b0ac5e0cc0ba3133f3b8",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "d4d00afced88ab9f1241bbb6",
             "_tpl": "5beecbb80db834001d2c465e",
             "parentId": "0f8adcd635b7485abbfadffa",
             "slotId": "mod_mount_001"
-        },
-        {
+        }, {
             "_id": "abe1ef7aa8fcceac1fd5e0a4",
             "_tpl": "5beecbb80db834001d2c465e",
             "parentId": "0f8adcd635b7485abbfadffa",
             "slotId": "mod_mount_000"
-        },
-        {
+        }, {
             "_id": "bd7a2c5eaf8fb6a5116cacd8",
             "_tpl": "5beec8b20db834001961942a",
             "parentId": "ed68b0ac5e0cc0ba3133f3b8",
             "slotId": "mod_stock_001"
-        },
-        {
+        }, {
             "_id": "db72630ddf7bb8a10bca7af3",
             "_tpl": "5beec8c20db834001d2c465c",
             "parentId": "bd7a2c5eaf8fb6a5116cacd8",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "dc24d06e0ef9bceae96bc958",
             "_tpl": "5beec91a0db834001961942d",
             "parentId": "ed68b0ac5e0cc0ba3133f3b8",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "6b57ff77dbb4a882aabf31df",
             "_tpl": "5beec9450db83400970084fd",
             "parentId": "dc24d06e0ef9bceae96bc958",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "dc3344300b3ddd63a475fa97",
             "_tpl": "5bf3f59f0db834001a6fa060",
             "parentId": "6b57ff77dbb4a882aabf31df",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "4fd4ae121b33fd1e0d5bf18c",
             "_tpl": "5beec8ea0db834001a6f9dbf",
             "parentId": "ed68b0ac5e0cc0ba3133f3b8",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "d6f7b2ca4be1152dd1bb926c",
             "_tpl": "64637076203536ad5600c990",
             "parentId": "hideout",
@@ -5581,50 +4819,42 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "864733c1b262f82f9e95a7fe",
             "_tpl": "6492fb8253acae0af00a29b6",
             "parentId": "d6f7b2ca4be1152dd1bb926c",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "9706e4cdd06ab0618adef9bd",
             "_tpl": "6464d870bb2c580352070cc4",
             "parentId": "d6f7b2ca4be1152dd1bb926c",
             "slotId": "mod_bipod"
-        },
-        {
+        }, {
             "_id": "affabee2a69caf61aa0d342c",
             "_tpl": "646371a9f2404ab67905c8e6",
             "parentId": "d6f7b2ca4be1152dd1bb926c",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "dddd472a3cee34b02e24d2ed",
             "_tpl": "646372518610c40fc20204e8",
             "parentId": "d6f7b2ca4be1152dd1bb926c",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "df0c7ddbbfeceafc6a8eae47",
             "_tpl": "646371faf2404ab67905c8e9",
             "parentId": "d6f7b2ca4be1152dd1bb926c",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "9bf4ee7acf728dfc53617cb5",
             "_tpl": "6492efb8cfcf7c89e701abf3",
             "parentId": "df0c7ddbbfeceafc6a8eae47",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "f0abb8e9d33efbb8ffbeb772",
             "_tpl": "646371779f5f0ea59a04c204",
             "parentId": "d6f7b2ca4be1152dd1bb926c",
             "slotId": "mod_pistolgrip"
-        },
-        {
+        }, {
             "_id": "3ab5dccaebc37dc6fae577be",
             "_tpl": "64ca3d3954fc657e230529cc",
             "parentId": "hideout",
@@ -5635,44 +4865,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "5bc82748c1bdfe7ffaabf634",
             "_tpl": "6492fb8253acae0af00a29b6",
             "parentId": "3ab5dccaebc37dc6fae577be",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "4b9fcf63ffa3af179dff91a8",
             "_tpl": "6464d870bb2c580352070cc4",
             "parentId": "3ab5dccaebc37dc6fae577be",
             "slotId": "mod_bipod"
-        },
-        {
+        }, {
             "_id": "cdfc47bf9ec7a2c7f37d26ec",
             "_tpl": "6492e3a97df7d749100e29ee",
             "parentId": "3ab5dccaebc37dc6fae577be",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "7fb279d0dc21beccda2e8c23",
             "_tpl": "646372518610c40fc20204e8",
             "parentId": "3ab5dccaebc37dc6fae577be",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "7cc2c4aec1cdcacfb25afb21",
             "_tpl": "64639a9aab86f8fd4300146c",
             "parentId": "3ab5dccaebc37dc6fae577be",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "10ed5c1b8eae2ffa2ffd03b4",
             "_tpl": "64cbad529f7cf7f75c077fd5",
             "parentId": "3ab5dccaebc37dc6fae577be",
             "slotId": "mod_pistolgrip"
-        },
-        {
+        }, {
             "_id": "5f1baa301eec2977d2b0cb39",
             "_tpl": "6513ef33e06849f06c0957ca",
             "parentId": "hideout",
@@ -5683,56 +4906,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b372b6bb04b7c12b8e8d055f",
             "_tpl": "6513f153e63f29908d0ffaba",
             "parentId": "5f1baa301eec2977d2b0cb39",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "d97adef45dcbdeadaebfea6e",
             "_tpl": "6513f05a94c72326990a3866",
             "parentId": "5f1baa301eec2977d2b0cb39",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "319ff5428caffcc7e8b1a2de",
             "_tpl": "6513eff1e06849f06c0957d4",
             "parentId": "5f1baa301eec2977d2b0cb39",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "c3dfcb16e75bf55de7c28fef",
             "_tpl": "6513f0f5e63f29908d0ffab8",
             "parentId": "319ff5428caffcc7e8b1a2de",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "3eb8e5ee8ad5a27104bc5574",
             "_tpl": "6513f037e06849f06c0957d7",
             "parentId": "319ff5428caffcc7e8b1a2de",
             "slotId": "mod_bipod"
-        },
-        {
+        }, {
             "_id": "3f88f7a65fdfafd4f6bc7eec",
             "_tpl": "6513f1798cb24472490ee331",
             "parentId": "5f1baa301eec2977d2b0cb39",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "595e6af27587a0bbe0aa4e9c",
             "_tpl": "6513f13a8cb24472490ee32f",
             "parentId": "3f88f7a65fdfafd4f6bc7eec",
             "slotId": "mod_pistolgrip"
-        },
-        {
+        }, {
             "_id": "99bce1761f5486474e948e7e",
             "_tpl": "6513f0a194c72326990a3868",
             "parentId": "5f1baa301eec2977d2b0cb39",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "8dbb6bab779b4fdd61d8bb5b",
             "_tpl": "65268d8ecb944ff1e90ea385",
             "parentId": "hideout",
@@ -5743,56 +4957,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bb1ecddda3ec4e5ec0ac691a",
             "_tpl": "6513f153e63f29908d0ffaba",
             "parentId": "8dbb6bab779b4fdd61d8bb5b",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "d0d9d8e432bd4f69ba8dce02",
             "_tpl": "6513f05a94c72326990a3866",
             "parentId": "8dbb6bab779b4fdd61d8bb5b",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "a8cdaeffcd8f3f1fb29ff13b",
             "_tpl": "6513eff1e06849f06c0957d4",
             "parentId": "8dbb6bab779b4fdd61d8bb5b",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "9cfca323838e48dee324b9ae",
             "_tpl": "6513f0f5e63f29908d0ffab8",
             "parentId": "a8cdaeffcd8f3f1fb29ff13b",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "fdcbac8ef3507e7e1df9c3f6",
             "_tpl": "6513f037e06849f06c0957d7",
             "parentId": "a8cdaeffcd8f3f1fb29ff13b",
             "slotId": "mod_bipod"
-        },
-        {
+        }, {
             "_id": "6ec171d5878d4a1db09e5de2",
             "_tpl": "6513f1798cb24472490ee331",
             "parentId": "8dbb6bab779b4fdd61d8bb5b",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "ae9f30ffe52fabeefad91275",
             "_tpl": "6513f13a8cb24472490ee32f",
             "parentId": "6ec171d5878d4a1db09e5de2",
             "slotId": "mod_pistolgrip"
-        },
-        {
+        }, {
             "_id": "375af4c2384d7aaaa10f0554",
             "_tpl": "6513f0a194c72326990a3868",
             "parentId": "8dbb6bab779b4fdd61d8bb5b",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "b000b8ffd5b1dbde2e1ed6d3",
             "_tpl": "5e81ebcd8e146c7080625e15",
             "parentId": "hideout",
@@ -5803,14 +5008,12 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ed38b039d83a8c2c4de8c75a",
             "_tpl": "571659bb2459771fb2755a12",
             "parentId": "b000b8ffd5b1dbde2e1ed6d3",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "53b1055578a15514d03a03b7",
             "_tpl": "6275303a9f372d6ea97f9ec7",
             "parentId": "hideout",
@@ -5821,32 +5024,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ce99f8c787ea272c4bc3a664",
             "_tpl": "6284bd5f95250a29bc628a30",
             "parentId": "53b1055578a15514d03a03b7",
             "slotId": "mod_scope"
-        },
-        {
+        }, {
             "_id": "d0ddc9e3cc002af6249ebeee",
             "_tpl": "627bce33f21bc425b06ab967",
             "parentId": "53b1055578a15514d03a03b7",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "6acf77a73e8705fcdbeb0e15",
             "_tpl": "55d4ae6c4bdc2d8b2f8b456e",
             "parentId": "53b1055578a15514d03a03b7",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "e9c3da35a423be898ae23dac",
             "_tpl": "571659bb2459771fb2755a12",
             "parentId": "53b1055578a15514d03a03b7",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "654d5a9a9ac241d57dae9f42",
             "_tpl": "6357c98711fb55120211f7e1",
             "parentId": "hideout",
@@ -5857,8 +5055,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "34addfbc85983915bdbfe81c",
             "_tpl": "6357c98711fb55120211f7e1",
             "parentId": "hideout",
@@ -5869,8 +5066,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b332cbbb14b269ce47da8385",
             "_tpl": "62e7e7bbe6da9612f743f1e0",
             "parentId": "hideout",
@@ -5881,8 +5077,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fcbd64c5c9a5a04d6b7133b7",
             "_tpl": "62e7e7bbe6da9612f743f1e0",
             "parentId": "hideout",
@@ -5893,8 +5088,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c4fe6deebbf6b03a0fdcd0ae",
             "_tpl": "6513f0a194c72326990a3868",
             "parentId": "hideout",
@@ -5905,8 +5099,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7cfb1b2dde615b4919acde0e",
             "_tpl": "646372518610c40fc20204e8",
             "parentId": "hideout",
@@ -5917,8 +5110,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "eb2ebbffaa3c02d63decedc1",
             "_tpl": "5bed625c0db834001c062946",
             "parentId": "hideout",
@@ -5929,8 +5121,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d58df4c39db7eb63abcf330d",
             "_tpl": "544fb37f4bdc2dee738b4567",
             "parentId": "hideout",
@@ -5941,8 +5132,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "cb891bbafd04990faa96f5fa",
             "_tpl": "544fb37f4bdc2dee738b4567",
             "parentId": "hideout",

--- a/db/traders/6765fbd20fdc7eb79b00000a/assort.json
+++ b/db/traders/6765fbd20fdc7eb79b00000a/assort.json
@@ -1,1067 +1,1232 @@
 {
     "barter_scheme": {
         "296cd34e1df0ea5f7c78eda1": [
-            [{
+            [
+                {
                     "_tpl": "57347c93245977448d35f6e3",
                     "count": 1
                 }
             ]
         ],
         "b3f674dcd7994f90a068e5e1": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1400
                 }
             ]
         ],
         "fe478372be29ef2e6fea6c8e": [
-            [{
+            [
+                {
                     "_tpl": "5c13cd2486f774072c757944",
                     "count": 1
                 }
             ]
         ],
         "0c67b04a47b6ab56302fef17": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2750
                 }
             ]
         ],
         "236ae5cd9fac1b13c4b0a230": [
-            [{
+            [
+                {
                     "_tpl": "544fb37f4bdc2dee738b4567",
                     "count": 2
-                }, {
+                },
+                {
                     "_tpl": "5755356824597772cb798962",
                     "count": 2
                 }
             ]
         ],
         "e965c7ec4cae4adbdd47be35": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24000
                 }
             ]
         ],
         "18fb4faa79dfab8cf109b8bf": [
-            [{
+            [
+                {
                     "_tpl": "590c661e86f7741e566b646a",
                     "count": 2
-                }, {
+                },
+                {
                     "_tpl": "544fb3f34bdc2d03748b456a",
                     "count": 1
-                }, {
+                },
+                {
                     "_tpl": "5e831507ea0a7c419c2f9bd9",
                     "count": 2
                 }
             ]
         ],
         "ec046ceec0607178aafcc540": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 18000
                 }
             ]
         ],
         "ca43ddb7a2ff58ee0b73b5b6": [
-            [{
+            [
+                {
                     "_tpl": "5c052f6886f7746b1e3db148",
                     "count": 3
                 }
             ]
         ],
         "5dffcffcb8cbba35c04b9dea": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 380000
                 }
             ]
         ],
         "31beb3ddfdc9ddaebfabb0f9": [
-            [{
+            [
+                {
                     "_tpl": "590c5c9f86f77477c91c36e7",
                     "count": 2
                 }
             ]
         ],
         "d7bd663d561e682fa66d579e": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24000
                 }
             ]
         ],
         "e1d9ef8f6a27ed0bad99d282": [
-            [{
+            [
+                {
                     "_tpl": "544fb25a4bdc2dfb738b4567",
                     "count": 1
-                }, {
+                },
+                {
                     "_tpl": "5c13cd2486f774072c757944",
                     "count": 1
                 }
             ]
         ],
         "9d8ec61fcbc51ec43f4d406f": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1950
                 }
             ]
         ],
         "edaa85667ccaa7d314460fa8": [
-            [{
+            [
+                {
                     "_tpl": "5af0548586f7743a532b7e99",
                     "count": 2
-                }, {
+                },
+                {
                     "_tpl": "5755383e24597772cb798966",
                     "count": 2
-                }, {
+                },
+                {
                     "_tpl": "590c695186f7741e566b64a2",
                     "count": 2
                 }
             ]
         ],
         "432016db2ae30eea29d0926d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24300
                 }
             ]
         ],
         "6caeda234b7dad5b3d5a1c5d": [
-            [{
+            [
+                {
                     "_tpl": "5d1b3f2d86f774253763b735",
                     "count": 2
                 }
             ]
         ],
         "664ccbdb08411483d983ff3d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 4900
                 }
             ]
         ],
         "97af3a0012e7150115892e74": [
-            [{
+            [
+                {
                     "_tpl": "590c695186f7741e566b64a2",
                     "count": 2
-                }, {
+                },
+                {
                     "_tpl": "544fb3f34bdc2d03748b456a",
                     "count": 1
                 }
             ]
         ],
         "d64ea3eb1ff99bff4b8dd7c5": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 14000
                 }
             ]
         ],
         "3d0cb29b9bee9a3ad426a2b2": [
-            [{
+            [
+                {
                     "_tpl": "5d02778e86f774203e7dedbe",
                     "count": 1
-                }, {
+                },
+                {
                     "_tpl": "590c678286f77426c9660122",
                     "count": 1
                 }
             ]
         ],
         "b50d2dbfd9fd7280dae6b23c": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 33000
                 }
             ]
         ],
         "ab95e89890d374edf6d804fd": [
-            [{
+            [
+                {
                     "_tpl": "544fb25a4bdc2dfb738b4567",
                     "count": 1
-                }, {
+                },
+                {
                     "_tpl": "5755356824597772cb798962",
                     "count": 2
-                }, {
+                },
+                {
                     "_tpl": "544fb37f4bdc2dee738b4567",
                     "count": 1
                 }
             ]
         ],
         "bde835c87ddeb15baa6a2667": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 9000
                 }
             ]
         ],
         "1d6cedd407aded383cd3f1d0": [
-            [{
+            [
+                {
                     "_tpl": "590c661e86f7741e566b646a",
                     "count": 2
-                }, {
+                },
+                {
                     "_tpl": "544fb3f34bdc2d03748b456a",
                     "count": 1
                 }
             ]
         ],
         "963fe9c5ef3b5fbbecfac0ae": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 22500
                 }
             ]
         ],
         "f6fd5f1b37c5fac4b77b5c8e": [
-            [{
+            [
+                {
                     "_tpl": "544fb3f34bdc2d03748b456a",
                     "count": 1
-                }, {
+                },
+                {
                     "_tpl": "544fb37f4bdc2dee738b4567",
                     "count": 4
                 }
             ]
         ],
         "0b6b65ec76753edaccf2da71": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 13000
                 }
             ]
         ],
         "07de2dd8f7af7ea3ca49dea6": [
-            [{
+            [
+                {
                     "_tpl": "57e26fc7245977162a14b800",
                     "count": 4
                 }
             ]
         ],
         "9eecaffa0cb6ddbccddb47fd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 20000
                 }
             ]
         ],
         "bf08bee90ce2d85bdbbd7591": [
-            [{
+            [
+                {
                     "_tpl": "5d1b392c86f77425243e98fe",
                     "count": 5
                 }
             ]
         ],
         "cc36008c3a9e5e48aaf90e46": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 32000
                 }
             ]
         ],
         "e6128dcefb016c69c572b79f": [
-            [{
+            [
+                {
                     "_tpl": "590c621186f774138d11ea29",
                     "count": 4
                 }
             ]
         ],
         "26de8c2b1dd68b5cedcd781a": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 138000
                 }
             ]
         ],
         "fc7ef60ac378aa2ee2fe4ce1": [
-            [{
+            [
+                {
                     "_tpl": "544fb3364bdc2d34748b456a",
                     "count": 2
-                }, {
+                },
+                {
                     "_tpl": "5751a25924597722c463c472",
                     "count": 2
-                }, {
+                },
+                {
                     "_tpl": "544fb37f4bdc2dee738b4567",
                     "count": 2
                 }
             ]
         ],
         "e63cba7f17cba8bec5d0df6a": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 8000
                 }
             ]
         ],
         "dc7bb11a67b4bebccedccaca": [
-            [{
+            [
+                {
                     "_tpl": "5755383e24597772cb798966",
                     "count": 3
-                }, {
+                },
+                {
                     "_tpl": "544fb37f4bdc2dee738b4567",
                     "count": 2
                 }
             ]
         ],
         "c1daddee7aead2ece4b7e2ca": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24000
                 }
             ]
         ],
         "c82ba4f25cd0586effdcbbf8": [
-            [{
+            [
+                {
                     "_tpl": "5d0377ce86f774186372f689",
                     "count": 3
                 }
             ]
         ],
         "462cefd5ddae8f6bab381b6e": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 185000
                 }
             ]
         ],
         "8ca7ba8c24bdfc361baacede": [
-            [{
+            [
+                {
                     "_tpl": "5d0375ff86f774186372f685",
                     "count": 5
                 }
             ]
         ],
         "b8ebacd89ab4fb24c4398dfd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 172000
                 }
             ]
         ],
         "fe4dddeecbba6d79cfdbabf7": [
-            [{
+            [
+                {
                     "_tpl": "590c392f86f77444754deb29",
                     "count": 3
                 }
             ]
         ],
         "81dcbbdcb9a6ef6752fe0fbb": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 152000
                 }
             ]
         ],
         "d11cfa4b99c1cfa92ccef995": [
-            [{
+            [
+                {
                     "_tpl": "5d1b309586f77425227d1676",
                     "count": 4
                 }
             ]
         ],
         "ba4b5efd1ab3e2bf0a547f51": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 43000
                 }
             ]
         ],
         "cab6fe7beb5c6efc23e8c34c": [
-            [{
+            [
+                {
                     "_tpl": "590a3d9c86f774385926e510",
                     "count": 5
                 }
             ]
         ],
         "bac2f080b35e85006ea3d7fd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 54000
                 }
             ]
         ],
         "933c0dfc0bab0c90210fc51e": [
-            [{
+            [
+                {
                     "_tpl": "5c052e6986f7746b207bc3c9",
                     "count": 2
                 }
             ]
         ],
         "2c6c79dfc30c4b8c56b1d1d8": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 256500
                 }
             ]
         ],
         "02adbe49c3da3ff3dedfbca2": [
-            [{
+            [
+                {
                     "_tpl": "590a373286f774287540368b",
                     "count": 3
                 }
             ]
         ],
         "e74bd4c8e8aad54ff7edf993": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 57000
                 }
             ]
         ],
         "fe44ffb6bf2550b2253286ee": [
-            [{
+            [
+                {
                     "_tpl": "590a3c0a86f774385a33c450",
                     "count": 5
                 }
             ]
         ],
         "fbfecbe8e8eff4585ad5be8f": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 36000
                 }
             ]
         ],
         "401d47ba10d19c030dd6c7eb": [
-            [{
+            [
+                {
                     "_tpl": "5d1b2ffd86f77425243e8d17",
                     "count": 3
                 }
             ]
         ],
         "4064dfe7bdfb2dcbb588ebef": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 36000
                 }
             ]
         ],
         "65ba7f61c561d8d4dca8287a": [
-            [{
+            [
+                {
                     "_tpl": "5c05300686f7746dce784e5d",
                     "count": 2
                 }
             ]
         ],
         "cddf2eedaaee1ed855325aa6": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 270000
                 }
             ]
         ],
         "255e685a05fe46fd6b46af5a": [
-            [{
+            [
+                {
                     "_tpl": "5c12613b86f7743bbe2c3f76",
                     "count": 3
                 }
             ]
         ],
         "df1baddd98542ee14eefefde": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 105000
                 }
             ]
         ],
         "eacba9139ba71c848ba0a4fa": [
-            [{
+            [
+                {
                     "_tpl": "5d403f9186f7743cac3f229b",
                     "count": 4
                 }
             ]
         ],
         "fac9bb2ff1bdd55c5d09f9ae": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 180000
                 }
             ]
         ],
         "aabde64d37dfb52e19841177": [
-            [{
+            [
+                {
                     "_tpl": "59faff1d86f7746c51718c9c",
                     "count": 1
                 }
             ]
         ],
         "b99f84c0c89cc0a0a71af70a": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 235000
                 }
             ]
         ],
         "c4cab056ec93fe0f1106c6dd": [
-            [{
+            [
+                {
                     "_tpl": "5751a25924597722c463c472",
                     "count": 1
-                }, {
+                },
+                {
                     "_tpl": "590c661e86f7741e566b646a",
                     "count": 2
-                }, {
+                },
+                {
                     "_tpl": "5e831507ea0a7c419c2f9bd9",
                     "count": 1
-                }, {
+                },
+                {
                     "_tpl": "5b4335ba86f7744d2837a264",
                     "count": 1
                 }
             ]
         ],
         "4c4d5d5c1126affe5ac8988b": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 34000
                 }
             ]
         ],
         "ba9aa88df8f0d8ea9b3f5ed3": [
-            [{
+            [
+                {
                     "_tpl": "5d02778e86f774203e7dedbe",
                     "count": 2
                 }
             ]
         ],
         "19cffd9e3ef6dbc9df27ebcb": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 69000
                 }
             ]
         ],
         "d46cef7809dbab9d538eafe5": [
-            [{
+            [
+                {
                     "_tpl": "56742c2e4bdc2d95058b456d",
                     "count": 3
                 }
             ]
         ],
         "35b94ceab1afe0fefec81fef": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 17000
                 }
             ]
         ],
         "64fbabbcca7e3bacb54d0ca5": [
-            [{
+            [
+                {
                     "_tpl": "57347ca924597744596b4e71",
                     "count": 2
                 }
             ]
         ],
         "1b29b4cdaeab7e690c4d3f5b": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 335000
                 }
             ]
         ],
         "1ebbadac895befe6b0de8aba": [
-            [{
+            [
+                {
                     "_tpl": "577e1c9d2459773cd707c525",
                     "count": 1
                 }
             ]
         ],
         "8cb5decc6f5dca9af262ed95": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1800
                 }
             ]
         ],
         "6fcdfa6e5e380f594ffeb4ce": [
-            [{
+            [
+                {
                     "_tpl": "5e831507ea0a7c419c2f9bd9",
                     "count": 1
-                }, {
+                },
+                {
                     "_tpl": "544fb37f4bdc2dee738b4567",
                     "count": 1
-                }, {
+                },
+                {
                     "_tpl": "5755356824597772cb798962",
                     "count": 3
                 }
             ]
         ],
         "acd2dfc926c090fe46b6eadd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5400
                 }
             ]
         ],
         "f8f0addd93bf96dc3fa8baa8": [
-            [{
+            [
+                {
                     "_tpl": "5d0376a486f7747d8050965c",
                     "count": 5
                 }
             ]
         ],
         "dda4fa330f096da94e9d81c3": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 148000
                 }
             ]
         ],
         "c6fe4ce275de1bf2eec3bc00": [
-            [{
+            [
+                {
                     "_tpl": "5f745ee30acaeb0d490d8c5b",
                     "count": 3
                 }
             ]
         ],
         "b9e2213c9da4adb80f18edee": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 126000
                 }
             ]
         ],
         "ea92d8455606338f534fbe2b": [
-            [{
+            [
+                {
                     "_tpl": "59e3639286f7741777737013",
                     "count": 2
                 }
             ]
         ],
         "b300dea5d6b91e0c9fdcdcfa": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 300000
                 }
             ]
         ],
         "8488c3505d05ab8c0e2dca7c": [
-            [{
+            [
+                {
                     "_tpl": "590c661e86f7741e566b646a",
                     "count": 2
-                }, {
+                },
+                {
                     "_tpl": "544fb37f4bdc2dee738b4567",
                     "count": 2
-                }, {
+                },
+                {
                     "_tpl": "5755356824597772cb798962",
                     "count": 3
                 }
             ]
         ],
         "4879f30eb43ccc1faecd0559": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 39300
                 }
             ]
         ],
         "60acc13a1d3e277eab7defbc": [
-            [{
+            [
+                {
                     "_tpl": "5e831507ea0a7c419c2f9bd9",
                     "count": 2
                 }
             ]
         ],
         "1abaf5adec1d2848cc09daec": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3000
                 }
             ]
         ],
         "013b74e2e962eb5b342cacb6": [
-            [{
+            [
+                {
                     "_tpl": "60391a8b3364dc22b04d0ce5",
                     "count": 3
                 }
             ]
         ],
         "cb5b71abe2b3433cb9c8cd13": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 58000
                 }
             ]
         ],
         "a21ba7c59fac6611daa459ee": [
-            [{
+            [
+                {
                     "_tpl": "59faff1d86f7746c51718c9c",
                     "count": 3
                 }
             ]
         ],
         "f863fc6d0eacccc5ad5535a7": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 369000
                 }
             ]
         ],
         "1cb2484a08e5db3b5e37af41": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "154867c34e24b23072b2dee0": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 52000
                 }
             ]
         ],
         "c4882a61d8b2be239c13b494": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "786036fd29bfaf00bec5c5b0": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 40000
                 }
             ]
         ],
         "4b9d28e454a4ff3aa33dcefb": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "b7fcc99b5cf753b5b6d400d8": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 40000
                 }
             ]
         ],
         "b12dd7656cc4faeb35a31e09": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "1d012074183a599d7c149ebb": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 150000
                 }
             ]
         ],
         "3b7fc4abf4ff9f74f620bec3": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "a029bbfb9b058bc8f25be586": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60000
                 }
             ]
         ],
         "51e9afbdfa34bc6bb1cc99f1": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 6000
                 }
             ]
         ],
         "af0fa3c7caa391e4f1f8b2fe": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 4500
                 }
             ]
         ],
         "f7e74aada5a556a9efcc70dd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 6000
                 }
             ]
         ],
         "d5ea7d470070ebca5a3caed9": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5000
                 }
             ]
         ],
         "ef68ad9bedb14eb19acebf53": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 4200
                 }
             ]
         ],
         "1b3d8cf6ebae7d9f4d2fafb3": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 6900
                 }
             ]
         ],
         "371fc0d3c86cba2c6df4abe9": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3600
                 }
             ]
         ],
         "965ef27a553a8dca26a27e2b": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2700
                 }
             ]
         ],
         "e9bfe4e91a92dade9ae3a1b1": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 20000
                 }
             ]
         ],
         "cfcd0a82f66efd3ae7c186fa": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 20000
                 }
             ]
         ],
         "42012fa6ebfe98bd4c68f59b": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 6600
                 }
             ]
         ],
         "6aafbeb9d48cd79ed4a5157b": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 7000
                 }
             ]
         ],
         "2d3ddc9a8fad6f28f6d586af": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 8000
                 }
             ]
         ],
         "2bc5e8b73c0a14ffd4bcdfa5": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5000
                 }
             ]
         ],
         "2911812d0dfde86e08d8a18a": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 8000
                 }
             ]
         ],
         "cc2a0f5dae0bd5cfc5d49fbf": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1800
                 }
             ]
         ],
         "da3a35d7ad7a4c4a0c7aec83": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5000
                 }
             ]
         ],
         "a22bd6adfbfc9e8b80a5a5ae": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 6000
                 }
             ]
         ],
         "3c93ad820a8e6f71b3a8b7dd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3000
                 }
             ]
         ],
         "b332cbbb14b269ce47da8385": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "fcbd64c5c9a5a04d6b7133b7": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 48000
                 }
             ]
         ],
         "654d5a9a9ac241d57dae9f42": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "34addfbc85983915bdbfe81c": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 58000
                 }
             ]
         ],
         "58ccadceea47bbf0ea9b9f10": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "5f1baa301eec2977d2b0cb39": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 56000
                 }
             ]
         ],
         "9ec426bc5e7602c678b9ddba": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "8dbb6bab779b4fdd61d8bb5b": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 58000
                 }
             ]
         ],
         "a2ce4ec5eabbd4fec171608a": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "ed68b0ac5e0cc0ba3133f3b8": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 54000
                 }
             ]
         ],
         "eeede87b52ac49e9fdf9d468": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "d6f7b2ca4be1152dd1bb926c": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 96000
                 }
             ]
         ],
         "cb9f4f04ef7beaded110f66b": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "3ab5dccaebc37dc6fae577be": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 120000
                 }
             ]
         ],
         "c0decbecaf6fce0fbdd427db": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "b000b8ffd5b1dbde2e1ed6d3": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 94000
                 }
             ]
         ],
         "dbb341b7b258fca356bd2fbb": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "53b1055578a15514d03a03b7": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 215000
                 }
             ]
         ],
         "c4fe6deebbf6b03a0fdcd0ae": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 20000
                 }
             ]
         ],
         "7cfb1b2dde615b4919acde0e": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 14500
                 }
             ]
         ],
         "eb2ebbffaa3c02d63decedc1": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 33000
                 }
             ]
         ],
         "cb891bbafd04990faa96f5fa": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "d58df4c39db7eb63abcf330d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5500
                 }
             ]
         ]
     },
-    "items": [{
+    "items": [
+        {
             "_id": "1ebbadac895befe6b0de8aba",
             "_tpl": "5e831507ea0a7c419c2f9bd9",
             "parentId": "hideout",
@@ -1072,7 +1237,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "296cd34e1df0ea5f7c78eda1",
             "_tpl": "544fb25a4bdc2dfb738b4567",
             "parentId": "hideout",
@@ -1083,7 +1249,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fe478372be29ef2e6fea6c8e",
             "_tpl": "544fb3364bdc2d34748b456a",
             "parentId": "hideout",
@@ -1094,7 +1261,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "6caeda234b7dad5b3d5a1c5d",
             "_tpl": "5755356824597772cb798962",
             "parentId": "hideout",
@@ -1105,7 +1273,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "60acc13a1d3e277eab7defbc",
             "_tpl": "60098af40accd37ef2175f27",
             "parentId": "hideout",
@@ -1116,7 +1285,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ab95e89890d374edf6d804fd",
             "_tpl": "590c661e86f7741e566b646a",
             "parentId": "hideout",
@@ -1127,7 +1297,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e1d9ef8f6a27ed0bad99d282",
             "_tpl": "5751a25924597722c463c472",
             "parentId": "hideout",
@@ -1138,7 +1309,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "236ae5cd9fac1b13c4b0a230",
             "_tpl": "544fb3f34bdc2d03748b456a",
             "parentId": "hideout",
@@ -1149,7 +1321,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "6fcdfa6e5e380f594ffeb4ce",
             "_tpl": "5e8488fa988a8701445df1e4",
             "parentId": "hideout",
@@ -1160,7 +1333,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fc7ef60ac378aa2ee2fe4ce1",
             "_tpl": "5af0454c86f7746bf20992e8",
             "parentId": "hideout",
@@ -1171,7 +1345,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f6fd5f1b37c5fac4b77b5c8e",
             "_tpl": "590c695186f7741e566b64a2",
             "parentId": "hideout",
@@ -1182,7 +1357,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "18fb4faa79dfab8cf109b8bf",
             "_tpl": "544fb45d4bdc2dee738b4568",
             "parentId": "hideout",
@@ -1193,7 +1369,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c4cab056ec93fe0f1106c6dd",
             "_tpl": "5d02778e86f774203e7dedbe",
             "parentId": "hideout",
@@ -1204,7 +1381,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "1d6cedd407aded383cd3f1d0",
             "_tpl": "590c678286f77426c9660122",
             "parentId": "hideout",
@@ -1215,7 +1393,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "97af3a0012e7150115892e74",
             "_tpl": "5755383e24597772cb798966",
             "parentId": "hideout",
@@ -1226,7 +1405,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "8488c3505d05ab8c0e2dca7c",
             "_tpl": "60098ad7c2240c0fe85c570a",
             "parentId": "hideout",
@@ -1237,7 +1417,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "dc7bb11a67b4bebccedccaca",
             "_tpl": "5af0548586f7743a532b7e99",
             "parentId": "hideout",
@@ -1248,7 +1429,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "3d0cb29b9bee9a3ad426a2b2",
             "_tpl": "590c657e86f77412b013051d",
             "parentId": "hideout",
@@ -1259,7 +1441,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ba9aa88df8f0d8ea9b3f5ed3",
             "_tpl": "5d02797c86f774203f38e30a",
             "parentId": "hideout",
@@ -1270,7 +1453,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "edaa85667ccaa7d314460fa8",
             "_tpl": "5751a89d24597722aa0e8db0",
             "parentId": "hideout",
@@ -1281,7 +1465,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "8cb5decc6f5dca9af262ed95",
             "_tpl": "5e831507ea0a7c419c2f9bd9",
             "parentId": "hideout",
@@ -1292,7 +1477,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b3f674dcd7994f90a068e5e1",
             "_tpl": "544fb25a4bdc2dfb738b4567",
             "parentId": "hideout",
@@ -1303,7 +1489,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "0c67b04a47b6ab56302fef17",
             "_tpl": "544fb3364bdc2d34748b456a",
             "parentId": "hideout",
@@ -1314,7 +1501,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "664ccbdb08411483d983ff3d",
             "_tpl": "5755356824597772cb798962",
             "parentId": "hideout",
@@ -1325,7 +1513,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "1abaf5adec1d2848cc09daec",
             "_tpl": "60098af40accd37ef2175f27",
             "parentId": "hideout",
@@ -1336,7 +1525,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bde835c87ddeb15baa6a2667",
             "_tpl": "590c661e86f7741e566b646a",
             "parentId": "hideout",
@@ -1347,7 +1537,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "9d8ec61fcbc51ec43f4d406f",
             "_tpl": "5751a25924597722c463c472",
             "parentId": "hideout",
@@ -1358,7 +1549,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e965c7ec4cae4adbdd47be35",
             "_tpl": "544fb3f34bdc2d03748b456a",
             "parentId": "hideout",
@@ -1369,7 +1561,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "acd2dfc926c090fe46b6eadd",
             "_tpl": "5e8488fa988a8701445df1e4",
             "parentId": "hideout",
@@ -1380,7 +1573,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e63cba7f17cba8bec5d0df6a",
             "_tpl": "5af0454c86f7746bf20992e8",
             "parentId": "hideout",
@@ -1391,7 +1585,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "0b6b65ec76753edaccf2da71",
             "_tpl": "590c695186f7741e566b64a2",
             "parentId": "hideout",
@@ -1402,7 +1597,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ec046ceec0607178aafcc540",
             "_tpl": "544fb45d4bdc2dee738b4568",
             "parentId": "hideout",
@@ -1413,7 +1609,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "4c4d5d5c1126affe5ac8988b",
             "_tpl": "5d02778e86f774203e7dedbe",
             "parentId": "hideout",
@@ -1424,7 +1621,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "963fe9c5ef3b5fbbecfac0ae",
             "_tpl": "590c678286f77426c9660122",
             "parentId": "hideout",
@@ -1435,7 +1633,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d64ea3eb1ff99bff4b8dd7c5",
             "_tpl": "5755383e24597772cb798966",
             "parentId": "hideout",
@@ -1446,7 +1645,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "4879f30eb43ccc1faecd0559",
             "_tpl": "60098ad7c2240c0fe85c570a",
             "parentId": "hideout",
@@ -1457,7 +1657,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c1daddee7aead2ece4b7e2ca",
             "_tpl": "5af0548586f7743a532b7e99",
             "parentId": "hideout",
@@ -1468,7 +1669,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b50d2dbfd9fd7280dae6b23c",
             "_tpl": "590c657e86f77412b013051d",
             "parentId": "hideout",
@@ -1479,7 +1681,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "19cffd9e3ef6dbc9df27ebcb",
             "_tpl": "5d02797c86f774203f38e30a",
             "parentId": "hideout",
@@ -1490,7 +1693,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "432016db2ae30eea29d0926d",
             "_tpl": "5751a89d24597722aa0e8db0",
             "parentId": "hideout",
@@ -1501,7 +1705,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "07de2dd8f7af7ea3ca49dea6",
             "_tpl": "59e7635f86f7742cbf2c1095",
             "parentId": "hideout",
@@ -1512,27 +1717,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065ef7",
             "_tpl": "65702f87722744627e05cdb8",
             "parentId": "07de2dd8f7af7ea3ca49dea6",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065ef8",
             "_tpl": "65702fe593b7ea9c330f4ce8",
             "parentId": "07de2dd8f7af7ea3ca49dea6",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065ef9",
             "_tpl": "6570305d93b7ea9c330f4ced",
             "parentId": "07de2dd8f7af7ea3ca49dea6",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065efa",
             "_tpl": "65703472c9030b928a0a8a78",
             "parentId": "07de2dd8f7af7ea3ca49dea6",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "d46cef7809dbab9d538eafe5",
             "_tpl": "5df8a2ca86f7740bfe6df777",
             "parentId": "hideout",
@@ -1543,17 +1753,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065efb",
             "_tpl": "656fd7c32668ef0402028fb9",
             "parentId": "d46cef7809dbab9d538eafe5",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065efc",
             "_tpl": "656fd89bf5a9631d4e042575",
             "parentId": "d46cef7809dbab9d538eafe5",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "31beb3ddfdc9ddaebfabb0f9",
             "_tpl": "5648a7494bdc2d9d488b4583",
             "parentId": "hideout",
@@ -1564,27 +1777,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065efd",
             "_tpl": "65703d866584602f7d057a8a",
             "parentId": "31beb3ddfdc9ddaebfabb0f9",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065efe",
             "_tpl": "65703fa06584602f7d057a8e",
             "parentId": "31beb3ddfdc9ddaebfabb0f9",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065eff",
             "_tpl": "65703fe46a912c8b5c03468b",
             "parentId": "31beb3ddfdc9ddaebfabb0f9",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f00",
             "_tpl": "657040374e67e8ec7a0d261c",
             "parentId": "31beb3ddfdc9ddaebfabb0f9",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "d11cfa4b99c1cfa92ccef995",
             "_tpl": "5b44d22286f774172b0c9de8",
             "parentId": "hideout",
@@ -1595,42 +1813,50 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f01",
             "_tpl": "65704de13e7bba58ea0285c8",
             "parentId": "d11cfa4b99c1cfa92ccef995",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f02",
             "_tpl": "65705c3c14f2ed6d7d0b7738",
             "parentId": "d11cfa4b99c1cfa92ccef995",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f03",
             "_tpl": "65705c777260e1139e091408",
             "parentId": "d11cfa4b99c1cfa92ccef995",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f04",
             "_tpl": "65705cb314f2ed6d7d0b773c",
             "parentId": "d11cfa4b99c1cfa92ccef995",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f05",
             "_tpl": "65705cea4916448ae1050897",
             "parentId": "d11cfa4b99c1cfa92ccef995",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f06",
             "_tpl": "656f9d5900d62bcd2e02407c",
             "parentId": "d11cfa4b99c1cfa92ccef995",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f07",
             "_tpl": "656f9d5900d62bcd2e02407c",
             "parentId": "d11cfa4b99c1cfa92ccef995",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "bf08bee90ce2d85bdbbd7591",
             "_tpl": "5ab8e4ed86f7742d8e50c7fa",
             "parentId": "hideout",
@@ -1641,27 +1867,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f08",
             "_tpl": "657044e971369562b300ce9b",
             "parentId": "bf08bee90ce2d85bdbbd7591",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f09",
             "_tpl": "657045741bd9beedc40b7299",
             "parentId": "bf08bee90ce2d85bdbbd7591",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f0a",
             "_tpl": "657045b97e80617cee095bda",
             "parentId": "bf08bee90ce2d85bdbbd7591",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f0b",
             "_tpl": "6570460471369562b300ce9f",
             "parentId": "bf08bee90ce2d85bdbbd7591",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "401d47ba10d19c030dd6c7eb",
             "_tpl": "5c0e5edb86f77461f55ed1f7",
             "parentId": "hideout",
@@ -1672,42 +1903,50 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f0c",
             "_tpl": "6571dbd388ead79fcf091d71",
             "parentId": "401d47ba10d19c030dd6c7eb",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f0d",
             "_tpl": "6571dbda88ead79fcf091d75",
             "parentId": "401d47ba10d19c030dd6c7eb",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f0e",
             "_tpl": "6571dbe07c02ae206002502e",
             "parentId": "401d47ba10d19c030dd6c7eb",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f0f",
             "_tpl": "6571dbeaee8ec43d520cf89e",
             "parentId": "401d47ba10d19c030dd6c7eb",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f10",
             "_tpl": "6571dbef88ead79fcf091d79",
             "parentId": "401d47ba10d19c030dd6c7eb",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f11",
             "_tpl": "656f57dc27aed95beb08f628",
             "parentId": "401d47ba10d19c030dd6c7eb",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f12",
             "_tpl": "656fac30c6baea13cd07e10c",
             "parentId": "401d47ba10d19c030dd6c7eb",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "fe44ffb6bf2550b2253286ee",
             "_tpl": "5c0e5bab86f77461f55ed1f3",
             "parentId": "hideout",
@@ -1718,47 +1957,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f13",
             "_tpl": "6571b27a6d84a2b8b6007f92",
             "parentId": "fe44ffb6bf2550b2253286ee",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f14",
             "_tpl": "6571baa74cb80d995d0a1490",
             "parentId": "fe44ffb6bf2550b2253286ee",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f15",
             "_tpl": "6571baac6d84a2b8b6007fa3",
             "parentId": "fe44ffb6bf2550b2253286ee",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f16",
             "_tpl": "6571bab0f41985531a038091",
             "parentId": "fe44ffb6bf2550b2253286ee",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f17",
             "_tpl": "6571babb4076795e5e07383f",
             "parentId": "fe44ffb6bf2550b2253286ee",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f18",
             "_tpl": "6571bac34076795e5e073843",
             "parentId": "fe44ffb6bf2550b2253286ee",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f19",
             "_tpl": "6571babf4cb80d995d0a1494",
             "parentId": "fe44ffb6bf2550b2253286ee",
             "slotId": "Groin_back"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f1a",
             "_tpl": "654a4dea7c17dec2f50cc86a",
             "parentId": "fe44ffb6bf2550b2253286ee",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "013b74e2e962eb5b342cacb6",
             "_tpl": "609e8540d5c319764c2bc2e9",
             "parentId": "hideout",
@@ -1769,37 +2017,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f1b",
             "_tpl": "6572e5221b5bc1185508c24f",
             "parentId": "013b74e2e962eb5b342cacb6",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f1c",
             "_tpl": "6572e52f73c0eabb700109a0",
             "parentId": "013b74e2e962eb5b342cacb6",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f1d",
             "_tpl": "6572e53c73c0eabb700109a4",
             "parentId": "013b74e2e962eb5b342cacb6",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f1e",
             "_tpl": "6572e54873c0eabb700109a8",
             "parentId": "013b74e2e962eb5b342cacb6",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f1f",
             "_tpl": "656f9fa0498d1b7e3e071d98",
             "parentId": "013b74e2e962eb5b342cacb6",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f20",
             "_tpl": "656f9fa0498d1b7e3e071d98",
             "parentId": "013b74e2e962eb5b342cacb6",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "cab6fe7beb5c6efc23e8c34c",
             "_tpl": "5c0e53c886f7747fa54205c7",
             "parentId": "hideout",
@@ -1810,47 +2065,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f21",
             "_tpl": "654a8b0b0337d53f9102c2ae",
             "parentId": "cab6fe7beb5c6efc23e8c34c",
             "slotId": "soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f22",
             "_tpl": "654a8976f414fcea4004d78b",
             "parentId": "cab6fe7beb5c6efc23e8c34c",
             "slotId": "soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f23",
             "_tpl": "654a8b3df414fcea4004d78f",
             "parentId": "cab6fe7beb5c6efc23e8c34c",
             "slotId": "soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f24",
             "_tpl": "654a8b80f414fcea4004d797",
             "parentId": "cab6fe7beb5c6efc23e8c34c",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f25",
             "_tpl": "654a8ae00337d53f9102c2aa",
             "parentId": "cab6fe7beb5c6efc23e8c34c",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f26",
             "_tpl": "654a8bc5f414fcea4004d79b",
             "parentId": "cab6fe7beb5c6efc23e8c34c",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f27",
             "_tpl": "656f603f94b480b8a500c0d6",
             "parentId": "cab6fe7beb5c6efc23e8c34c",
             "slotId": "front_plate"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f28",
             "_tpl": "656efd66034e8e01c407f35c",
             "parentId": "cab6fe7beb5c6efc23e8c34c",
             "slotId": "back_plate"
-        }, {
+        },
+        {
             "_id": "02adbe49c3da3ff3dedfbca2",
             "_tpl": "5c0e57ba86f7747fa141986d",
             "parentId": "hideout",
@@ -1861,52 +2125,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f29",
             "_tpl": "65707fc348c7a887f2010432",
             "parentId": "02adbe49c3da3ff3dedfbca2",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f2a",
             "_tpl": "6570800612755ae0d907acf8",
             "parentId": "02adbe49c3da3ff3dedfbca2",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f2b",
             "_tpl": "65708070f65e2491bf00972c",
             "parentId": "02adbe49c3da3ff3dedfbca2",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f2c",
             "_tpl": "657080a212755ae0d907ad04",
             "parentId": "02adbe49c3da3ff3dedfbca2",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f2d",
             "_tpl": "657080ca12755ae0d907ad5e",
             "parentId": "02adbe49c3da3ff3dedfbca2",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f2e",
             "_tpl": "65708122f65e2491bf009755",
             "parentId": "02adbe49c3da3ff3dedfbca2",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f2f",
             "_tpl": "65708165696fe382cf073255",
             "parentId": "02adbe49c3da3ff3dedfbca2",
             "slotId": "Groin_back"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f30",
             "_tpl": "656f603f94b480b8a500c0d6",
             "parentId": "02adbe49c3da3ff3dedfbca2",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f31",
             "_tpl": "657b22485f444d6dff0c6c2f",
             "parentId": "02adbe49c3da3ff3dedfbca2",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "255e685a05fe46fd6b46af5a",
             "_tpl": "5c0e655586f774045612eeb2",
             "parentId": "hideout",
@@ -1917,27 +2191,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f32",
             "_tpl": "6570e025615f54368b04fcb0",
             "parentId": "255e685a05fe46fd6b46af5a",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f33",
             "_tpl": "6570e0610b57c03ec90b96ef",
             "parentId": "255e685a05fe46fd6b46af5a",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f34",
             "_tpl": "656fad8c498d1b7e3e071da0",
             "parentId": "255e685a05fe46fd6b46af5a",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f35",
             "_tpl": "656fad8c498d1b7e3e071da0",
             "parentId": "255e685a05fe46fd6b46af5a",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "e6128dcefb016c69c572b79f",
             "_tpl": "5ab8e79e86f7742d8b372e78",
             "parentId": "hideout",
@@ -1948,42 +2227,50 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f36",
             "_tpl": "65732688d9d89ff7ac0d9c4c",
             "parentId": "e6128dcefb016c69c572b79f",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f37",
             "_tpl": "657326978c1cc6dcd9098b56",
             "parentId": "e6128dcefb016c69c572b79f",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f38",
             "_tpl": "657326a28c1cc6dcd9098b5a",
             "parentId": "e6128dcefb016c69c572b79f",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f39",
             "_tpl": "657326b08c1cc6dcd9098b5e",
             "parentId": "e6128dcefb016c69c572b79f",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f3a",
             "_tpl": "657326bc5d3a3129fb05f36b",
             "parentId": "e6128dcefb016c69c572b79f",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f3b",
             "_tpl": "656f611f94b480b8a500c0db",
             "parentId": "e6128dcefb016c69c572b79f",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f3c",
             "_tpl": "65573fa5655447403702a816",
             "parentId": "e6128dcefb016c69c572b79f",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "fe4dddeecbba6d79cfdbabf7",
             "_tpl": "5b44d0de86f774503d30cba8",
             "parentId": "hideout",
@@ -1994,52 +2281,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f3f",
             "_tpl": "6575c342efc786cd9101a5e5",
             "parentId": "fe4dddeecbba6d79cfdbabf7",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f3d",
             "_tpl": "6575c34bc6700bd6b40e8a84",
             "parentId": "fe4dddeecbba6d79cfdbabf7",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f3e",
             "_tpl": "6575c35bc6700bd6b40e8a88",
             "parentId": "fe4dddeecbba6d79cfdbabf7",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f40",
             "_tpl": "6575c366c6700bd6b40e8a8c",
             "parentId": "fe4dddeecbba6d79cfdbabf7",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f41",
             "_tpl": "6575c373dc9932aed601c5ec",
             "parentId": "fe4dddeecbba6d79cfdbabf7",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f42",
             "_tpl": "6575c385dc9932aed601c5f0",
             "parentId": "fe4dddeecbba6d79cfdbabf7",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f43",
             "_tpl": "6575c390efc786cd9101a5e9",
             "parentId": "fe4dddeecbba6d79cfdbabf7",
             "slotId": "Groin_back"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f44",
             "_tpl": "656fa8d700d62bcd2e024084",
             "parentId": "fe4dddeecbba6d79cfdbabf7",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f45",
             "_tpl": "656fa8d700d62bcd2e024084",
             "parentId": "fe4dddeecbba6d79cfdbabf7",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "eacba9139ba71c848ba0a4fa",
             "_tpl": "5ca2151486f774244a3b8d30",
             "parentId": "hideout",
@@ -2050,52 +2347,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f46",
             "_tpl": "6575dd3e9e27f4a85e081142",
             "parentId": "eacba9139ba71c848ba0a4fa",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f47",
             "_tpl": "6575dd519e27f4a85e081146",
             "parentId": "eacba9139ba71c848ba0a4fa",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f48",
             "_tpl": "6575dd64945bf78edd04c438",
             "parentId": "eacba9139ba71c848ba0a4fa",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f49",
             "_tpl": "6575dd6e9d3a0ddf660b9047",
             "parentId": "eacba9139ba71c848ba0a4fa",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f4a",
             "_tpl": "6575dd769d3a0ddf660b904b",
             "parentId": "eacba9139ba71c848ba0a4fa",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f4b",
             "_tpl": "6575dd800546f8b1de093df6",
             "parentId": "eacba9139ba71c848ba0a4fa",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f4c",
             "_tpl": "6575dd94945bf78edd04c43c",
             "parentId": "eacba9139ba71c848ba0a4fa",
             "slotId": "Groin_back"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f4d",
             "_tpl": "65573fa5655447403702a816",
             "parentId": "eacba9139ba71c848ba0a4fa",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f4e",
             "_tpl": "65573fa5655447403702a816",
             "parentId": "eacba9139ba71c848ba0a4fa",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "8ca7ba8c24bdfc361baacede",
             "_tpl": "5b44cf1486f77431723e3d05",
             "parentId": "hideout",
@@ -2106,62 +2413,74 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f4f",
             "_tpl": "6575c3b3dc9932aed601c5f4",
             "parentId": "8ca7ba8c24bdfc361baacede",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f50",
             "_tpl": "6575c3beefc786cd9101a5ed",
             "parentId": "8ca7ba8c24bdfc361baacede",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f51",
             "_tpl": "6575c3cdc6700bd6b40e8a90",
             "parentId": "8ca7ba8c24bdfc361baacede",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f52",
             "_tpl": "6575c3dfdc9932aed601c5f8",
             "parentId": "8ca7ba8c24bdfc361baacede",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f53",
             "_tpl": "6575c3ec52b7f8c76a05ee39",
             "parentId": "8ca7ba8c24bdfc361baacede",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f54",
             "_tpl": "6575c3fd52b7f8c76a05ee3d",
             "parentId": "8ca7ba8c24bdfc361baacede",
             "slotId": "Shoulder_l"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f55",
             "_tpl": "6575c40c52b7f8c76a05ee41",
             "parentId": "8ca7ba8c24bdfc361baacede",
             "slotId": "Shoulder_r"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f56",
             "_tpl": "656fa8d700d62bcd2e024084",
             "parentId": "8ca7ba8c24bdfc361baacede",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f57",
             "_tpl": "656fa8d700d62bcd2e024084",
             "parentId": "8ca7ba8c24bdfc361baacede",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f58",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "8ca7ba8c24bdfc361baacede",
             "slotId": "Left_side_plate"
-        }, {
+        },
+        {
             "_id": "666e47393142970f96065f59",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "8ca7ba8c24bdfc361baacede",
             "slotId": "Right_side_plate"
-        }, {
+        },
+        {
             "_id": "c82ba4f25cd0586effdcbbf8",
             "_tpl": "5b44cd8b86f774503d30cba2",
             "parentId": "hideout",
@@ -2172,72 +2491,86 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f5b",
             "_tpl": "6575c2adefc786cd9101a5d9",
             "parentId": "c82ba4f25cd0586effdcbbf8",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f5c",
             "_tpl": "6575c2be52b7f8c76a05ee25",
             "parentId": "c82ba4f25cd0586effdcbbf8",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f5d",
             "_tpl": "6575c2cd52b7f8c76a05ee29",
             "parentId": "c82ba4f25cd0586effdcbbf8",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f5e",
             "_tpl": "6575c2d852b7f8c76a05ee2d",
             "parentId": "c82ba4f25cd0586effdcbbf8",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f60",
             "_tpl": "6575c2e4efc786cd9101a5dd",
             "parentId": "c82ba4f25cd0586effdcbbf8",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f61",
             "_tpl": "6575c2f7efc786cd9101a5e1",
             "parentId": "c82ba4f25cd0586effdcbbf8",
             "slotId": "Shoulder_l"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f62",
             "_tpl": "6575c30352b7f8c76a05ee31",
             "parentId": "c82ba4f25cd0586effdcbbf8",
             "slotId": "Shoulder_r"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f63",
             "_tpl": "6575c31b52b7f8c76a05ee35",
             "parentId": "c82ba4f25cd0586effdcbbf8",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f64",
             "_tpl": "6575c326c6700bd6b40e8a80",
             "parentId": "c82ba4f25cd0586effdcbbf8",
             "slotId": "Groin_back"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f65",
             "_tpl": "656fa8d700d62bcd2e024084",
             "parentId": "c82ba4f25cd0586effdcbbf8",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f66",
             "_tpl": "656fa8d700d62bcd2e024084",
             "parentId": "c82ba4f25cd0586effdcbbf8",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f67",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "c82ba4f25cd0586effdcbbf8",
             "slotId": "Left_side_plate"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f68",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "c82ba4f25cd0586effdcbbf8",
             "slotId": "Right_side_plate"
-        }, {
+        },
+        {
             "_id": "c6fe4ce275de1bf2eec3bc00",
             "_tpl": "5f5f41476bdad616ad46d631",
             "parentId": "hideout",
@@ -2248,62 +2581,74 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f69",
             "_tpl": "65731b46cea9255e2102360a",
             "parentId": "c6fe4ce275de1bf2eec3bc00",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f6a",
             "_tpl": "65731b4fcea9255e2102360e",
             "parentId": "c6fe4ce275de1bf2eec3bc00",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f6b",
             "_tpl": "65731b576e709cddd001ec3f",
             "parentId": "c6fe4ce275de1bf2eec3bc00",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f6c",
             "_tpl": "65731b60ff6dc44a7d068c4a",
             "parentId": "c6fe4ce275de1bf2eec3bc00",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f6d",
             "_tpl": "65731b666e709cddd001ec43",
             "parentId": "c6fe4ce275de1bf2eec3bc00",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f6e",
             "_tpl": "65731b716e709cddd001ec47",
             "parentId": "c6fe4ce275de1bf2eec3bc00",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f6f",
             "_tpl": "65731b6b6042b0f210020ef6",
             "parentId": "c6fe4ce275de1bf2eec3bc00",
             "slotId": "Groin_back"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f70",
             "_tpl": "656f664200d62bcd2e024077",
             "parentId": "c6fe4ce275de1bf2eec3bc00",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f71",
             "_tpl": "654a4f8bc721968a4404ef18",
             "parentId": "c6fe4ce275de1bf2eec3bc00",
             "slotId": "Left_side_plate"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f72",
             "_tpl": "654a4f8bc721968a4404ef18",
             "parentId": "c6fe4ce275de1bf2eec3bc00",
             "slotId": "Right_side_plate"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f73",
             "_tpl": "657b2797c3dbcb01d60c35ea",
             "parentId": "c6fe4ce275de1bf2eec3bc00",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "f8f0addd93bf96dc3fa8baa8",
             "_tpl": "5e9dacf986f774054d6b89f4",
             "parentId": "hideout",
@@ -2314,47 +2659,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f74",
             "_tpl": "65732de75d3a3129fb05f3dd",
             "parentId": "f8f0addd93bf96dc3fa8baa8",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f75",
             "_tpl": "65732df4d0acf75aea06c87b",
             "parentId": "f8f0addd93bf96dc3fa8baa8",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f76",
             "_tpl": "65732e05d0acf75aea06c87f",
             "parentId": "f8f0addd93bf96dc3fa8baa8",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f77",
             "_tpl": "65732e0f6784ca384b0167ad",
             "parentId": "f8f0addd93bf96dc3fa8baa8",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f78",
             "_tpl": "65732e215d3a3129fb05f3e1",
             "parentId": "f8f0addd93bf96dc3fa8baa8",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f79",
             "_tpl": "65732e30dd8739f6440ef383",
             "parentId": "f8f0addd93bf96dc3fa8baa8",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f7a",
             "_tpl": "65573fa5655447403702a816",
             "parentId": "f8f0addd93bf96dc3fa8baa8",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f7b",
             "_tpl": "65573fa5655447403702a816",
             "parentId": "f8f0addd93bf96dc3fa8baa8",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "933c0dfc0bab0c90210fc51e",
             "_tpl": "5c0e541586f7747fa54205c9",
             "parentId": "hideout",
@@ -2365,47 +2719,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f7c",
             "_tpl": "6575ea3060703324250610da",
             "parentId": "933c0dfc0bab0c90210fc51e",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f7d",
             "_tpl": "6575ea4cf6a13a7b7100adc4",
             "parentId": "933c0dfc0bab0c90210fc51e",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f7e",
             "_tpl": "6575ea5cf6a13a7b7100adc8",
             "parentId": "933c0dfc0bab0c90210fc51e",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f7f",
             "_tpl": "6575ea6760703324250610de",
             "parentId": "933c0dfc0bab0c90210fc51e",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f80",
             "_tpl": "6575ea719c7cad336508e418",
             "parentId": "933c0dfc0bab0c90210fc51e",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f81",
             "_tpl": "6575ea7c60703324250610e2",
             "parentId": "933c0dfc0bab0c90210fc51e",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f82",
             "_tpl": "656f611f94b480b8a500c0db",
             "parentId": "933c0dfc0bab0c90210fc51e",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f83",
             "_tpl": "656efaf54772930db4031ff5",
             "parentId": "933c0dfc0bab0c90210fc51e",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "aabde64d37dfb52e19841177",
             "_tpl": "5ca21c6986f77479963115a7",
             "parentId": "hideout",
@@ -2416,72 +2779,86 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f84",
             "_tpl": "6575d9a79e27f4a85e08112d",
             "parentId": "aabde64d37dfb52e19841177",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f85",
             "_tpl": "6575d9b8945bf78edd04c427",
             "parentId": "aabde64d37dfb52e19841177",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f86",
             "_tpl": "6575d9c40546f8b1de093dee",
             "parentId": "aabde64d37dfb52e19841177",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f87",
             "_tpl": "6575d9cf0546f8b1de093df2",
             "parentId": "aabde64d37dfb52e19841177",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f88",
             "_tpl": "6575d9d8945bf78edd04c42b",
             "parentId": "aabde64d37dfb52e19841177",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f89",
             "_tpl": "6575da07945bf78edd04c433",
             "parentId": "aabde64d37dfb52e19841177",
             "slotId": "Shoulder_l"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f8a",
             "_tpl": "6575da159e27f4a85e081131",
             "parentId": "aabde64d37dfb52e19841177",
             "slotId": "Shoulder_r"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f8b",
             "_tpl": "6575d9e7945bf78edd04c42f",
             "parentId": "aabde64d37dfb52e19841177",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f8c",
             "_tpl": "6575d9f816c2762fba00588d",
             "parentId": "aabde64d37dfb52e19841177",
             "slotId": "Groin_back"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f8d",
             "_tpl": "65573fa5655447403702a816",
             "parentId": "aabde64d37dfb52e19841177",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f8e",
             "_tpl": "65573fa5655447403702a816",
             "parentId": "aabde64d37dfb52e19841177",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f8f",
             "_tpl": "64afd81707e2cf40e903a316",
             "parentId": "aabde64d37dfb52e19841177",
             "slotId": "Left_side_plate"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f90",
             "_tpl": "64afd81707e2cf40e903a316",
             "parentId": "aabde64d37dfb52e19841177",
             "slotId": "Right_side_plate"
-        }, {
+        },
+        {
             "_id": "65ba7f61c561d8d4dca8287a",
             "_tpl": "5c0e625a86f7742d77340f62",
             "parentId": "hideout",
@@ -2492,52 +2869,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f91",
             "_tpl": "65764275d8537eb26a0355e9",
             "parentId": "65ba7f61c561d8d4dca8287a",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f92",
             "_tpl": "657642b0e6d5dd75f40688a5",
             "parentId": "65ba7f61c561d8d4dca8287a",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f93",
             "_tpl": "6576434820cc24d17102b148",
             "parentId": "65ba7f61c561d8d4dca8287a",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f94",
             "_tpl": "657643732bc38ef78e076477",
             "parentId": "65ba7f61c561d8d4dca8287a",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f95",
             "_tpl": "657643a220cc24d17102b14c",
             "parentId": "65ba7f61c561d8d4dca8287a",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f96",
             "_tpl": "656f63c027aed95beb08f62c",
             "parentId": "65ba7f61c561d8d4dca8287a",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f97",
             "_tpl": "656fafe3498d1b7e3e071da4",
             "parentId": "65ba7f61c561d8d4dca8287a",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f98",
             "_tpl": "64afd81707e2cf40e903a316",
             "parentId": "65ba7f61c561d8d4dca8287a",
             "slotId": "Left_side_plate"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f99",
             "_tpl": "64afd81707e2cf40e903a316",
             "parentId": "65ba7f61c561d8d4dca8287a",
             "slotId": "Right_side_plate"
-        }, {
+        },
+        {
             "_id": "ea92d8455606338f534fbe2b",
             "_tpl": "5fd4c474dd870108a754b241",
             "parentId": "hideout",
@@ -2548,17 +2935,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f9a",
             "_tpl": "656faf0ca0dce000a2020f77",
             "parentId": "ea92d8455606338f534fbe2b",
             "slotId": "front_plate"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f9b",
             "_tpl": "656faf0ca0dce000a2020f77",
             "parentId": "ea92d8455606338f534fbe2b",
             "slotId": "back_plate"
-        }, {
+        },
+        {
             "_id": "64fbabbcca7e3bacb54d0ca5",
             "_tpl": "5e4abb5086f77406975c9342",
             "parentId": "hideout",
@@ -2569,27 +2959,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f9c",
             "_tpl": "6575e71760703324250610c3",
             "parentId": "64fbabbcca7e3bacb54d0ca5",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f9d",
             "_tpl": "6575e72660703324250610c7",
             "parentId": "64fbabbcca7e3bacb54d0ca5",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f9e",
             "_tpl": "656fa76500d62bcd2e024080",
             "parentId": "64fbabbcca7e3bacb54d0ca5",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065f9f",
             "_tpl": "656fa76500d62bcd2e024080",
             "parentId": "64fbabbcca7e3bacb54d0ca5",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "a21ba7c59fac6611daa459ee",
             "_tpl": "60a283193cb70855c43a381d",
             "parentId": "hideout",
@@ -2600,67 +2995,80 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065fa0",
             "_tpl": "6575d561b15fef3dd4051670",
             "parentId": "a21ba7c59fac6611daa459ee",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065fa1",
             "_tpl": "6575d56b16c2762fba005818",
             "parentId": "a21ba7c59fac6611daa459ee",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065fa2",
             "_tpl": "6575d57a16c2762fba00581c",
             "parentId": "a21ba7c59fac6611daa459ee",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065fa3",
             "_tpl": "6575d589b15fef3dd4051674",
             "parentId": "a21ba7c59fac6611daa459ee",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065fa4",
             "_tpl": "6575d598b15fef3dd4051678",
             "parentId": "a21ba7c59fac6611daa459ee",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065fa5",
             "_tpl": "6575d5b316c2762fba005824",
             "parentId": "a21ba7c59fac6611daa459ee",
             "slotId": "Shoulder_l"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065fa6",
             "_tpl": "6575d5bd16c2762fba005828",
             "parentId": "a21ba7c59fac6611daa459ee",
             "slotId": "Shoulder_r"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065fa7",
             "_tpl": "6575d5a616c2762fba005820",
             "parentId": "a21ba7c59fac6611daa459ee",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065fa8",
             "_tpl": "656fa61e94b480b8a500c0e8",
             "parentId": "a21ba7c59fac6611daa459ee",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065fa9",
             "_tpl": "656fa61e94b480b8a500c0e8",
             "parentId": "a21ba7c59fac6611daa459ee",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065faa",
             "_tpl": "64afdb577bb3bfe8fe03fd1d",
             "parentId": "a21ba7c59fac6611daa459ee",
             "slotId": "Left_side_plate"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065fab",
             "_tpl": "64afdb577bb3bfe8fe03fd1d",
             "parentId": "a21ba7c59fac6611daa459ee",
             "slotId": "Right_side_plate"
-        }, {
+        },
+        {
             "_id": "ca43ddb7a2ff58ee0b73b5b6",
             "_tpl": "545cdb794bdc2d3a198b456a",
             "parentId": "hideout",
@@ -2671,67 +3079,80 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065fac",
             "_tpl": "6575ce3716c2762fba0057fd",
             "parentId": "ca43ddb7a2ff58ee0b73b5b6",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065fad",
             "_tpl": "6575ce45dc9932aed601c616",
             "parentId": "ca43ddb7a2ff58ee0b73b5b6",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065fae",
             "_tpl": "6575ce5016c2762fba005802",
             "parentId": "ca43ddb7a2ff58ee0b73b5b6",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065faf",
             "_tpl": "6575ce5befc786cd9101a671",
             "parentId": "ca43ddb7a2ff58ee0b73b5b6",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065fb0",
             "_tpl": "6575ce6f16c2762fba005806",
             "parentId": "ca43ddb7a2ff58ee0b73b5b6",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065fb1",
             "_tpl": "6575ce9db15fef3dd4051628",
             "parentId": "ca43ddb7a2ff58ee0b73b5b6",
             "slotId": "Shoulder_l"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065fb2",
             "_tpl": "6575cea8b15fef3dd405162c",
             "parentId": "ca43ddb7a2ff58ee0b73b5b6",
             "slotId": "Shoulder_r"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065fb3",
             "_tpl": "6575ce8bdc9932aed601c61e",
             "parentId": "ca43ddb7a2ff58ee0b73b5b6",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065fb4",
             "_tpl": "64afc71497cf3a403c01ff38",
             "parentId": "ca43ddb7a2ff58ee0b73b5b6",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065fb5",
             "_tpl": "64afc71497cf3a403c01ff38",
             "parentId": "ca43ddb7a2ff58ee0b73b5b6",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065fb6",
             "_tpl": "64afd81707e2cf40e903a316",
             "parentId": "ca43ddb7a2ff58ee0b73b5b6",
             "slotId": "Left_side_plate"
-        }, {
+        },
+        {
             "_id": "666e4a6e3142970f96065fb7",
             "_tpl": "64afd81707e2cf40e903a316",
             "parentId": "ca43ddb7a2ff58ee0b73b5b6",
             "slotId": "Right_side_plate"
-        }, {
+        },
+        {
             "_id": "9eecaffa0cb6ddbccddb47fd",
             "_tpl": "59e7635f86f7742cbf2c1095",
             "parentId": "hideout",
@@ -2742,27 +3163,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fbf",
             "_tpl": "65702f87722744627e05cdb8",
             "parentId": "9eecaffa0cb6ddbccddb47fd",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fc0",
             "_tpl": "65702fe593b7ea9c330f4ce8",
             "parentId": "9eecaffa0cb6ddbccddb47fd",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fc1",
             "_tpl": "6570305d93b7ea9c330f4ced",
             "parentId": "9eecaffa0cb6ddbccddb47fd",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fc2",
             "_tpl": "65703472c9030b928a0a8a78",
             "parentId": "9eecaffa0cb6ddbccddb47fd",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "35b94ceab1afe0fefec81fef",
             "_tpl": "5df8a2ca86f7740bfe6df777",
             "parentId": "hideout",
@@ -2773,17 +3199,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fc3",
             "_tpl": "656fd7c32668ef0402028fb9",
             "parentId": "35b94ceab1afe0fefec81fef",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fc4",
             "_tpl": "656fd89bf5a9631d4e042575",
             "parentId": "35b94ceab1afe0fefec81fef",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "d7bd663d561e682fa66d579e",
             "_tpl": "5648a7494bdc2d9d488b4583",
             "parentId": "hideout",
@@ -2794,27 +3223,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fc5",
             "_tpl": "65703d866584602f7d057a8a",
             "parentId": "d7bd663d561e682fa66d579e",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fc6",
             "_tpl": "65703fa06584602f7d057a8e",
             "parentId": "d7bd663d561e682fa66d579e",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fc7",
             "_tpl": "65703fe46a912c8b5c03468b",
             "parentId": "d7bd663d561e682fa66d579e",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fc8",
             "_tpl": "657040374e67e8ec7a0d261c",
             "parentId": "d7bd663d561e682fa66d579e",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "ba4b5efd1ab3e2bf0a547f51",
             "_tpl": "5b44d22286f774172b0c9de8",
             "parentId": "hideout",
@@ -2825,42 +3259,50 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fc9",
             "_tpl": "65704de13e7bba58ea0285c8",
             "parentId": "ba4b5efd1ab3e2bf0a547f51",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fca",
             "_tpl": "65705c3c14f2ed6d7d0b7738",
             "parentId": "ba4b5efd1ab3e2bf0a547f51",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fcb",
             "_tpl": "65705c777260e1139e091408",
             "parentId": "ba4b5efd1ab3e2bf0a547f51",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fcc",
             "_tpl": "65705cb314f2ed6d7d0b773c",
             "parentId": "ba4b5efd1ab3e2bf0a547f51",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fcd",
             "_tpl": "65705cea4916448ae1050897",
             "parentId": "ba4b5efd1ab3e2bf0a547f51",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fce",
             "_tpl": "656f9d5900d62bcd2e02407c",
             "parentId": "ba4b5efd1ab3e2bf0a547f51",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fcf",
             "_tpl": "656f9d5900d62bcd2e02407c",
             "parentId": "ba4b5efd1ab3e2bf0a547f51",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "cc36008c3a9e5e48aaf90e46",
             "_tpl": "5ab8e4ed86f7742d8e50c7fa",
             "parentId": "hideout",
@@ -2871,27 +3313,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fd0",
             "_tpl": "657044e971369562b300ce9b",
             "parentId": "cc36008c3a9e5e48aaf90e46",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fd1",
             "_tpl": "657045741bd9beedc40b7299",
             "parentId": "cc36008c3a9e5e48aaf90e46",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fd2",
             "_tpl": "657045b97e80617cee095bda",
             "parentId": "cc36008c3a9e5e48aaf90e46",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fd3",
             "_tpl": "6570460471369562b300ce9f",
             "parentId": "cc36008c3a9e5e48aaf90e46",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "4064dfe7bdfb2dcbb588ebef",
             "_tpl": "5c0e5edb86f77461f55ed1f7",
             "parentId": "hideout",
@@ -2902,42 +3349,50 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fd4",
             "_tpl": "6571dbd388ead79fcf091d71",
             "parentId": "4064dfe7bdfb2dcbb588ebef",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fd5",
             "_tpl": "6571dbda88ead79fcf091d75",
             "parentId": "4064dfe7bdfb2dcbb588ebef",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fd6",
             "_tpl": "6571dbe07c02ae206002502e",
             "parentId": "4064dfe7bdfb2dcbb588ebef",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fd7",
             "_tpl": "6571dbeaee8ec43d520cf89e",
             "parentId": "4064dfe7bdfb2dcbb588ebef",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fd8",
             "_tpl": "6571dbef88ead79fcf091d79",
             "parentId": "4064dfe7bdfb2dcbb588ebef",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fd9",
             "_tpl": "656f57dc27aed95beb08f628",
             "parentId": "4064dfe7bdfb2dcbb588ebef",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fda",
             "_tpl": "656fac30c6baea13cd07e10c",
             "parentId": "4064dfe7bdfb2dcbb588ebef",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "fbfecbe8e8eff4585ad5be8f",
             "_tpl": "5c0e5bab86f77461f55ed1f3",
             "parentId": "hideout",
@@ -2948,47 +3403,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fdb",
             "_tpl": "6571b27a6d84a2b8b6007f92",
             "parentId": "fbfecbe8e8eff4585ad5be8f",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fdc",
             "_tpl": "6571baa74cb80d995d0a1490",
             "parentId": "fbfecbe8e8eff4585ad5be8f",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fdd",
             "_tpl": "6571baac6d84a2b8b6007fa3",
             "parentId": "fbfecbe8e8eff4585ad5be8f",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fde",
             "_tpl": "6571bab0f41985531a038091",
             "parentId": "fbfecbe8e8eff4585ad5be8f",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fdf",
             "_tpl": "6571babb4076795e5e07383f",
             "parentId": "fbfecbe8e8eff4585ad5be8f",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fe0",
             "_tpl": "6571bac34076795e5e073843",
             "parentId": "fbfecbe8e8eff4585ad5be8f",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fe1",
             "_tpl": "6571babf4cb80d995d0a1494",
             "parentId": "fbfecbe8e8eff4585ad5be8f",
             "slotId": "Groin_back"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fe2",
             "_tpl": "654a4dea7c17dec2f50cc86a",
             "parentId": "fbfecbe8e8eff4585ad5be8f",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "cb5b71abe2b3433cb9c8cd13",
             "_tpl": "609e8540d5c319764c2bc2e9",
             "parentId": "hideout",
@@ -2999,37 +3463,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fe3",
             "_tpl": "6572e5221b5bc1185508c24f",
             "parentId": "cb5b71abe2b3433cb9c8cd13",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fe4",
             "_tpl": "6572e52f73c0eabb700109a0",
             "parentId": "cb5b71abe2b3433cb9c8cd13",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fe5",
             "_tpl": "6572e53c73c0eabb700109a4",
             "parentId": "cb5b71abe2b3433cb9c8cd13",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fe6",
             "_tpl": "6572e54873c0eabb700109a8",
             "parentId": "cb5b71abe2b3433cb9c8cd13",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fe7",
             "_tpl": "656f9fa0498d1b7e3e071d98",
             "parentId": "cb5b71abe2b3433cb9c8cd13",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fe8",
             "_tpl": "656f9fa0498d1b7e3e071d98",
             "parentId": "cb5b71abe2b3433cb9c8cd13",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "bac2f080b35e85006ea3d7fd",
             "_tpl": "5c0e53c886f7747fa54205c7",
             "parentId": "hideout",
@@ -3040,47 +3511,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fe9",
             "_tpl": "654a8b0b0337d53f9102c2ae",
             "parentId": "bac2f080b35e85006ea3d7fd",
             "slotId": "soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fea",
             "_tpl": "654a8976f414fcea4004d78b",
             "parentId": "bac2f080b35e85006ea3d7fd",
             "slotId": "soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065feb",
             "_tpl": "654a8b3df414fcea4004d78f",
             "parentId": "bac2f080b35e85006ea3d7fd",
             "slotId": "soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fec",
             "_tpl": "654a8b80f414fcea4004d797",
             "parentId": "bac2f080b35e85006ea3d7fd",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fed",
             "_tpl": "654a8ae00337d53f9102c2aa",
             "parentId": "bac2f080b35e85006ea3d7fd",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fee",
             "_tpl": "654a8bc5f414fcea4004d79b",
             "parentId": "bac2f080b35e85006ea3d7fd",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fef",
             "_tpl": "656f603f94b480b8a500c0d6",
             "parentId": "bac2f080b35e85006ea3d7fd",
             "slotId": "front_plate"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065ff0",
             "_tpl": "656efd66034e8e01c407f35c",
             "parentId": "bac2f080b35e85006ea3d7fd",
             "slotId": "back_plate"
-        }, {
+        },
+        {
             "_id": "e74bd4c8e8aad54ff7edf993",
             "_tpl": "5c0e57ba86f7747fa141986d",
             "parentId": "hideout",
@@ -3091,52 +3571,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065ff1",
             "_tpl": "65707fc348c7a887f2010432",
             "parentId": "e74bd4c8e8aad54ff7edf993",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065ff2",
             "_tpl": "6570800612755ae0d907acf8",
             "parentId": "e74bd4c8e8aad54ff7edf993",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065ff3",
             "_tpl": "65708070f65e2491bf00972c",
             "parentId": "e74bd4c8e8aad54ff7edf993",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065ff4",
             "_tpl": "657080a212755ae0d907ad04",
             "parentId": "e74bd4c8e8aad54ff7edf993",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065ff5",
             "_tpl": "657080ca12755ae0d907ad5e",
             "parentId": "e74bd4c8e8aad54ff7edf993",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065ff6",
             "_tpl": "65708122f65e2491bf009755",
             "parentId": "e74bd4c8e8aad54ff7edf993",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065ff7",
             "_tpl": "65708165696fe382cf073255",
             "parentId": "e74bd4c8e8aad54ff7edf993",
             "slotId": "Groin_back"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065ff8",
             "_tpl": "656f603f94b480b8a500c0d6",
             "parentId": "e74bd4c8e8aad54ff7edf993",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065ff9",
             "_tpl": "657b22485f444d6dff0c6c2f",
             "parentId": "e74bd4c8e8aad54ff7edf993",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "df1baddd98542ee14eefefde",
             "_tpl": "5c0e655586f774045612eeb2",
             "parentId": "hideout",
@@ -3147,27 +3637,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065ffa",
             "_tpl": "6570e025615f54368b04fcb0",
             "parentId": "df1baddd98542ee14eefefde",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065ffb",
             "_tpl": "6570e0610b57c03ec90b96ef",
             "parentId": "df1baddd98542ee14eefefde",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065ffc",
             "_tpl": "656fad8c498d1b7e3e071da0",
             "parentId": "df1baddd98542ee14eefefde",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065ffd",
             "_tpl": "656fad8c498d1b7e3e071da0",
             "parentId": "df1baddd98542ee14eefefde",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "26de8c2b1dd68b5cedcd781a",
             "_tpl": "5ab8e79e86f7742d8b372e78",
             "parentId": "hideout",
@@ -3178,42 +3673,50 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065ffe",
             "_tpl": "65732688d9d89ff7ac0d9c4c",
             "parentId": "26de8c2b1dd68b5cedcd781a",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96065fff",
             "_tpl": "657326978c1cc6dcd9098b56",
             "parentId": "26de8c2b1dd68b5cedcd781a",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066000",
             "_tpl": "657326a28c1cc6dcd9098b5a",
             "parentId": "26de8c2b1dd68b5cedcd781a",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066001",
             "_tpl": "657326b08c1cc6dcd9098b5e",
             "parentId": "26de8c2b1dd68b5cedcd781a",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066002",
             "_tpl": "657326bc5d3a3129fb05f36b",
             "parentId": "26de8c2b1dd68b5cedcd781a",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066003",
             "_tpl": "656f611f94b480b8a500c0db",
             "parentId": "26de8c2b1dd68b5cedcd781a",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066004",
             "_tpl": "65573fa5655447403702a816",
             "parentId": "26de8c2b1dd68b5cedcd781a",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "81dcbbdcb9a6ef6752fe0fbb",
             "_tpl": "5b44d0de86f774503d30cba8",
             "parentId": "hideout",
@@ -3224,52 +3727,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066005",
             "_tpl": "6575c342efc786cd9101a5e5",
             "parentId": "81dcbbdcb9a6ef6752fe0fbb",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066006",
             "_tpl": "6575c34bc6700bd6b40e8a84",
             "parentId": "81dcbbdcb9a6ef6752fe0fbb",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066007",
             "_tpl": "6575c35bc6700bd6b40e8a88",
             "parentId": "81dcbbdcb9a6ef6752fe0fbb",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066008",
             "_tpl": "6575c366c6700bd6b40e8a8c",
             "parentId": "81dcbbdcb9a6ef6752fe0fbb",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066009",
             "_tpl": "6575c373dc9932aed601c5ec",
             "parentId": "81dcbbdcb9a6ef6752fe0fbb",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606600a",
             "_tpl": "6575c385dc9932aed601c5f0",
             "parentId": "81dcbbdcb9a6ef6752fe0fbb",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606600b",
             "_tpl": "6575c390efc786cd9101a5e9",
             "parentId": "81dcbbdcb9a6ef6752fe0fbb",
             "slotId": "Groin_back"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606600c",
             "_tpl": "656fa8d700d62bcd2e024084",
             "parentId": "81dcbbdcb9a6ef6752fe0fbb",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606600d",
             "_tpl": "656fa8d700d62bcd2e024084",
             "parentId": "81dcbbdcb9a6ef6752fe0fbb",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "fac9bb2ff1bdd55c5d09f9ae",
             "_tpl": "5ca2151486f774244a3b8d30",
             "parentId": "hideout",
@@ -3280,52 +3793,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606600e",
             "_tpl": "6575dd3e9e27f4a85e081142",
             "parentId": "fac9bb2ff1bdd55c5d09f9ae",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606600f",
             "_tpl": "6575dd519e27f4a85e081146",
             "parentId": "fac9bb2ff1bdd55c5d09f9ae",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066010",
             "_tpl": "6575dd64945bf78edd04c438",
             "parentId": "fac9bb2ff1bdd55c5d09f9ae",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066011",
             "_tpl": "6575dd6e9d3a0ddf660b9047",
             "parentId": "fac9bb2ff1bdd55c5d09f9ae",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066012",
             "_tpl": "6575dd769d3a0ddf660b904b",
             "parentId": "fac9bb2ff1bdd55c5d09f9ae",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066013",
             "_tpl": "6575dd800546f8b1de093df6",
             "parentId": "fac9bb2ff1bdd55c5d09f9ae",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066014",
             "_tpl": "6575dd94945bf78edd04c43c",
             "parentId": "fac9bb2ff1bdd55c5d09f9ae",
             "slotId": "Groin_back"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066015",
             "_tpl": "65573fa5655447403702a816",
             "parentId": "fac9bb2ff1bdd55c5d09f9ae",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066016",
             "_tpl": "65573fa5655447403702a816",
             "parentId": "fac9bb2ff1bdd55c5d09f9ae",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "b8ebacd89ab4fb24c4398dfd",
             "_tpl": "5b44cf1486f77431723e3d05",
             "parentId": "hideout",
@@ -3336,62 +3859,74 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066017",
             "_tpl": "6575c3b3dc9932aed601c5f4",
             "parentId": "b8ebacd89ab4fb24c4398dfd",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066018",
             "_tpl": "6575c3beefc786cd9101a5ed",
             "parentId": "b8ebacd89ab4fb24c4398dfd",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066019",
             "_tpl": "6575c3cdc6700bd6b40e8a90",
             "parentId": "b8ebacd89ab4fb24c4398dfd",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606601a",
             "_tpl": "6575c3dfdc9932aed601c5f8",
             "parentId": "b8ebacd89ab4fb24c4398dfd",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606601b",
             "_tpl": "6575c3ec52b7f8c76a05ee39",
             "parentId": "b8ebacd89ab4fb24c4398dfd",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606601c",
             "_tpl": "6575c3fd52b7f8c76a05ee3d",
             "parentId": "b8ebacd89ab4fb24c4398dfd",
             "slotId": "Shoulder_l"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606601d",
             "_tpl": "6575c40c52b7f8c76a05ee41",
             "parentId": "b8ebacd89ab4fb24c4398dfd",
             "slotId": "Shoulder_r"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606601e",
             "_tpl": "656fa8d700d62bcd2e024084",
             "parentId": "b8ebacd89ab4fb24c4398dfd",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606601f",
             "_tpl": "656fa8d700d62bcd2e024084",
             "parentId": "b8ebacd89ab4fb24c4398dfd",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066020",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "b8ebacd89ab4fb24c4398dfd",
             "slotId": "Left_side_plate"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066021",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "b8ebacd89ab4fb24c4398dfd",
             "slotId": "Right_side_plate"
-        }, {
+        },
+        {
             "_id": "462cefd5ddae8f6bab381b6e",
             "_tpl": "5b44cd8b86f774503d30cba2",
             "parentId": "hideout",
@@ -3402,72 +3937,86 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066022",
             "_tpl": "6575c2adefc786cd9101a5d9",
             "parentId": "462cefd5ddae8f6bab381b6e",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066023",
             "_tpl": "6575c2be52b7f8c76a05ee25",
             "parentId": "462cefd5ddae8f6bab381b6e",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066024",
             "_tpl": "6575c2cd52b7f8c76a05ee29",
             "parentId": "462cefd5ddae8f6bab381b6e",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066025",
             "_tpl": "6575c2d852b7f8c76a05ee2d",
             "parentId": "462cefd5ddae8f6bab381b6e",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066026",
             "_tpl": "6575c2e4efc786cd9101a5dd",
             "parentId": "462cefd5ddae8f6bab381b6e",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066027",
             "_tpl": "6575c2f7efc786cd9101a5e1",
             "parentId": "462cefd5ddae8f6bab381b6e",
             "slotId": "Shoulder_l"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066028",
             "_tpl": "6575c30352b7f8c76a05ee31",
             "parentId": "462cefd5ddae8f6bab381b6e",
             "slotId": "Shoulder_r"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066029",
             "_tpl": "6575c31b52b7f8c76a05ee35",
             "parentId": "462cefd5ddae8f6bab381b6e",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606602a",
             "_tpl": "6575c326c6700bd6b40e8a80",
             "parentId": "462cefd5ddae8f6bab381b6e",
             "slotId": "Groin_back"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606602b",
             "_tpl": "656fa8d700d62bcd2e024084",
             "parentId": "462cefd5ddae8f6bab381b6e",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606602c",
             "_tpl": "656fa8d700d62bcd2e024084",
             "parentId": "462cefd5ddae8f6bab381b6e",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606602d",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "462cefd5ddae8f6bab381b6e",
             "slotId": "Left_side_plate"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606602e",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "462cefd5ddae8f6bab381b6e",
             "slotId": "Right_side_plate"
-        }, {
+        },
+        {
             "_id": "b9e2213c9da4adb80f18edee",
             "_tpl": "5f5f41476bdad616ad46d631",
             "parentId": "hideout",
@@ -3478,62 +4027,74 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606602f",
             "_tpl": "65731b46cea9255e2102360a",
             "parentId": "b9e2213c9da4adb80f18edee",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066030",
             "_tpl": "65731b4fcea9255e2102360e",
             "parentId": "b9e2213c9da4adb80f18edee",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066031",
             "_tpl": "65731b576e709cddd001ec3f",
             "parentId": "b9e2213c9da4adb80f18edee",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066032",
             "_tpl": "65731b60ff6dc44a7d068c4a",
             "parentId": "b9e2213c9da4adb80f18edee",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066033",
             "_tpl": "65731b666e709cddd001ec43",
             "parentId": "b9e2213c9da4adb80f18edee",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066034",
             "_tpl": "65731b716e709cddd001ec47",
             "parentId": "b9e2213c9da4adb80f18edee",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066035",
             "_tpl": "65731b6b6042b0f210020ef6",
             "parentId": "b9e2213c9da4adb80f18edee",
             "slotId": "Groin_back"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066036",
             "_tpl": "656f664200d62bcd2e024077",
             "parentId": "b9e2213c9da4adb80f18edee",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066037",
             "_tpl": "654a4f8bc721968a4404ef18",
             "parentId": "b9e2213c9da4adb80f18edee",
             "slotId": "Left_side_plate"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066038",
             "_tpl": "654a4f8bc721968a4404ef18",
             "parentId": "b9e2213c9da4adb80f18edee",
             "slotId": "Right_side_plate"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066039",
             "_tpl": "657b2797c3dbcb01d60c35ea",
             "parentId": "b9e2213c9da4adb80f18edee",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "dda4fa330f096da94e9d81c3",
             "_tpl": "5e9dacf986f774054d6b89f4",
             "parentId": "hideout",
@@ -3544,47 +4105,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606603a",
             "_tpl": "65732de75d3a3129fb05f3dd",
             "parentId": "dda4fa330f096da94e9d81c3",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606603b",
             "_tpl": "65732df4d0acf75aea06c87b",
             "parentId": "dda4fa330f096da94e9d81c3",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606603c",
             "_tpl": "65732e05d0acf75aea06c87f",
             "parentId": "dda4fa330f096da94e9d81c3",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606603d",
             "_tpl": "65732e0f6784ca384b0167ad",
             "parentId": "dda4fa330f096da94e9d81c3",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606603e",
             "_tpl": "65732e215d3a3129fb05f3e1",
             "parentId": "dda4fa330f096da94e9d81c3",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606603f",
             "_tpl": "65732e30dd8739f6440ef383",
             "parentId": "dda4fa330f096da94e9d81c3",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066040",
             "_tpl": "65573fa5655447403702a816",
             "parentId": "dda4fa330f096da94e9d81c3",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066041",
             "_tpl": "65573fa5655447403702a816",
             "parentId": "dda4fa330f096da94e9d81c3",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "2c6c79dfc30c4b8c56b1d1d8",
             "_tpl": "5c0e541586f7747fa54205c9",
             "parentId": "hideout",
@@ -3595,47 +4165,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066042",
             "_tpl": "6575ea3060703324250610da",
             "parentId": "2c6c79dfc30c4b8c56b1d1d8",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066043",
             "_tpl": "6575ea4cf6a13a7b7100adc4",
             "parentId": "2c6c79dfc30c4b8c56b1d1d8",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066044",
             "_tpl": "6575ea5cf6a13a7b7100adc8",
             "parentId": "2c6c79dfc30c4b8c56b1d1d8",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066045",
             "_tpl": "6575ea6760703324250610de",
             "parentId": "2c6c79dfc30c4b8c56b1d1d8",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066046",
             "_tpl": "6575ea719c7cad336508e418",
             "parentId": "2c6c79dfc30c4b8c56b1d1d8",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066047",
             "_tpl": "6575ea7c60703324250610e2",
             "parentId": "2c6c79dfc30c4b8c56b1d1d8",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066048",
             "_tpl": "656f611f94b480b8a500c0db",
             "parentId": "2c6c79dfc30c4b8c56b1d1d8",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066049",
             "_tpl": "656efaf54772930db4031ff5",
             "parentId": "2c6c79dfc30c4b8c56b1d1d8",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "b99f84c0c89cc0a0a71af70a",
             "_tpl": "5ca21c6986f77479963115a7",
             "parentId": "hideout",
@@ -3646,72 +4225,86 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606604a",
             "_tpl": "6575d9a79e27f4a85e08112d",
             "parentId": "b99f84c0c89cc0a0a71af70a",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606604b",
             "_tpl": "6575d9b8945bf78edd04c427",
             "parentId": "b99f84c0c89cc0a0a71af70a",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606604c",
             "_tpl": "6575d9c40546f8b1de093dee",
             "parentId": "b99f84c0c89cc0a0a71af70a",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606604d",
             "_tpl": "6575d9cf0546f8b1de093df2",
             "parentId": "b99f84c0c89cc0a0a71af70a",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606604e",
             "_tpl": "6575d9d8945bf78edd04c42b",
             "parentId": "b99f84c0c89cc0a0a71af70a",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066050",
             "_tpl": "6575da07945bf78edd04c433",
             "parentId": "b99f84c0c89cc0a0a71af70a",
             "slotId": "Shoulder_l"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066051",
             "_tpl": "6575da159e27f4a85e081131",
             "parentId": "b99f84c0c89cc0a0a71af70a",
             "slotId": "Shoulder_r"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066052",
             "_tpl": "6575d9e7945bf78edd04c42f",
             "parentId": "b99f84c0c89cc0a0a71af70a",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066053",
             "_tpl": "6575d9f816c2762fba00588d",
             "parentId": "b99f84c0c89cc0a0a71af70a",
             "slotId": "Groin_back"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066054",
             "_tpl": "65573fa5655447403702a816",
             "parentId": "b99f84c0c89cc0a0a71af70a",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066055",
             "_tpl": "65573fa5655447403702a816",
             "parentId": "b99f84c0c89cc0a0a71af70a",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066056",
             "_tpl": "64afd81707e2cf40e903a316",
             "parentId": "b99f84c0c89cc0a0a71af70a",
             "slotId": "Left_side_plate"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066057",
             "_tpl": "64afd81707e2cf40e903a316",
             "parentId": "b99f84c0c89cc0a0a71af70a",
             "slotId": "Right_side_plate"
-        }, {
+        },
+        {
             "_id": "cddf2eedaaee1ed855325aa6",
             "_tpl": "5c0e625a86f7742d77340f62",
             "parentId": "hideout",
@@ -3722,52 +4315,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066058",
             "_tpl": "65764275d8537eb26a0355e9",
             "parentId": "cddf2eedaaee1ed855325aa6",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066059",
             "_tpl": "657642b0e6d5dd75f40688a5",
             "parentId": "cddf2eedaaee1ed855325aa6",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606605a",
             "_tpl": "6576434820cc24d17102b148",
             "parentId": "cddf2eedaaee1ed855325aa6",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606605b",
             "_tpl": "657643732bc38ef78e076477",
             "parentId": "cddf2eedaaee1ed855325aa6",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606605c",
             "_tpl": "657643a220cc24d17102b14c",
             "parentId": "cddf2eedaaee1ed855325aa6",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606605d",
             "_tpl": "656f63c027aed95beb08f62c",
             "parentId": "cddf2eedaaee1ed855325aa6",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606605e",
             "_tpl": "656fafe3498d1b7e3e071da4",
             "parentId": "cddf2eedaaee1ed855325aa6",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606605f",
             "_tpl": "64afd81707e2cf40e903a316",
             "parentId": "cddf2eedaaee1ed855325aa6",
             "slotId": "Left_side_plate"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066060",
             "_tpl": "64afd81707e2cf40e903a316",
             "parentId": "cddf2eedaaee1ed855325aa6",
             "slotId": "Right_side_plate"
-        }, {
+        },
+        {
             "_id": "b300dea5d6b91e0c9fdcdcfa",
             "_tpl": "5fd4c474dd870108a754b241",
             "parentId": "hideout",
@@ -3778,17 +4381,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066061",
             "_tpl": "656faf0ca0dce000a2020f77",
             "parentId": "b300dea5d6b91e0c9fdcdcfa",
             "slotId": "front_plate"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066062",
             "_tpl": "656faf0ca0dce000a2020f77",
             "parentId": "b300dea5d6b91e0c9fdcdcfa",
             "slotId": "back_plate"
-        }, {
+        },
+        {
             "_id": "1b29b4cdaeab7e690c4d3f5b",
             "_tpl": "5e4abb5086f77406975c9342",
             "parentId": "hideout",
@@ -3799,27 +4405,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066063",
             "_tpl": "6575e71760703324250610c3",
             "parentId": "1b29b4cdaeab7e690c4d3f5b",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066064",
             "_tpl": "6575e72660703324250610c7",
             "parentId": "1b29b4cdaeab7e690c4d3f5b",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066065",
             "_tpl": "656fa76500d62bcd2e024080",
             "parentId": "1b29b4cdaeab7e690c4d3f5b",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066066",
             "_tpl": "656fa76500d62bcd2e024080",
             "parentId": "1b29b4cdaeab7e690c4d3f5b",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "f863fc6d0eacccc5ad5535a7",
             "_tpl": "60a283193cb70855c43a381d",
             "parentId": "hideout",
@@ -3830,67 +4441,80 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066067",
             "_tpl": "6575d561b15fef3dd4051670",
             "parentId": "f863fc6d0eacccc5ad5535a7",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066068",
             "_tpl": "6575d56b16c2762fba005818",
             "parentId": "f863fc6d0eacccc5ad5535a7",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066069",
             "_tpl": "6575d57a16c2762fba00581c",
             "parentId": "f863fc6d0eacccc5ad5535a7",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606606a",
             "_tpl": "6575d589b15fef3dd4051674",
             "parentId": "f863fc6d0eacccc5ad5535a7",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606606b",
             "_tpl": "6575d598b15fef3dd4051678",
             "parentId": "f863fc6d0eacccc5ad5535a7",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606606c",
             "_tpl": "6575d5b316c2762fba005824",
             "parentId": "f863fc6d0eacccc5ad5535a7",
             "slotId": "Shoulder_l"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606606d",
             "_tpl": "6575d5bd16c2762fba005828",
             "parentId": "f863fc6d0eacccc5ad5535a7",
             "slotId": "Shoulder_r"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606606e",
             "_tpl": "6575d5a616c2762fba005820",
             "parentId": "f863fc6d0eacccc5ad5535a7",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606606f",
             "_tpl": "656fa61e94b480b8a500c0e8",
             "parentId": "f863fc6d0eacccc5ad5535a7",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066070",
             "_tpl": "656fa61e94b480b8a500c0e8",
             "parentId": "f863fc6d0eacccc5ad5535a7",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066071",
             "_tpl": "64afdb577bb3bfe8fe03fd1d",
             "parentId": "f863fc6d0eacccc5ad5535a7",
             "slotId": "Left_side_plate"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066072",
             "_tpl": "64afdb577bb3bfe8fe03fd1d",
             "parentId": "f863fc6d0eacccc5ad5535a7",
             "slotId": "Right_side_plate"
-        }, {
+        },
+        {
             "_id": "5dffcffcb8cbba35c04b9dea",
             "_tpl": "545cdb794bdc2d3a198b456a",
             "parentId": "hideout",
@@ -3901,67 +4525,80 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066073",
             "_tpl": "6575ce3716c2762fba0057fd",
             "parentId": "5dffcffcb8cbba35c04b9dea",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066074",
             "_tpl": "6575ce45dc9932aed601c616",
             "parentId": "5dffcffcb8cbba35c04b9dea",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066075",
             "_tpl": "6575ce5016c2762fba005802",
             "parentId": "5dffcffcb8cbba35c04b9dea",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066076",
             "_tpl": "6575ce5befc786cd9101a671",
             "parentId": "5dffcffcb8cbba35c04b9dea",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066077",
             "_tpl": "6575ce6f16c2762fba005806",
             "parentId": "5dffcffcb8cbba35c04b9dea",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066078",
             "_tpl": "6575ce9db15fef3dd4051628",
             "parentId": "5dffcffcb8cbba35c04b9dea",
             "slotId": "Shoulder_l"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f96066079",
             "_tpl": "6575cea8b15fef3dd405162c",
             "parentId": "5dffcffcb8cbba35c04b9dea",
             "slotId": "Shoulder_r"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606607a",
             "_tpl": "6575ce8bdc9932aed601c61e",
             "parentId": "5dffcffcb8cbba35c04b9dea",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606607b",
             "_tpl": "64afc71497cf3a403c01ff38",
             "parentId": "5dffcffcb8cbba35c04b9dea",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606607c",
             "_tpl": "64afc71497cf3a403c01ff38",
             "parentId": "5dffcffcb8cbba35c04b9dea",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606607d",
             "_tpl": "64afd81707e2cf40e903a316",
             "parentId": "5dffcffcb8cbba35c04b9dea",
             "slotId": "Left_side_plate"
-        }, {
+        },
+        {
             "_id": "666e4c253142970f9606607e",
             "_tpl": "64afd81707e2cf40e903a316",
             "parentId": "5dffcffcb8cbba35c04b9dea",
             "slotId": "Right_side_plate"
-        }, {
+        },
+        {
             "_id": "154867c34e24b23072b2dee0",
             "_tpl": "62a09d79de7ac81993580530",
             "parentId": "hideout",
@@ -3972,27 +4609,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "abe4b9adc0ac7bd2fc9cfaee",
             "_tpl": "6572e048371fccfbf909d5d8",
             "parentId": "154867c34e24b23072b2dee0",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "6cc7db64eba7d5efef3e6d2d",
             "_tpl": "6572e059371fccfbf909d5dc",
             "parentId": "154867c34e24b23072b2dee0",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "f01a0edded13685d6ec9f4f8",
             "_tpl": "6572e06219b4b511af012f89",
             "parentId": "154867c34e24b23072b2dee0",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "6dd4ab3fb3b7bd327c81e1c6",
             "_tpl": "6572e06819b4b511af012f8d",
             "parentId": "154867c34e24b23072b2dee0",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "1cb2484a08e5db3b5e37af41",
             "_tpl": "62a09d79de7ac81993580530",
             "parentId": "hideout",
@@ -4003,27 +4645,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "52da2da11875b17ae1cd14e9",
             "_tpl": "6572e048371fccfbf909d5d8",
             "parentId": "1cb2484a08e5db3b5e37af41",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "90dce0cb2d351efaebc15924",
             "_tpl": "6572e059371fccfbf909d5dc",
             "parentId": "1cb2484a08e5db3b5e37af41",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "682d8cc0b0d9c12ece67bf25",
             "_tpl": "6572e06219b4b511af012f89",
             "parentId": "1cb2484a08e5db3b5e37af41",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "fb0df1e5ef99a9f879216b17",
             "_tpl": "6572e06819b4b511af012f8d",
             "parentId": "1cb2484a08e5db3b5e37af41",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "c4882a61d8b2be239c13b494",
             "_tpl": "64be79c487d1510151095552",
             "parentId": "hideout",
@@ -4034,17 +4681,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "4b99ee7ab7bd2ffa6c3fbdbb",
             "_tpl": "6570495b45d573133d0d6adb",
             "parentId": "c4882a61d8b2be239c13b494",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "eecab7aeb9b7243bef78efdf",
             "_tpl": "657049d23425b19bbc0502f0",
             "parentId": "c4882a61d8b2be239c13b494",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "786036fd29bfaf00bec5c5b0",
             "_tpl": "64be79c487d1510151095552",
             "parentId": "hideout",
@@ -4055,17 +4705,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "3fceea7a4fdb5786da1eaab1",
             "_tpl": "6570495b45d573133d0d6adb",
             "parentId": "786036fd29bfaf00bec5c5b0",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "938cc6f9bed1fcf32c91dd25",
             "_tpl": "657049d23425b19bbc0502f0",
             "parentId": "786036fd29bfaf00bec5c5b0",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "4b9d28e454a4ff3aa33dcefb",
             "_tpl": "64be79e2bf8412471d0d9bcc",
             "parentId": "hideout",
@@ -4076,17 +4729,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "3ee56c7a2e5d91bf6fd61eef",
             "_tpl": "6570495b45d573133d0d6adb",
             "parentId": "4b9d28e454a4ff3aa33dcefb",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "f7f2bd230bbba8c8baf5b1ca",
             "_tpl": "657049d23425b19bbc0502f0",
             "parentId": "4b9d28e454a4ff3aa33dcefb",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "b7fcc99b5cf753b5b6d400d8",
             "_tpl": "64be79e2bf8412471d0d9bcc",
             "parentId": "hideout",
@@ -4097,17 +4753,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "abfccf886dfd7ea60b9cd2b5",
             "_tpl": "6570495b45d573133d0d6adb",
             "parentId": "b7fcc99b5cf753b5b6d400d8",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "fffae5aaac86ba8b3dc6ba84",
             "_tpl": "657049d23425b19bbc0502f0",
             "parentId": "b7fcc99b5cf753b5b6d400d8",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "1d012074183a599d7c149ebb",
             "_tpl": "63737f448b28897f2802b874",
             "parentId": "hideout",
@@ -4118,17 +4777,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "dab5846b7a51222bfe8db62f",
             "_tpl": "656fae5f7c2d57afe200c0d7",
             "parentId": "1d012074183a599d7c149ebb",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "9b7fbfbd7b8d8aaa46192aad",
             "_tpl": "656fae5f7c2d57afe200c0d7",
             "parentId": "1d012074183a599d7c149ebb",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "b12dd7656cc4faeb35a31e09",
             "_tpl": "63737f448b28897f2802b874",
             "parentId": "hideout",
@@ -4139,17 +4801,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "69fa66aee2b4f23e9917c6ef",
             "_tpl": "656fae5f7c2d57afe200c0d7",
             "parentId": "b12dd7656cc4faeb35a31e09",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "6ae9e1a4eaefec0ee340e304",
             "_tpl": "656fae5f7c2d57afe200c0d7",
             "parentId": "b12dd7656cc4faeb35a31e09",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "a029bbfb9b058bc8f25be586",
             "_tpl": "64abd93857958b4249003418",
             "parentId": "hideout",
@@ -4160,37 +4825,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c3cedb464bab0733b5bc7ebc",
             "_tpl": "6570f30b0921c914bf07964c",
             "parentId": "a029bbfb9b058bc8f25be586",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "ce25dec839b11dead1ee292b",
             "_tpl": "6570f35cd67d0309980a7acb",
             "parentId": "a029bbfb9b058bc8f25be586",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "b2cccec63ee0bcced1ac962e",
             "_tpl": "6570f3890b4ae5847f060dad",
             "parentId": "a029bbfb9b058bc8f25be586",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "e0eddc6bde02fbbfb694ec52",
             "_tpl": "6570f3bb0b4ae5847f060db2",
             "parentId": "a029bbfb9b058bc8f25be586",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "d4e0db0ffbf62bdccf0edfcf",
             "_tpl": "656fb0bd7c2d57afe200c0dc",
             "parentId": "a029bbfb9b058bc8f25be586",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "b6ffbfe10cddcfe270bfaf8a",
             "_tpl": "656fb0bd7c2d57afe200c0dc",
             "parentId": "a029bbfb9b058bc8f25be586",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "3b7fc4abf4ff9f74f620bec3",
             "_tpl": "64abd93857958b4249003418",
             "parentId": "hideout",
@@ -4201,37 +4873,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "af37f4d0cd267a29d85574ca",
             "_tpl": "6570f30b0921c914bf07964c",
             "parentId": "3b7fc4abf4ff9f74f620bec3",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "fd81b7dbf4b737a388cacd6a",
             "_tpl": "6570f35cd67d0309980a7acb",
             "parentId": "3b7fc4abf4ff9f74f620bec3",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "ee9e5adbebf5b28c1b6ed7a8",
             "_tpl": "6570f3890b4ae5847f060dad",
             "parentId": "3b7fc4abf4ff9f74f620bec3",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "dbcec0ee8c5d2eb3cb089549",
             "_tpl": "6570f3bb0b4ae5847f060db2",
             "parentId": "3b7fc4abf4ff9f74f620bec3",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "d99c85a4102be9ddf7c3bc7e",
             "_tpl": "656fb0bd7c2d57afe200c0dc",
             "parentId": "3b7fc4abf4ff9f74f620bec3",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "acfedbdfce6ddb21d2cb534b",
             "_tpl": "656fb0bd7c2d57afe200c0dc",
             "parentId": "3b7fc4abf4ff9f74f620bec3",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "51e9afbdfa34bc6bb1cc99f1",
             "_tpl": "5448be9a4bdc2dfd2f8b456a",
             "parentId": "hideout",
@@ -4242,7 +4921,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "af0fa3c7caa391e4f1f8b2fe",
             "_tpl": "5710c24ad2720bc3458b45a3",
             "parentId": "hideout",
@@ -4253,7 +4933,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f7e74aada5a556a9efcc70dd",
             "_tpl": "58d3db5386f77426186285a0",
             "parentId": "hideout",
@@ -4264,7 +4945,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d5ea7d470070ebca5a3caed9",
             "_tpl": "5a0c27731526d80618476ac4",
             "parentId": "hideout",
@@ -4275,7 +4957,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ef68ad9bedb14eb19acebf53",
             "_tpl": "5a2a57cfc4a2826c6e06d44a",
             "parentId": "hideout",
@@ -4286,7 +4969,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "1b3d8cf6ebae7d9f4d2fafb3",
             "_tpl": "5e32f56fcb6d5863cc5e5ee4",
             "parentId": "hideout",
@@ -4297,7 +4981,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "371fc0d3c86cba2c6df4abe9",
             "_tpl": "5e340dcdcb6d5863cc5e5efb",
             "parentId": "hideout",
@@ -4308,7 +4993,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "965ef27a553a8dca26a27e2b",
             "_tpl": "617aa4dd8166f034d57de9c5",
             "parentId": "hideout",
@@ -4319,7 +5005,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e9bfe4e91a92dade9ae3a1b1",
             "_tpl": "617fd91e5539a84ec44ce155",
             "parentId": "hideout",
@@ -4330,7 +5017,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "cfcd0a82f66efd3ae7c186fa",
             "_tpl": "618a431df1eb8e24b8741deb",
             "parentId": "hideout",
@@ -4341,7 +5029,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "42012fa6ebfe98bd4c68f59b",
             "_tpl": "619256e5f8af2c1a4e1f5d92",
             "parentId": "hideout",
@@ -4352,7 +5041,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "6aafbeb9d48cd79ed4a5157b",
             "_tpl": "5656eb674bdc2d35148b457c",
             "parentId": "hideout",
@@ -4363,7 +5053,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "2d3ddc9a8fad6f28f6d586af",
             "_tpl": "620109578d82e67e7911abf2",
             "parentId": "hideout",
@@ -4374,7 +5065,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "2bc5e8b73c0a14ffd4bcdfa5",
             "_tpl": "6217726288ed9f0845317459",
             "parentId": "hideout",
@@ -4385,7 +5077,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "2911812d0dfde86e08d8a18a",
             "_tpl": "62178be9d0050232da3485d9",
             "parentId": "hideout",
@@ -4396,7 +5089,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "cc2a0f5dae0bd5cfc5d49fbf",
             "_tpl": "624c0b3340357b5f566e8766",
             "parentId": "hideout",
@@ -4407,7 +5101,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "da3a35d7ad7a4c4a0c7aec83",
             "_tpl": "62389aaba63f32501b1b444f",
             "parentId": "hideout",
@@ -4418,7 +5113,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a22bd6adfbfc9e8b80a5a5ae",
             "_tpl": "62389bc9423ed1685422dc57",
             "parentId": "hideout",
@@ -4429,7 +5125,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "3c93ad820a8e6f71b3a8b7dd",
             "_tpl": "62389be94d5d474bf712e709",
             "parentId": "hideout",
@@ -4440,7 +5137,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a2ce4ec5eabbd4fec171608a",
             "_tpl": "5beed0f50db834001c062b12",
             "parentId": "hideout",
@@ -4451,62 +5149,74 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a7219bcece79c354f8b8f3b6",
             "_tpl": "5beec1bd0db834001e6006f3",
             "parentId": "a2ce4ec5eabbd4fec171608a",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "0cca1bcbcb283346a0edbcac",
             "_tpl": "5beec3420db834001b095429",
             "parentId": "a7219bcece79c354f8b8f3b6",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "8e87cf0fb94c739e22fa83ec",
             "_tpl": "5beec3e30db8340019619424",
             "parentId": "a2ce4ec5eabbd4fec171608a",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "0c51fe3910eee76fab87a7f9",
             "_tpl": "5beecbb80db834001d2c465e",
             "parentId": "8e87cf0fb94c739e22fa83ec",
             "slotId": "mod_mount_001"
-        }, {
+        },
+        {
             "_id": "2a2adedddf94a99506bfcb1e",
             "_tpl": "5beecbb80db834001d2c465e",
             "parentId": "8e87cf0fb94c739e22fa83ec",
             "slotId": "mod_mount_000"
-        }, {
+        },
+        {
             "_id": "801ab23c985f2af8cce3fb48",
             "_tpl": "5beec8b20db834001961942a",
             "parentId": "a2ce4ec5eabbd4fec171608a",
             "slotId": "mod_stock_001"
-        }, {
+        },
+        {
             "_id": "10d1ed9a6133e12baf7ffe8d",
             "_tpl": "5beec8c20db834001d2c465c",
             "parentId": "801ab23c985f2af8cce3fb48",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "6302e4954ab0c84d550f6f7c",
             "_tpl": "5beec91a0db834001961942d",
             "parentId": "a2ce4ec5eabbd4fec171608a",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "c0e86e6257c84b3cfb7e6440",
             "_tpl": "5beec9450db83400970084fd",
             "parentId": "6302e4954ab0c84d550f6f7c",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "adb4edf4b7f980c76f5ec19c",
             "_tpl": "5bf3f59f0db834001a6fa060",
             "parentId": "c0e86e6257c84b3cfb7e6440",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "eccf73bc7bba6f71afbeaf8a",
             "_tpl": "5beec8ea0db834001a6f9dbf",
             "parentId": "a2ce4ec5eabbd4fec171608a",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "eeede87b52ac49e9fdf9d468",
             "_tpl": "64637076203536ad5600c990",
             "parentId": "hideout",
@@ -4517,42 +5227,50 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fadaefcaadf7cdd94a3802aa",
             "_tpl": "6492fb8253acae0af00a29b6",
             "parentId": "eeede87b52ac49e9fdf9d468",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "6e9a37bf9f6dffddcdcc053c",
             "_tpl": "6464d870bb2c580352070cc4",
             "parentId": "eeede87b52ac49e9fdf9d468",
             "slotId": "mod_bipod"
-        }, {
+        },
+        {
             "_id": "cc327c5b3dfcd847c93aa460",
             "_tpl": "646371a9f2404ab67905c8e6",
             "parentId": "eeede87b52ac49e9fdf9d468",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "ad980c0a2ff3c54f7b05f5ac",
             "_tpl": "646372518610c40fc20204e8",
             "parentId": "eeede87b52ac49e9fdf9d468",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "f05088706fe4a589cbd5f8cc",
             "_tpl": "646371faf2404ab67905c8e9",
             "parentId": "eeede87b52ac49e9fdf9d468",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "88c3a361c2c62fb25d90bea5",
             "_tpl": "6492efb8cfcf7c89e701abf3",
             "parentId": "f05088706fe4a589cbd5f8cc",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "2fadbd2fd62aafa2d19db4e3",
             "_tpl": "646371779f5f0ea59a04c204",
             "parentId": "eeede87b52ac49e9fdf9d468",
             "slotId": "mod_pistolgrip"
-        }, {
+        },
+        {
             "_id": "cb9f4f04ef7beaded110f66b",
             "_tpl": "64ca3d3954fc657e230529cc",
             "parentId": "hideout",
@@ -4563,37 +5281,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f0acdf0e0503a767bd3c7ae9",
             "_tpl": "6492fb8253acae0af00a29b6",
             "parentId": "cb9f4f04ef7beaded110f66b",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "291a2dc9b7b9afa7939c4132",
             "_tpl": "6464d870bb2c580352070cc4",
             "parentId": "cb9f4f04ef7beaded110f66b",
             "slotId": "mod_bipod"
-        }, {
+        },
+        {
             "_id": "d9eedcf64d2a2d373debec8b",
             "_tpl": "6492e3a97df7d749100e29ee",
             "parentId": "cb9f4f04ef7beaded110f66b",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "fd6eaad3efc77bfccd04eb7a",
             "_tpl": "646372518610c40fc20204e8",
             "parentId": "cb9f4f04ef7beaded110f66b",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "b86b37dcea3cab4abccd73ea",
             "_tpl": "64639a9aab86f8fd4300146c",
             "parentId": "cb9f4f04ef7beaded110f66b",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "bcefaaeb0c68ec5beac67bbd",
             "_tpl": "64cbad529f7cf7f75c077fd5",
             "parentId": "cb9f4f04ef7beaded110f66b",
             "slotId": "mod_pistolgrip"
-        }, {
+        },
+        {
             "_id": "58ccadceea47bbf0ea9b9f10",
             "_tpl": "6513ef33e06849f06c0957ca",
             "parentId": "hideout",
@@ -4604,47 +5329,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d48b5bb9ab4fa480d2f3a3a7",
             "_tpl": "6513f153e63f29908d0ffaba",
             "parentId": "58ccadceea47bbf0ea9b9f10",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "feaabe7bef0b9d438c5be9bf",
             "_tpl": "6513f05a94c72326990a3866",
             "parentId": "58ccadceea47bbf0ea9b9f10",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "cc1c6fc5ea4beeb0ee7beeda",
             "_tpl": "6513eff1e06849f06c0957d4",
             "parentId": "58ccadceea47bbf0ea9b9f10",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "ab5cd1da5a74fa485d515955",
             "_tpl": "6513f0f5e63f29908d0ffab8",
             "parentId": "cc1c6fc5ea4beeb0ee7beeda",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "c6cc7c828fbeddfaa2232e3a",
             "_tpl": "6513f037e06849f06c0957d7",
             "parentId": "cc1c6fc5ea4beeb0ee7beeda",
             "slotId": "mod_bipod"
-        }, {
+        },
+        {
             "_id": "4c5beaf35eb9148feba992ee",
             "_tpl": "6513f1798cb24472490ee331",
             "parentId": "58ccadceea47bbf0ea9b9f10",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "7e1ed0fcca87f87bf63afbac",
             "_tpl": "6513f13a8cb24472490ee32f",
             "parentId": "4c5beaf35eb9148feba992ee",
             "slotId": "mod_pistolgrip"
-        }, {
+        },
+        {
             "_id": "eabc55bd5bfe12e73a35f20d",
             "_tpl": "6513f0a194c72326990a3868",
             "parentId": "58ccadceea47bbf0ea9b9f10",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "9ec426bc5e7602c678b9ddba",
             "_tpl": "65268d8ecb944ff1e90ea385",
             "parentId": "hideout",
@@ -4655,47 +5389,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ed1f61d7f1e82cbc882fa7ce",
             "_tpl": "6513f153e63f29908d0ffaba",
             "parentId": "9ec426bc5e7602c678b9ddba",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "ceafbed9b85a8aeaeabbfc72",
             "_tpl": "6513f05a94c72326990a3866",
             "parentId": "9ec426bc5e7602c678b9ddba",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "868b1e8b1b2f3bec8d98e416",
             "_tpl": "6513eff1e06849f06c0957d4",
             "parentId": "9ec426bc5e7602c678b9ddba",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "a37142d8da97aa3fbcf49abd",
             "_tpl": "6513f0f5e63f29908d0ffab8",
             "parentId": "868b1e8b1b2f3bec8d98e416",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "335b0ecbbbeddaeff3ecf47c",
             "_tpl": "6513f037e06849f06c0957d7",
             "parentId": "868b1e8b1b2f3bec8d98e416",
             "slotId": "mod_bipod"
-        }, {
+        },
+        {
             "_id": "afbd6a34d1fe795669c3d02a",
             "_tpl": "6513f1798cb24472490ee331",
             "parentId": "9ec426bc5e7602c678b9ddba",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "2ff41aa47bfced7fde5dd118",
             "_tpl": "6513f13a8cb24472490ee32f",
             "parentId": "afbd6a34d1fe795669c3d02a",
             "slotId": "mod_pistolgrip"
-        }, {
+        },
+        {
             "_id": "a1da7ebef3dd67a0cbe0f9dc",
             "_tpl": "6513f0a194c72326990a3868",
             "parentId": "9ec426bc5e7602c678b9ddba",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "c0decbecaf6fce0fbdd427db",
             "_tpl": "5e81ebcd8e146c7080625e15",
             "parentId": "hideout",
@@ -4706,12 +5449,14 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "baf6fcce92dd41bca8e0fcac",
             "_tpl": "571659bb2459771fb2755a12",
             "parentId": "c0decbecaf6fce0fbdd427db",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "dbb341b7b258fca356bd2fbb",
             "_tpl": "6275303a9f372d6ea97f9ec7",
             "parentId": "hideout",
@@ -4722,27 +5467,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "1e6be8ff0713adff3e57ff1d",
             "_tpl": "6284bd5f95250a29bc628a30",
             "parentId": "dbb341b7b258fca356bd2fbb",
             "slotId": "mod_scope"
-        }, {
+        },
+        {
             "_id": "61e23eac8d7ca568e6ca4ba5",
             "_tpl": "627bce33f21bc425b06ab967",
             "parentId": "dbb341b7b258fca356bd2fbb",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "7937ce310fb5bf8dba73590f",
             "_tpl": "55d4ae6c4bdc2d8b2f8b456e",
             "parentId": "dbb341b7b258fca356bd2fbb",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "ee6f4a9e0bd36eacbe2abd6f",
             "_tpl": "571659bb2459771fb2755a12",
             "parentId": "dbb341b7b258fca356bd2fbb",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "ed68b0ac5e0cc0ba3133f3b8",
             "_tpl": "5beed0f50db834001c062b12",
             "parentId": "hideout",
@@ -4753,62 +5503,74 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "92d3f4caba80a41f554fa4ea",
             "_tpl": "5beec1bd0db834001e6006f3",
             "parentId": "ed68b0ac5e0cc0ba3133f3b8",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "cfca7a0e251e9a2e047c02bf",
             "_tpl": "5beec3420db834001b095429",
             "parentId": "92d3f4caba80a41f554fa4ea",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "0f8adcd635b7485abbfadffa",
             "_tpl": "5beec3e30db8340019619424",
             "parentId": "ed68b0ac5e0cc0ba3133f3b8",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "d4d00afced88ab9f1241bbb6",
             "_tpl": "5beecbb80db834001d2c465e",
             "parentId": "0f8adcd635b7485abbfadffa",
             "slotId": "mod_mount_001"
-        }, {
+        },
+        {
             "_id": "abe1ef7aa8fcceac1fd5e0a4",
             "_tpl": "5beecbb80db834001d2c465e",
             "parentId": "0f8adcd635b7485abbfadffa",
             "slotId": "mod_mount_000"
-        }, {
+        },
+        {
             "_id": "bd7a2c5eaf8fb6a5116cacd8",
             "_tpl": "5beec8b20db834001961942a",
             "parentId": "ed68b0ac5e0cc0ba3133f3b8",
             "slotId": "mod_stock_001"
-        }, {
+        },
+        {
             "_id": "db72630ddf7bb8a10bca7af3",
             "_tpl": "5beec8c20db834001d2c465c",
             "parentId": "bd7a2c5eaf8fb6a5116cacd8",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "dc24d06e0ef9bceae96bc958",
             "_tpl": "5beec91a0db834001961942d",
             "parentId": "ed68b0ac5e0cc0ba3133f3b8",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "6b57ff77dbb4a882aabf31df",
             "_tpl": "5beec9450db83400970084fd",
             "parentId": "dc24d06e0ef9bceae96bc958",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "dc3344300b3ddd63a475fa97",
             "_tpl": "5bf3f59f0db834001a6fa060",
             "parentId": "6b57ff77dbb4a882aabf31df",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "4fd4ae121b33fd1e0d5bf18c",
             "_tpl": "5beec8ea0db834001a6f9dbf",
             "parentId": "ed68b0ac5e0cc0ba3133f3b8",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "d6f7b2ca4be1152dd1bb926c",
             "_tpl": "64637076203536ad5600c990",
             "parentId": "hideout",
@@ -4819,42 +5581,50 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "864733c1b262f82f9e95a7fe",
             "_tpl": "6492fb8253acae0af00a29b6",
             "parentId": "d6f7b2ca4be1152dd1bb926c",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "9706e4cdd06ab0618adef9bd",
             "_tpl": "6464d870bb2c580352070cc4",
             "parentId": "d6f7b2ca4be1152dd1bb926c",
             "slotId": "mod_bipod"
-        }, {
+        },
+        {
             "_id": "affabee2a69caf61aa0d342c",
             "_tpl": "646371a9f2404ab67905c8e6",
             "parentId": "d6f7b2ca4be1152dd1bb926c",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "dddd472a3cee34b02e24d2ed",
             "_tpl": "646372518610c40fc20204e8",
             "parentId": "d6f7b2ca4be1152dd1bb926c",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "df0c7ddbbfeceafc6a8eae47",
             "_tpl": "646371faf2404ab67905c8e9",
             "parentId": "d6f7b2ca4be1152dd1bb926c",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "9bf4ee7acf728dfc53617cb5",
             "_tpl": "6492efb8cfcf7c89e701abf3",
             "parentId": "df0c7ddbbfeceafc6a8eae47",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "f0abb8e9d33efbb8ffbeb772",
             "_tpl": "646371779f5f0ea59a04c204",
             "parentId": "d6f7b2ca4be1152dd1bb926c",
             "slotId": "mod_pistolgrip"
-        }, {
+        },
+        {
             "_id": "3ab5dccaebc37dc6fae577be",
             "_tpl": "64ca3d3954fc657e230529cc",
             "parentId": "hideout",
@@ -4865,37 +5635,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "5bc82748c1bdfe7ffaabf634",
             "_tpl": "6492fb8253acae0af00a29b6",
             "parentId": "3ab5dccaebc37dc6fae577be",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "4b9fcf63ffa3af179dff91a8",
             "_tpl": "6464d870bb2c580352070cc4",
             "parentId": "3ab5dccaebc37dc6fae577be",
             "slotId": "mod_bipod"
-        }, {
+        },
+        {
             "_id": "cdfc47bf9ec7a2c7f37d26ec",
             "_tpl": "6492e3a97df7d749100e29ee",
             "parentId": "3ab5dccaebc37dc6fae577be",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "7fb279d0dc21beccda2e8c23",
             "_tpl": "646372518610c40fc20204e8",
             "parentId": "3ab5dccaebc37dc6fae577be",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "7cc2c4aec1cdcacfb25afb21",
             "_tpl": "64639a9aab86f8fd4300146c",
             "parentId": "3ab5dccaebc37dc6fae577be",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "10ed5c1b8eae2ffa2ffd03b4",
             "_tpl": "64cbad529f7cf7f75c077fd5",
             "parentId": "3ab5dccaebc37dc6fae577be",
             "slotId": "mod_pistolgrip"
-        }, {
+        },
+        {
             "_id": "5f1baa301eec2977d2b0cb39",
             "_tpl": "6513ef33e06849f06c0957ca",
             "parentId": "hideout",
@@ -4906,47 +5683,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b372b6bb04b7c12b8e8d055f",
             "_tpl": "6513f153e63f29908d0ffaba",
             "parentId": "5f1baa301eec2977d2b0cb39",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "d97adef45dcbdeadaebfea6e",
             "_tpl": "6513f05a94c72326990a3866",
             "parentId": "5f1baa301eec2977d2b0cb39",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "319ff5428caffcc7e8b1a2de",
             "_tpl": "6513eff1e06849f06c0957d4",
             "parentId": "5f1baa301eec2977d2b0cb39",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "c3dfcb16e75bf55de7c28fef",
             "_tpl": "6513f0f5e63f29908d0ffab8",
             "parentId": "319ff5428caffcc7e8b1a2de",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "3eb8e5ee8ad5a27104bc5574",
             "_tpl": "6513f037e06849f06c0957d7",
             "parentId": "319ff5428caffcc7e8b1a2de",
             "slotId": "mod_bipod"
-        }, {
+        },
+        {
             "_id": "3f88f7a65fdfafd4f6bc7eec",
             "_tpl": "6513f1798cb24472490ee331",
             "parentId": "5f1baa301eec2977d2b0cb39",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "595e6af27587a0bbe0aa4e9c",
             "_tpl": "6513f13a8cb24472490ee32f",
             "parentId": "3f88f7a65fdfafd4f6bc7eec",
             "slotId": "mod_pistolgrip"
-        }, {
+        },
+        {
             "_id": "99bce1761f5486474e948e7e",
             "_tpl": "6513f0a194c72326990a3868",
             "parentId": "5f1baa301eec2977d2b0cb39",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "8dbb6bab779b4fdd61d8bb5b",
             "_tpl": "65268d8ecb944ff1e90ea385",
             "parentId": "hideout",
@@ -4957,47 +5743,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bb1ecddda3ec4e5ec0ac691a",
             "_tpl": "6513f153e63f29908d0ffaba",
             "parentId": "8dbb6bab779b4fdd61d8bb5b",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "d0d9d8e432bd4f69ba8dce02",
             "_tpl": "6513f05a94c72326990a3866",
             "parentId": "8dbb6bab779b4fdd61d8bb5b",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "a8cdaeffcd8f3f1fb29ff13b",
             "_tpl": "6513eff1e06849f06c0957d4",
             "parentId": "8dbb6bab779b4fdd61d8bb5b",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "9cfca323838e48dee324b9ae",
             "_tpl": "6513f0f5e63f29908d0ffab8",
             "parentId": "a8cdaeffcd8f3f1fb29ff13b",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "fdcbac8ef3507e7e1df9c3f6",
             "_tpl": "6513f037e06849f06c0957d7",
             "parentId": "a8cdaeffcd8f3f1fb29ff13b",
             "slotId": "mod_bipod"
-        }, {
+        },
+        {
             "_id": "6ec171d5878d4a1db09e5de2",
             "_tpl": "6513f1798cb24472490ee331",
             "parentId": "8dbb6bab779b4fdd61d8bb5b",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "ae9f30ffe52fabeefad91275",
             "_tpl": "6513f13a8cb24472490ee32f",
             "parentId": "6ec171d5878d4a1db09e5de2",
             "slotId": "mod_pistolgrip"
-        }, {
+        },
+        {
             "_id": "375af4c2384d7aaaa10f0554",
             "_tpl": "6513f0a194c72326990a3868",
             "parentId": "8dbb6bab779b4fdd61d8bb5b",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "b000b8ffd5b1dbde2e1ed6d3",
             "_tpl": "5e81ebcd8e146c7080625e15",
             "parentId": "hideout",
@@ -5008,12 +5803,14 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ed38b039d83a8c2c4de8c75a",
             "_tpl": "571659bb2459771fb2755a12",
             "parentId": "b000b8ffd5b1dbde2e1ed6d3",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "53b1055578a15514d03a03b7",
             "_tpl": "6275303a9f372d6ea97f9ec7",
             "parentId": "hideout",
@@ -5024,27 +5821,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ce99f8c787ea272c4bc3a664",
             "_tpl": "6284bd5f95250a29bc628a30",
             "parentId": "53b1055578a15514d03a03b7",
             "slotId": "mod_scope"
-        }, {
+        },
+        {
             "_id": "d0ddc9e3cc002af6249ebeee",
             "_tpl": "627bce33f21bc425b06ab967",
             "parentId": "53b1055578a15514d03a03b7",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "6acf77a73e8705fcdbeb0e15",
             "_tpl": "55d4ae6c4bdc2d8b2f8b456e",
             "parentId": "53b1055578a15514d03a03b7",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "e9c3da35a423be898ae23dac",
             "_tpl": "571659bb2459771fb2755a12",
             "parentId": "53b1055578a15514d03a03b7",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "654d5a9a9ac241d57dae9f42",
             "_tpl": "6357c98711fb55120211f7e1",
             "parentId": "hideout",
@@ -5055,7 +5857,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "34addfbc85983915bdbfe81c",
             "_tpl": "6357c98711fb55120211f7e1",
             "parentId": "hideout",
@@ -5066,7 +5869,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b332cbbb14b269ce47da8385",
             "_tpl": "62e7e7bbe6da9612f743f1e0",
             "parentId": "hideout",
@@ -5077,7 +5881,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fcbd64c5c9a5a04d6b7133b7",
             "_tpl": "62e7e7bbe6da9612f743f1e0",
             "parentId": "hideout",
@@ -5088,7 +5893,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c4fe6deebbf6b03a0fdcd0ae",
             "_tpl": "6513f0a194c72326990a3868",
             "parentId": "hideout",
@@ -5099,7 +5905,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7cfb1b2dde615b4919acde0e",
             "_tpl": "646372518610c40fc20204e8",
             "parentId": "hideout",
@@ -5110,7 +5917,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "eb2ebbffaa3c02d63decedc1",
             "_tpl": "5bed625c0db834001c062946",
             "parentId": "hideout",
@@ -5121,7 +5929,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d58df4c39db7eb63abcf330d",
             "_tpl": "544fb37f4bdc2dee738b4567",
             "parentId": "hideout",
@@ -5132,7 +5941,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "cb891bbafd04990faa96f5fa",
             "_tpl": "544fb37f4bdc2dee738b4567",
             "parentId": "hideout",

--- a/db/traders/6765fbd20fdc7eb79b00000b/assort.json
+++ b/db/traders/6765fbd20fdc7eb79b00000b/assort.json
@@ -1,1275 +1,1460 @@
 {
     "barter_scheme": {
         "eaaa4f07dde2f2931f8bdde4": [
-            [{
+            [
+                {
                     "_tpl": "56742c284bdc2d98058b456d",
                     "count": 5
                 }
             ]
         ],
         "b92dab04f7c919f620a2bec5": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 18000
                 }
             ]
         ],
         "a3ee33b02afcd42acc10a0fc": [
-            [{
+            [
+                {
                     "_tpl": "5d0378d486f77420421a5ff4",
                     "count": 2
                 }
             ]
         ],
         "d467fa8da6ff089edbfa7fe1": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 57000
                 }
             ]
         ],
         "fb52f9d44e810c41abfed05c": [
-            [{
+            [
+                {
                     "_tpl": "56742c2e4bdc2d95058b456d",
                     "count": 3
-                }, {
+                },
+                {
                     "_tpl": "5d1b313086f77425227d1678",
                     "count": 3
                 }
             ]
         ],
         "d9cdd4e5a76c15e542a82e76": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 36000
                 }
             ]
         ],
         "e4dcd1aae831dae84eca05cf": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3600
                 }
             ]
         ],
         "457322ec97ddfa2bd5c5bdd7": [
-            [{
+            [
+                {
                     "_tpl": "5887431f2459777e1612938f",
                     "count": 3
                 }
             ]
         ],
         "8aa340a5caf5b3dc3bd6f1e0": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1350
                 }
             ]
         ],
         "a707e551bf09eed6a32da74a": [
-            [{
+            [
+                {
                     "_tpl": "59e3577886f774176a362503",
                     "count": 1
                 }
             ]
         ],
         "cf5af2b57b78d9cc8b0e3c9f": [
-            [{
+            [
+                {
                     "_tpl": "572b7d8524597762b472f9d1",
                     "count": 3
                 }
             ]
         ],
         "62eba6bffdd622a4f6aadf45": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 8200
                 }
             ]
         ],
         "80b2afafa0c554ef12efafec": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 27000
                 }
             ]
         ],
         "ae2874d9cdefe6a3038befdf": [
-            [{
+            [
+                {
                     "_tpl": "5e2aee0a86f774755a234b62",
                     "count": 1
-                }, {
+                },
+                {
                     "_tpl": "5d03784a86f774203e7e0c4d",
                     "count": 1
                 }
             ]
         ],
         "deaa7060a81e84a6bbbc50af": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 90000
                 }
             ]
         ],
         "b6a2f8a5cfe2c78c746dee26": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 4400
                 }
             ]
         ],
         "3cc5f9d9ccbb41ffacb3e8f9": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 90000
                 }
             ]
         ],
         "dfcd1a2b8aefb3d55b86a0df": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "d9a8cac1b6edac29bc959d5d": [
-            [{
+            [
+                {
                     "_tpl": "57347d7224597744596b4e72",
                     "count": 2
-                }, {
+                },
+                {
                     "_tpl": "57347d8724597744596b4e76",
                     "count": 2
                 }
             ]
         ],
         "bc6ca2c2ef6aa46f3ac0fa05": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 30000
                 }
             ]
         ],
         "e9beeeced0b3cb909ef6ab4f": [
-            [{
+            [
+                {
                     "_tpl": "5e023cf8186a883be655e54f",
                     "count": 2
                 }
             ]
         ],
         "d76acd135e9606c5aa44ae60": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1300
                 }
             ]
         ],
         "dd6d3f7ecdfecd47f7d25322": [
-            [{
+            [
+                {
                     "_tpl": "5d235b4d86f7742e017bc88a",
                     "count": 5
                 }
             ]
         ],
         "74fedc1edf2226e1f33ce2bf": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 90000
                 }
             ]
         ],
         "f8f55d5ca1fd93019399d7fb": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 4200
                 }
             ]
         ],
         "fc4b0dfcfcb6ee9ffef903c2": [
-            [{
+            [
+                {
                     "_tpl": "57371f8d24597761006c6a81",
                     "count": 3
                 }
             ]
         ],
         "cd5d1e86edd1d11c4ae29e8f": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 75
                 }
             ]
         ],
         "2c063c6a7bc0f6df076cee60": [
-            [{
+            [
+                {
                     "_tpl": "59e6542b86f77411dc52a77a",
                     "count": 3
                 }
             ]
         ],
         "482d4fef762d731c600a97ea": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 105
                 }
             ]
         ],
         "bb4e0d27bfddf187408a79db": [
-            [{
+            [
+                {
                     "_tpl": "59e655cb86f77411dc52a77b",
                     "count": 6
                 }
             ]
         ],
         "94f8fb3791baa4f5acbb80dd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 75
                 }
             ]
         ],
         "254a6fb5a09ba346ada90813": [
-            [{
+            [
+                {
                     "_tpl": "5d1b39a386f774252339976f",
                     "count": 4
                 }
             ]
         ],
         "aac930d9f0f1293c50bb27ec": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 75000
                 }
             ]
         ],
         "b0da7a4cbde0d4f3d5c2bacf": [
-            [{
+            [
+                {
                     "_tpl": "560d61e84bdc2da74d8b4571",
                     "count": 3
                 }
             ]
         ],
         "41fbbf09de967378d627f968": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 855
                 }
             ]
         ],
         "85b6f03df9ecb327dbdfd6a7": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3200
                 }
             ]
         ],
         "5877e6bf1dd1e928361406c4": [
-            [{
+            [
+                {
                     "_tpl": "5d1b32c186f774252167a530",
                     "count": 5
                 }
             ]
         ],
         "d713bbbc4cc8dd73af2bd937": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 144000
                 }
             ]
         ],
         "977cb75f35769e0530fdd4dd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3000
                 }
             ]
         ],
         "f96edd4fe4f26e29b2345e56": [
-            [{
+            [
+                {
                     "_tpl": "5d0378d486f77420421a5ff4",
                     "count": 2
                 }
             ]
         ],
         "b0ce2a2ddbf1abace32836a0": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 68000
                 }
             ]
         ],
         "03de69cdaf82c89d5182df63": [
-            [{
+            [
+                {
                     "_tpl": "59e7708286f7742cbd762753",
                     "count": 3
                 }
             ]
         ],
         "0aee122fb0e3a09281697eff": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 7500
                 }
             ]
         ],
         "a4139dcac0782aaee3bd038d": [
-            [{
+            [
+                {
                     "_tpl": "5c13cef886f774072e618e82",
                     "count": 1
                 }
             ]
         ],
         "ebd3b7ec97a29dd3ccae9c84": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5600
                 }
             ]
         ],
         "4c8ddcf45edc5d3adbbd9edf": [
-            [{
+            [
+                {
                     "_tpl": "57347d7224597744596b4e72",
                     "count": 2
-                }, {
+                },
+                {
                     "_tpl": "57347d90245977448f7b7f65",
                     "count": 2
                 }
             ]
         ],
         "ff2cac4220f9dfbdbe97b5eb": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24000
                 }
             ]
         ],
         "5e2cdef9eee7633c9026fcfe": [
-            [{
+            [
+                {
                     "_tpl": "5d0375ff86f774186372f685",
                     "count": 1
-                }, {
+                },
+                {
                     "_tpl": "59e36c6f86f774176c10a2a7",
                     "count": 3
                 }
             ]
         ],
         "74db8832db8e346bffd5fe46": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 64000
                 }
             ]
         ],
         "cd1c070711aa27a77cd32f1b": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2000
                 }
             ]
         ],
         "6c4ef36ca1f6071dea1eaef0": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 6000
                 }
             ]
         ],
         "e25c5da0f9e3de58aa32ebcc": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 15000
                 }
             ]
         ],
         "2ec7bae63f35bd6be2aeb2f4": [
-            [{
+            [
+                {
                     "_tpl": "5d0376a486f7747d8050965c",
                     "count": 2
                 }
             ]
         ],
         "a58eeeaac8bdfeb3ac20c05d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 42000
                 }
             ]
         ],
         "1c45bc6bde85da1a3ac51d00": [
-            [{
+            [
+                {
                     "_tpl": "5d1b327086f7742525194449",
                     "count": 3
                 }
             ]
         ],
         "ecbf4c0367f5eb0b36f1ccdf": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 120000
                 }
             ]
         ],
         "ab5cf0b95ddc9c4f93f5bd04": [
-            [{
+            [
+                {
                     "_tpl": "5bd06f5d86f77427101ad47c",
                     "count": 3
                 }
             ]
         ],
         "57d4075f2eafaea98dcfae41": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 55000
                 }
             ]
         ],
         "31ab7e1f41ecfbfaa7f64bab": [
-            [{
+            [
+                {
                     "_tpl": "5734758f24597738025ee253",
                     "count": 3
                 }
             ]
         ],
         "5ced8db5a03f6afe5569bbb3": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 36000
                 }
             ]
         ],
         "bcc29a9fd5c39954544eabb5": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3600
                 }
             ]
         ],
         "538dfbc148f169d4c1294ceb": [
-            [{
+            [
+                {
                     "_tpl": "5d1b309586f77425227d1676",
                     "count": 3
                 }
             ]
         ],
         "dc232bbf20b811bfcc347f19": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 39000
                 }
             ]
         ],
         "76cd0aaef5bdede9d7f964d7": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1050
                 }
             ]
         ],
         "d4d6ddadea6b1fabaa08df93": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 9500
                 }
             ]
         ],
         "1d72cd9321b71e773dd77f9b": [
-            [{
+            [
+                {
                     "_tpl": "5ab8f4ff86f77431c60d91ba",
                     "count": 4
                 }
             ]
         ],
         "04ad2e8dc93c6cada0d3efdf": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 21000
                 }
             ]
         ],
         "7799bf35faafcdac4d7fad1e": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2700
                 }
             ]
         ],
         "d9b1f7643c6256e3b2d9d48f": [
-            [{
+            [
+                {
                     "_tpl": "590a3b0486f7743954552bdb",
                     "count": 5
                 }
             ]
         ],
         "b93de025c5ae0dcf4ddcc70f": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 50000
                 }
             ]
         ],
         "9dc68e0bc4bfee5eeff97dfb": [
-            [{
+            [
+                {
                     "_tpl": "575062b524597720a31c09a1",
                     "count": 4
                 }
             ]
         ],
         "f8de1e7cfad533cdafb11bcc": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 15000
                 }
             ]
         ],
         "4547c7f4e129efe87b8cadec": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1100
                 }
             ]
         ],
         "53dcbbeaf1a94d638cec299a": [
-            [{
+            [
+                {
                     "_tpl": "590a3b0486f7743954552bdb",
                     "count": 7
                 }
             ]
         ],
         "bdc81d1c0a8555706057cefe": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 72000
                 }
             ]
         ],
         "c030cb8697857ca8abadb81e": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2000
                 }
             ]
         ],
         "4e48ecaceb793ec9edbd6c7a": [
-            [{
+            [
+                {
                     "_tpl": "5c12613b86f7743bbe2c3f76",
                     "count": 1
                 }
             ]
         ],
         "9b5acf1bd712b23fc7bfdc74": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 135000
                 }
             ]
         ],
         "6e200ac32b7aa75c264d7fdc": [
-            [{
+            [
+                {
                     "_tpl": "619cbfeb6b8a1b37a54eebfa",
                     "count": 2
                 }
             ]
         ],
         "b58d3a7fdfdaafd12d35c111": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 96000
                 }
             ]
         ],
         "dfceccc7ddacec9fda862394": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1800
                 }
             ]
         ],
         "5f2eea4230cb688d19bcdffc": [
-            [{
+            [
+                {
                     "_tpl": "573603c924597764442bd9cb",
                     "count": 5
                 }
             ]
         ],
         "e1fc3c7e3e530cdc1fe9ad8f": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 330
                 }
             ]
         ],
         "dcd883de4eac0c9ceefe4e9b": [
-            [{
+            [
+                {
                     "_tpl": "59e77a2386f7742ee578960a",
                     "count": 2
                 }
             ]
         ],
         "be69cf6df3680ddbc8c0e39c": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1100
                 }
             ]
         ],
         "2edc91e27fcbcf23fbb997aa": [
-            [{
+            [
+                {
                     "_tpl": "5e023d34e8a400319a28ed44",
                     "count": 4
                 }
             ]
         ],
         "ff067fabc0caf50c8d0dd1e1": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1850
                 }
             ]
         ],
         "c923d6b01cab59a721ceacfd": [
-            [{
+            [
+                {
                     "_tpl": "5bc9be8fd4351e00334cae6e",
                     "count": 5
                 }
             ]
         ],
         "412b47756e68e3dcbab74cbb": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 19000
                 }
             ]
         ],
         "da8a2bd3c0bea312bbcd3e74": [
-            [{
+            [
+                {
                     "_tpl": "59e6658b86f77411d949b250",
                     "count": 5
                 }
             ]
         ],
         "8d694d5f50ffa2449f6f9fbb": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 700
                 }
             ]
         ],
         "dfcedcf85a228fa9c7d7d114": [
-            [{
+            [
+                {
                     "_tpl": "5e2af29386f7746d4159f077",
                     "count": 4
                 }
             ]
         ],
         "af0feddae5728df8d5e7c2ca": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 54000
                 }
             ]
         ],
         "5b8e8cea43272d4e44aaf540": [
-            [{
+            [
+                {
                     "_tpl": "5b4329075acfc400153b78ff",
                     "count": 4
                 }
             ]
         ],
         "07e8bdbc54ffec30531821f8": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 16000
                 }
             ]
         ],
         "f9052d17426eab4a97c8cea2": [
-            [{
+            [
+                {
                     "_tpl": "5b43575a86f77424f443fe62",
                     "count": 4
                 }
             ]
         ],
         "2008e929887d0fee68eef7dc": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 84000
                 }
             ]
         ],
         "bdff25636c0c9bcc4dddd7f6": [
-            [{
+            [
+                {
                     "_tpl": "5d1b327086f7742525194449",
                     "count": 5
                 }
             ]
         ],
         "b51a839b94a75a787a208dbf": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 206000
                 }
             ]
         ],
         "61f7bef9c04afa27ae91fcfd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 14000
                 }
             ]
         ],
         "2a3def3e8473ea8ad3d7ee9a": [
-            [{
+            [
+                {
                     "_tpl": "5fc382b6d6fa9c00c571bbc3",
                     "count": 15
                 }
             ]
         ],
         "bfcb182d41414b1af00c5aa4": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1700
                 }
             ]
         ],
         "0fe7e0e2c768a24dfbdf4bbb": [
-            [{
+            [
+                {
                     "_tpl": "5fc275cf85fd526b824a571a",
                     "count": 5
                 }
             ]
         ],
         "66ffc62dc5bdad9cf3fc9e78": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 4500
                 }
             ]
         ],
         "1eb98bc6bd7fa14adeaae79b": [
-            [{
+            [
+                {
                     "_tpl": "5fc382c1016cce60e8341b20",
                     "count": 4
                 }
             ]
         ],
         "adda4698b69d08ccecab2468": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 700
                 }
             ]
         ],
         "d0da2cfbbb47e16fbcafc761": [
-            [{
+            [
+                {
                     "_tpl": "56742c284bdc2d98058b456d",
                     "count": 1
                 }
             ]
         ],
         "fbaccb9eae1be092833ec45d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 780
                 }
             ]
         ],
         "d4bf97cfacae69bfd1c75636": [
-            [{
+            [
+                {
                     "_tpl": "5bc9c29cd4351e003562b8a3",
                     "count": 6
                 }
             ]
         ],
         "dcde076bf069b7efde4bfcfe": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 25500
                 }
             ]
         ],
         "01b6dd97d9e8d2bee3fdf73c": [
-            [{
+            [
+                {
                     "_tpl": "590c651286f7741e566b6461",
                     "count": 3
                 }
             ]
         ],
         "ae4fcda9fedd3afa9ffeeaeb": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 57000
                 }
             ]
         ],
         "4dafe80ace8bbd86c85d0fde": [
-            [{
+            [
+                {
                     "_tpl": "5bc9b355d4351e6d1509862a",
                     "count": 1
                 }
             ]
         ],
         "ca3dc4093fc1ae5683f89e4f": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 28000
                 }
             ]
         ],
         "adec1bf1d41f0cf2f4afe3ae": [
-            [{
+            [
+                {
                     "_tpl": "590c5c9f86f77477c91c36e7",
                     "count": 1
                 }
             ]
         ],
         "98caede86cabc99dee96a95c": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 20000
                 }
             ]
         ],
         "1cbd1cca1aab6f1fcb50fd8a": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2000
                 }
             ]
         ],
         "f5ddeb8ccfdc7dbaec7fbf18": [
-            [{
+            [
+                {
                     "_tpl": "61bf83814088ec1a363d7097",
                     "count": 6
                 }
             ]
         ],
         "f2eacf53404dbc5a62b7b1ad": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 160000
                 }
             ]
         ],
         "c51bb3702304ece7edcd76dd": [
-            [{
+            [
+                {
                     "_tpl": "573477e124597737dd42e191",
                     "count": 6
                 }
             ]
         ],
         "aad9edc3287b4ce81e9707ca": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 27000
                 }
             ]
         ],
         "70de7dfe8e6b0ed0794e2d19": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "e4ded52bfbe5b42c294f0ffe": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 250
                 }
             ]
         ],
         "3fe2f21b9b0d86dff054ffe4": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "be48b7ccd293d9f2e5546e8d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 225
                 }
             ]
         ],
         "f65fa316c9cb7fd50034f7cb": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "ada484f2dcba351b1ede85f0": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 180
                 }
             ]
         ],
         "bcd8abaf2db0f2bdc8ddbdc6": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "fbe194db904dd12abc8c4a9f": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 10500
                 }
             ]
         ],
         "058da8bb6cea515b80eabf4b": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "aac9cfafd213af399be3722d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 19000
                 }
             ]
         ],
         "194a1e97f6d112880c100284": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "fa2dac4fadacaaafec31cbde": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 21000
                 }
             ]
         ],
         "d37f2c22c97cb77aa78ddacf": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "4e80ce2f131e3305dc6c5dea": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 25500
                 }
             ]
         ],
         "8ee57a37dfdc46cb2ae27fcc": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "dbe8dd4dcfec2cdbdf6ecf2a": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 25500
                 }
             ]
         ],
         "fbade5bda9fe6bb2a236dd1f": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "b1e20be1e2ea02ee63d6fbd1": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 28500
                 }
             ]
         ],
         "a55fcbaa1ab2ca7ebfceca03": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "0ccb05c2c9ba1a5959c324d1": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24500
                 }
             ]
         ],
         "e781e5573e2c5c3ce62aaba2": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "f7bb73f55d746cfbf1a5476b": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24500
                 }
             ]
         ],
         "eab787b9fb1dd688fbc3e267": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "5eddfef14fbcef75abb19cf2": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60000
                 }
             ]
         ],
         "ee2a5e834ba218c63dacbbeb": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "8b154d0ef5be36aec1c5a388": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60000
                 }
             ]
         ],
         "cc0ad6e59c08ac28ed713ebb": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "6b4c4e83bbffd4e6dcdfb5e8": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 55000
                 }
             ]
         ],
         "2aaec2a0f01689f75c7d327b": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "ad13ca88ce67db71cac9bac9": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 81000
                 }
             ]
         ],
         "8d1cbe53be42e0ce71ebb90a": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "af5f3cfda9449b2b7befc5d1": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 73000
                 }
             ]
         ],
         "b722a58fb68eedcaec08388d": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "cd1d3f7fd0ef4b7a42f9734c": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 84000
                 }
             ]
         ],
         "dbe67442de3cf36b0e2acdd0": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "bb3090d5b8e9cbf2fa977bfd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 174000
                 }
             ]
         ],
         "9f73e7bb5ff3fae70beecc63": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "4cb54d4faefafe34b2d0fba0": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 43000
                 }
             ]
         ],
         "05ab0dd0f83897027adb14b4": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "dfebbc2c79d7da7caee7f46e": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 57000
                 }
             ]
         ],
         "6bf919996e3f7d9442b4f4bf": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "d589abf8bd03bbbf7fd9fd58": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 39000
                 }
             ]
         ],
         "2464cf8a8e8a1fbfd0f9eba0": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "d3b6abcadbdfb0c1deeeaf4c": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 78000
                 }
             ]
         ],
         "fe7eb0f3e1ee7dbd49dbed3a": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "638dae2266adbbef13f6a57d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 80000
                 }
             ]
         ],
         "003c2c9db2b8dde27cc21c7c": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "bf8a68cc1c5b35a8a27c7eed": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 38500
                 }
             ]
         ],
         "f02daaee0df5d4e6bb4cfafd": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "0a6c89c0beff4a99a1218348": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 135000
                 }
             ]
         ],
         "40bcd1980b5274f896bbecb7": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 9000
                 }
             ]
         ],
         "0e3e5dcab535dab6f281dc5c": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5400
                 }
             ]
         ],
         "5b1c1f7b7d3ea76eb4f868ae": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5400
                 }
             ]
         ],
         "8a624d589119c4d2a24de9b5": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 4200
                 }
             ]
         ],
         "79b74f9a54adcd8671d3eda0": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 15500
                 }
             ]
         ],
         "f42ab266eb5d079fef2f8ffc": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5300
                 }
             ]
         ],
         "a331bf1a7c88cdcbe0d7a957": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1600
                 }
             ]
         ],
         "eaaa847ac7c8cebfb5b1a59b": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3200
                 }
             ]
         ]
     },
-    "items": [{
+    "items": [
+        {
             "_id": "a4139dcac0782aaee3bd038d",
             "_tpl": "5ab8f04f86f774585f4237d8",
             "parentId": "hideout",
@@ -1280,7 +1465,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "03de69cdaf82c89d5182df63",
             "_tpl": "5ab8ee7786f7742d8f33f0b9",
             "parentId": "hideout",
@@ -1291,7 +1477,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "cf5af2b57b78d9cc8b0e3c9f",
             "_tpl": "56e33680d2720be2748b4576",
             "parentId": "hideout",
@@ -1302,7 +1489,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "5b8e8cea43272d4e44aaf540",
             "_tpl": "5f5e45cc5021ce62144be7aa",
             "parentId": "hideout",
@@ -1313,7 +1501,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "eaaa4f07dde2f2931f8bdde4",
             "_tpl": "544a5cde4bdc2d39388b456b",
             "parentId": "hideout",
@@ -1324,7 +1513,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "1d72cd9321b71e773dd77f9b",
             "_tpl": "5ca20d5986f774331e7c9602",
             "parentId": "hideout",
@@ -1335,7 +1525,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "adec1bf1d41f0cf2f4afe3ae",
             "_tpl": "60a2828e8689911a226117f9",
             "parentId": "hideout",
@@ -1346,7 +1537,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d4bf97cfacae69bfd1c75636",
             "_tpl": "6034d103ca006d2dca39b3f0",
             "parentId": "hideout",
@@ -1357,7 +1549,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "4dafe80ace8bbd86c85d0fde",
             "_tpl": "60a272cc93ef783291411d8e",
             "parentId": "hideout",
@@ -1368,7 +1561,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c51bb3702304ece7edcd76dd",
             "_tpl": "618cfae774bb2d036a049e7c",
             "parentId": "hideout",
@@ -1379,7 +1573,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d9b1f7643c6256e3b2d9d48f",
             "_tpl": "5d5d940f86f7742797262046",
             "parentId": "hideout",
@@ -1390,7 +1585,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c923d6b01cab59a721ceacfd",
             "_tpl": "5e4abc6786f77406812bd572",
             "parentId": "hideout",
@@ -1401,7 +1597,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a3ee33b02afcd42acc10a0fc",
             "_tpl": "545cdae64bdc2d39198b4568",
             "parentId": "hideout",
@@ -1412,7 +1609,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "5e2cdef9eee7633c9026fcfe",
             "_tpl": "5b44c6ae86f7742d1627baea",
             "parentId": "hideout",
@@ -1423,7 +1621,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ab5cf0b95ddc9c4f93f5bd04",
             "_tpl": "5c0e805e86f774683f3dd637",
             "parentId": "hideout",
@@ -1434,7 +1633,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "01b6dd97d9e8d2bee3fdf73c",
             "_tpl": "6034d2d697633951dc245ea6",
             "parentId": "hideout",
@@ -1445,7 +1645,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f9052d17426eab4a97c8cea2",
             "_tpl": "5f5e46b96bdad616ad46d613",
             "parentId": "hideout",
@@ -1456,7 +1657,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "254a6fb5a09ba346ada90813",
             "_tpl": "59e763f286f7742ee57895da",
             "parentId": "hideout",
@@ -1467,7 +1669,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "1c45bc6bde85da1a3ac51d00",
             "_tpl": "5c0e774286f77468413cc5b2",
             "parentId": "hideout",
@@ -1478,7 +1681,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "4e48ecaceb793ec9edbd6c7a",
             "_tpl": "5df8a4d786f77412672a1e3b",
             "parentId": "hideout",
@@ -1489,7 +1693,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ebd3b7ec97a29dd3ccae9c84",
             "_tpl": "5ab8f04f86f774585f4237d8",
             "parentId": "hideout",
@@ -1500,7 +1705,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "0aee122fb0e3a09281697eff",
             "_tpl": "5ab8ee7786f7742d8f33f0b9",
             "parentId": "hideout",
@@ -1511,7 +1717,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "62eba6bffdd622a4f6aadf45",
             "_tpl": "56e33680d2720be2748b4576",
             "parentId": "hideout",
@@ -1522,7 +1729,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "07e8bdbc54ffec30531821f8",
             "_tpl": "5f5e45cc5021ce62144be7aa",
             "parentId": "hideout",
@@ -1533,7 +1741,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b92dab04f7c919f620a2bec5",
             "_tpl": "544a5cde4bdc2d39388b456b",
             "parentId": "hideout",
@@ -1544,7 +1753,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "04ad2e8dc93c6cada0d3efdf",
             "_tpl": "5ca20d5986f774331e7c9602",
             "parentId": "hideout",
@@ -1555,7 +1765,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "98caede86cabc99dee96a95c",
             "_tpl": "60a2828e8689911a226117f9",
             "parentId": "hideout",
@@ -1566,7 +1777,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "dcde076bf069b7efde4bfcfe",
             "_tpl": "6034d103ca006d2dca39b3f0",
             "parentId": "hideout",
@@ -1577,7 +1789,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ca3dc4093fc1ae5683f89e4f",
             "_tpl": "60a272cc93ef783291411d8e",
             "parentId": "hideout",
@@ -1588,7 +1801,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "aad9edc3287b4ce81e9707ca",
             "_tpl": "618cfae774bb2d036a049e7c",
             "parentId": "hideout",
@@ -1599,7 +1813,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b93de025c5ae0dcf4ddcc70f",
             "_tpl": "5d5d940f86f7742797262046",
             "parentId": "hideout",
@@ -1610,7 +1825,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "412b47756e68e3dcbab74cbb",
             "_tpl": "5e4abc6786f77406812bd572",
             "parentId": "hideout",
@@ -1621,7 +1837,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d467fa8da6ff089edbfa7fe1",
             "_tpl": "545cdae64bdc2d39198b4568",
             "parentId": "hideout",
@@ -1632,7 +1849,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "74db8832db8e346bffd5fe46",
             "_tpl": "5b44c6ae86f7742d1627baea",
             "parentId": "hideout",
@@ -1643,7 +1861,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "57d4075f2eafaea98dcfae41",
             "_tpl": "5c0e805e86f774683f3dd637",
             "parentId": "hideout",
@@ -1654,7 +1873,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ae4fcda9fedd3afa9ffeeaeb",
             "_tpl": "6034d2d697633951dc245ea6",
             "parentId": "hideout",
@@ -1665,7 +1885,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "2008e929887d0fee68eef7dc",
             "_tpl": "5f5e46b96bdad616ad46d613",
             "parentId": "hideout",
@@ -1676,7 +1897,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "aac930d9f0f1293c50bb27ec",
             "_tpl": "59e763f286f7742ee57895da",
             "parentId": "hideout",
@@ -1687,7 +1909,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ecbf4c0367f5eb0b36f1ccdf",
             "_tpl": "5c0e774286f77468413cc5b2",
             "parentId": "hideout",
@@ -1698,7 +1921,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "9b5acf1bd712b23fc7bfdc74",
             "_tpl": "5df8a4d786f77412672a1e3b",
             "parentId": "hideout",
@@ -1709,7 +1933,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fc4b0dfcfcb6ee9ffef903c2",
             "_tpl": "59e6542b86f77411dc52a77a",
             "parentId": "hideout",
@@ -1720,7 +1945,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "2c063c6a7bc0f6df076cee60",
             "_tpl": "59e655cb86f77411dc52a77b",
             "parentId": "hideout",
@@ -1731,7 +1957,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bb4e0d27bfddf187408a79db",
             "_tpl": "59e6658b86f77411d949b250",
             "parentId": "hideout",
@@ -1742,7 +1969,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "da8a2bd3c0bea312bbcd3e74",
             "_tpl": "5f0596629e22f464da6bbdd9",
             "parentId": "hideout",
@@ -1753,7 +1981,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "cd5d1e86edd1d11c4ae29e8f",
             "_tpl": "59e6542b86f77411dc52a77a",
             "parentId": "hideout",
@@ -1764,7 +1993,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "482d4fef762d731c600a97ea",
             "_tpl": "59e655cb86f77411dc52a77b",
             "parentId": "hideout",
@@ -1775,7 +2005,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "94f8fb3791baa4f5acbb80dd",
             "_tpl": "59e6658b86f77411d949b250",
             "parentId": "hideout",
@@ -1786,7 +2017,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "8d694d5f50ffa2449f6f9fbb",
             "_tpl": "5f0596629e22f464da6bbdd9",
             "parentId": "hideout",
@@ -1797,7 +2029,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "5f2eea4230cb688d19bcdffc",
             "_tpl": "5e023cf8186a883be655e54f",
             "parentId": "hideout",
@@ -1808,7 +2041,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e9beeeced0b3cb909ef6ab4f",
             "_tpl": "5887431f2459777e1612938f",
             "parentId": "hideout",
@@ -1819,7 +2053,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "457322ec97ddfa2bd5c5bdd7",
             "_tpl": "560d61e84bdc2da74d8b4571",
             "parentId": "hideout",
@@ -1830,7 +2065,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a707e551bf09eed6a32da74a",
             "_tpl": "560d75f54bdc2da74d8b4573",
             "parentId": "hideout",
@@ -1841,7 +2077,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "9a6f2dcaeeaed51a70d96c60",
             "_tpl": "560d61e84bdc2da74d8b4571",
             "parentId": "a707e551bf09eed6a32da74a",
@@ -1850,7 +2087,8 @@
             "upd": {
                 "StackObjectsCount": 20
             }
-        }, {
+        },
+        {
             "_id": "6c4ef36ca1f6071dea1eaef0",
             "_tpl": "5bae13ded4351e44f824bf38",
             "parentId": "hideout",
@@ -1861,7 +2099,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b0da7a4cbde0d4f3d5c2bacf",
             "_tpl": "59e77a2386f7742ee578960a",
             "parentId": "hideout",
@@ -1872,7 +2111,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d4d6ddadea6b1fabaa08df93",
             "_tpl": "5c88f24b2e22160bc12c69a6",
             "parentId": "hideout",
@@ -1883,7 +2123,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "dcd883de4eac0c9ceefe4e9b",
             "_tpl": "5e023d34e8a400319a28ed44",
             "parentId": "hideout",
@@ -1894,7 +2135,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "2edc91e27fcbcf23fbb997aa",
             "_tpl": "5e023d48186a883be655e551",
             "parentId": "hideout",
@@ -1905,7 +2147,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e1fc3c7e3e530cdc1fe9ad8f",
             "_tpl": "5e023cf8186a883be655e54f",
             "parentId": "hideout",
@@ -1916,7 +2159,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d76acd135e9606c5aa44ae60",
             "_tpl": "5887431f2459777e1612938f",
             "parentId": "hideout",
@@ -1927,7 +2171,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "8aa340a5caf5b3dc3bd6f1e0",
             "_tpl": "560d61e84bdc2da74d8b4571",
             "parentId": "hideout",
@@ -1938,7 +2183,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "41fbbf09de967378d627f968",
             "_tpl": "59e77a2386f7742ee578960a",
             "parentId": "hideout",
@@ -1949,7 +2195,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "be69cf6df3680ddbc8c0e39c",
             "_tpl": "5e023d34e8a400319a28ed44",
             "parentId": "hideout",
@@ -1960,7 +2207,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ff067fabc0caf50c8d0dd1e1",
             "_tpl": "5e023d48186a883be655e551",
             "parentId": "hideout",
@@ -1971,7 +2219,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d0da2cfbbb47e16fbcafc761",
             "_tpl": "5fc382c1016cce60e8341b20",
             "parentId": "hideout",
@@ -1982,7 +2231,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "1eb98bc6bd7fa14adeaae79b",
             "_tpl": "5fc382b6d6fa9c00c571bbc3",
             "parentId": "hideout",
@@ -1993,7 +2243,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "2a3def3e8473ea8ad3d7ee9a",
             "_tpl": "5fc275cf85fd526b824a571a",
             "parentId": "hideout",
@@ -2004,7 +2255,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "0fe7e0e2c768a24dfbdf4bbb",
             "_tpl": "5fc382a9d724d907e2077dab",
             "parentId": "hideout",
@@ -2015,7 +2267,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fbaccb9eae1be092833ec45d",
             "_tpl": "5fc382c1016cce60e8341b20",
             "parentId": "hideout",
@@ -2026,7 +2279,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "adda4698b69d08ccecab2468",
             "_tpl": "5fc382b6d6fa9c00c571bbc3",
             "parentId": "hideout",
@@ -2037,7 +2291,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bfcb182d41414b1af00c5aa4",
             "_tpl": "5fc275cf85fd526b824a571a",
             "parentId": "hideout",
@@ -2048,7 +2303,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "66ffc62dc5bdad9cf3fc9e78",
             "_tpl": "5fc382a9d724d907e2077dab",
             "parentId": "hideout",
@@ -2059,7 +2315,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "9dc68e0bc4bfee5eeff97dfb",
             "_tpl": "5de652c31b7e3716273428be",
             "parentId": "hideout",
@@ -2070,32 +2327,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b9a674eebbfc0a0804ed7f2c",
             "_tpl": "5de653abf76fdc1ce94a5a2a",
             "parentId": "9dc68e0bc4bfee5eeff97dfb",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "b22eadc8f42be036a16e51c5",
             "_tpl": "5de655be4a9f347bc92edb88",
             "parentId": "9dc68e0bc4bfee5eeff97dfb",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "506aeb9bdce5e6cdd76bcf70",
             "_tpl": "5de65547883dde217541644b",
             "parentId": "9dc68e0bc4bfee5eeff97dfb",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "8d7331caafee9ef437c748ea",
             "_tpl": "5de6556a205ddc616a6bc4f7",
             "parentId": "506aeb9bdce5e6cdd76bcf70",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "8f2ced5bedf1fbb87aaf9f4c",
             "_tpl": "5de6558e9f98ac2bc65950fc",
             "parentId": "9dc68e0bc4bfee5eeff97dfb",
             "slotId": "mod_mount"
-        }, {
+        },
+        {
             "_id": "4c8ddcf45edc5d3adbbd9edf",
             "_tpl": "5ae08f0a5acfc408fb1398a1",
             "parentId": "hideout",
@@ -2106,32 +2369,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7f7b9dfe7b94466fd0b32aa6",
             "_tpl": "5ae0973a5acfc4001562206c",
             "parentId": "4c8ddcf45edc5d3adbbd9edf",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "e09bdcacaef4bdb17c2ceecc",
             "_tpl": "5ae096d95acfc400185c2c81",
             "parentId": "4c8ddcf45edc5d3adbbd9edf",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "d6f7d1bf85eb8bea45b548df",
             "_tpl": "5ae09bff5acfc4001562219d",
             "parentId": "4c8ddcf45edc5d3adbbd9edf",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "fadc04ab3bee00bc7d21c404",
             "_tpl": "5ae099875acfc4001714e593",
             "parentId": "d6f7d1bf85eb8bea45b548df",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "bc344d05868b33f79bcdcc2d",
             "_tpl": "5ae099925acfc4001a5fc7b3",
             "parentId": "d6f7d1bf85eb8bea45b548df",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "d9a8cac1b6edac29bc959d5d",
             "_tpl": "587e02ff24597743df3deaeb",
             "parentId": "hideout",
@@ -2142,47 +2411,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "6670e1e2622e80dbf3056c2f",
             "_tpl": "587e0531245977466077a0f7",
             "parentId": "d9a8cac1b6edac29bc959d5d",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "6670e1e2622e80dbf3056c30",
             "_tpl": "634eff66517ccc8a960fc735",
             "parentId": "d9a8cac1b6edac29bc959d5d",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "6670e1e2622e80dbf3056c31",
             "_tpl": "634f05a21f9f536910079b56",
             "parentId": "6670e1e2622e80dbf3056c30",
             "slotId": "mod_mount_000"
-        }, {
+        },
+        {
             "_id": "6670e1e2622e80dbf3056c32",
             "_tpl": "634f036a517ccc8a960fc746",
             "parentId": "6670e1e2622e80dbf3056c31",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "6670e1e2622e80dbf3056c33",
             "_tpl": "634f03d40384a3ba4f06f874",
             "parentId": "6670e1e2622e80dbf3056c32",
             "slotId": "mod_mount_000"
-        }, {
+        },
+        {
             "_id": "6670e1e2622e80dbf3056c34",
             "_tpl": "574db213245977459a2f3f5d",
             "parentId": "6670e1e2622e80dbf3056c31",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "6670e1e2622e80dbf3056c35",
             "_tpl": "587df3a12459772c28142567",
             "parentId": "d9a8cac1b6edac29bc959d5d",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "6670e1e2622e80dbf3056c36",
             "_tpl": "634f06262e5def262d0b30ca",
             "parentId": "d9a8cac1b6edac29bc959d5d",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "538dfbc148f169d4c1294ceb",
             "_tpl": "5c501a4d2e221602b412b540",
             "parentId": "hideout",
@@ -2193,32 +2471,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "eec55cdba1af63daa1ede81e",
             "_tpl": "5c5039be2e221602b177c9ff",
             "parentId": "538dfbc148f169d4c1294ceb",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "c4fcebd9fc4cdd8478cf5daa",
             "_tpl": "5c503d0a2e221602b542b7ef",
             "parentId": "538dfbc148f169d4c1294ceb",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "4b0e6947546a3cdefe78f5e4",
             "_tpl": "5c503b1c2e221602b21d6e9d",
             "parentId": "538dfbc148f169d4c1294ceb",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "8cb42a7a07f689dcbebe1e52",
             "_tpl": "5c503af12e221602b177ca02",
             "parentId": "538dfbc148f169d4c1294ceb",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "e6cb1491044aee8cffb27b46",
             "_tpl": "5c503ac82e221602b21d6e9a",
             "parentId": "538dfbc148f169d4c1294ceb",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "4547c7f4e129efe87b8cadec",
             "_tpl": "5de653abf76fdc1ce94a5a2a",
             "parentId": "hideout",
@@ -2229,7 +2513,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "76cd0aaef5bdede9d7f964d7",
             "_tpl": "5c503ac82e221602b21d6e9a",
             "parentId": "hideout",
@@ -2240,7 +2525,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "2ec7bae63f35bd6be2aeb2f4",
             "_tpl": "5bfea6e90db834001b7347f3",
             "parentId": "hideout",
@@ -2251,22 +2537,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "cc8f8f7c0a8bc8f6ff8a8edd",
             "_tpl": "5bfea7ad0db834001c38f1ee",
             "parentId": "2ec7bae63f35bd6be2aeb2f4",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "02e62cdd906befce5a7a6bcc",
             "_tpl": "5bfeb32b0db834001a6694d9",
             "parentId": "2ec7bae63f35bd6be2aeb2f4",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "d074c3ecaa4b7abeeae4b4ce",
             "_tpl": "5bfebc320db8340019668d79",
             "parentId": "2ec7bae63f35bd6be2aeb2f4",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "53dcbbeaf1a94d638cec299a",
             "_tpl": "5df24cf80dee1b22f862e9bc",
             "parentId": "hideout",
@@ -2277,72 +2567,86 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "94c1dfb4a4c92e93b00eab63",
             "_tpl": "5df25b6c0b92095fd441e4cf",
             "parentId": "53dcbbeaf1a94d638cec299a",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "bdcba0eea275eaa07e6ffc9f",
             "_tpl": "5df256570dee1b22f862e9c4",
             "parentId": "53dcbbeaf1a94d638cec299a",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "ece5f2d24fb2f06ff86fcc0e",
             "_tpl": "5df35e7f2a78646d96665dd4",
             "parentId": "bdcba0eea275eaa07e6ffc9f",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "acf3ef4a85ed32fecdc322fd",
             "_tpl": "5df35e59c41b2312ea3334d5",
             "parentId": "53dcbbeaf1a94d638cec299a",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "edcb4fa5a5bbdeabda5d11bd",
             "_tpl": "5df25d3bfd6b4e6e2276dc9a",
             "parentId": "acf3ef4a85ed32fecdc322fd",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "35c6a4bb5e3d66a57cbbeb15",
             "_tpl": "5df35eb2b11454561e3923e2",
             "parentId": "edcb4fa5a5bbdeabda5d11bd",
             "slotId": "mod_mount_000"
-        }, {
+        },
+        {
             "_id": "bff4c8d49fd75ec669344bd7",
             "_tpl": "5df35eb2b11454561e3923e2",
             "parentId": "edcb4fa5a5bbdeabda5d11bd",
             "slotId": "mod_mount_001"
-        }, {
+        },
+        {
             "_id": "f8b5ad9c9afc9838dfe40fdb",
             "_tpl": "5df35ea9c41b2312ea3334d8",
             "parentId": "edcb4fa5a5bbdeabda5d11bd",
             "slotId": "mod_mount_002"
-        }, {
+        },
+        {
             "_id": "76f6fafdeabda3d7ac800cc5",
             "_tpl": "5df35eb2b11454561e3923e2",
             "parentId": "edcb4fa5a5bbdeabda5d11bd",
             "slotId": "mod_mount_003"
-        }, {
+        },
+        {
             "_id": "1d7a3d67d70eb782becd0dce",
             "_tpl": "5df36948bb49d91fb446d5ad",
             "parentId": "edcb4fa5a5bbdeabda5d11bd",
             "slotId": "mod_foregrip"
-        }, {
+        },
+        {
             "_id": "b0fa9fb8cb423fe835fc7d3f",
             "_tpl": "5df38a5fb74cd90030650cb6",
             "parentId": "acf3ef4a85ed32fecdc322fd",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "eeb1a114dced5c09587df0b2",
             "_tpl": "5df35ddddfc58d14537c2036",
             "parentId": "acf3ef4a85ed32fecdc322fd",
             "slotId": "mod_stock_axis"
-        }, {
+        },
+        {
             "_id": "76247094fd8e73c4a4c7b8fc",
             "_tpl": "5df35e970b92095fd441e4d2",
             "parentId": "53dcbbeaf1a94d638cec299a",
             "slotId": "mod_mount"
-        }, {
+        },
+        {
             "_id": "fb52f9d44e810c41abfed05c",
             "_tpl": "55801eed4bdc2d89578b4588",
             "parentId": "hideout",
@@ -2353,37 +2657,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d29",
             "_tpl": "559ba5b34bdc2d1f1a8b4582",
             "parentId": "fb52f9d44e810c41abfed05c",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d2a",
             "_tpl": "56083e1b4bdc2dc8488b4572",
             "parentId": "fb52f9d44e810c41abfed05c",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d2b",
             "_tpl": "56083eab4bdc2d26448b456a",
             "parentId": "fb52f9d44e810c41abfed05c",
             "slotId": "mod_tactical"
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d2c",
             "_tpl": "560e620e4bdc2d724b8b456b",
             "parentId": "fb52f9d44e810c41abfed05c",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d2f",
             "_tpl": "61faa91878830f069b6b7967",
             "parentId": "fb52f9d44e810c41abfed05c",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d2e",
             "_tpl": "56ea8222d2720b69698b4567",
             "parentId": "6670e6bb622e80dbf3056d2f",
             "slotId": "mod_bipod"
-        }, {
+        },
+        {
             "_id": "dd6d3f7ecdfecd47f7d25322",
             "_tpl": "588892092459774ac91d4b11",
             "parentId": "hideout",
@@ -2394,37 +2705,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e8c0defe3ee1b99e151df88e",
             "_tpl": "5888988e24597752fe43a6fa",
             "parentId": "dd6d3f7ecdfecd47f7d25322",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "c5ff4a6fed96f59fbdf82f96",
             "_tpl": "5888956924597752983e182d",
             "parentId": "dd6d3f7ecdfecd47f7d25322",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "cd788634830c8ac92d83a75f",
             "_tpl": "5888996c24597754281f9419",
             "parentId": "c5ff4a6fed96f59fbdf82f96",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "bdf332a9f17fae262fdecc9f",
             "_tpl": "5888976c24597754281f93f5",
             "parentId": "c5ff4a6fed96f59fbdf82f96",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "c2d2dfba6c879cb0bc75fdd7",
             "_tpl": "57c55f172459772d27602381",
             "parentId": "dd6d3f7ecdfecd47f7d25322",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "f5e83423d0ef0122e64fff6b",
             "_tpl": "58889d0c2459775bc215d981",
             "parentId": "dd6d3f7ecdfecd47f7d25322",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "f8f55d5ca1fd93019399d7fb",
             "_tpl": "5888988e24597752fe43a6fa",
             "parentId": "hideout",
@@ -2435,7 +2753,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7799bf35faafcdac4d7fad1e",
             "_tpl": "5ce69cbad7f00c00b61c5098",
             "parentId": "hideout",
@@ -2446,7 +2765,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c030cb8697857ca8abadb81e",
             "_tpl": "5df25b6c0b92095fd441e4cf",
             "parentId": "hideout",
@@ -2457,7 +2777,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e4dcd1aae831dae84eca05cf",
             "_tpl": "559ba5b34bdc2d1f1a8b4582",
             "parentId": "hideout",
@@ -2468,7 +2789,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "6e200ac32b7aa75c264d7fdc",
             "_tpl": "5df8ce05b11454561e39243b",
             "parentId": "hideout",
@@ -2479,67 +2801,80 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "80aa75ab820ad3e892d74d8a",
             "_tpl": "55d4b9964bdc2d1d4e8b456e",
             "parentId": "6e200ac32b7aa75c264d7fdc",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "9cb0b801fa96620ac9460eca",
             "_tpl": "5df8f541c41b2312ea3335e3",
             "parentId": "6e200ac32b7aa75c264d7fdc",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "ccfe9a0cbc4bd7bebd89e16e",
             "_tpl": "5649be884bdc2d79388b4577",
             "parentId": "6e200ac32b7aa75c264d7fdc",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "fafe18face50dbadcc1ce873",
             "_tpl": "5ae30c9a5acfc408fb139a03",
             "parentId": "ccfe9a0cbc4bd7bebd89e16e",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "7c9d4b8fd1d5eda76af48eca",
             "_tpl": "5df8e4080b92095fd441e594",
             "parentId": "6e200ac32b7aa75c264d7fdc",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "5ad750e6debf0bcd04f3ddd2",
             "_tpl": "5df917564a9f347bc92edca3",
             "parentId": "7c9d4b8fd1d5eda76af48eca",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "efaefbaf8a51782e2ac2db19",
             "_tpl": "5dfa3cd1b33c0951220c079b",
             "parentId": "5ad750e6debf0bcd04f3ddd2",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "6de6673521a024e920eca5cb",
             "_tpl": "5dfa3d45dfc58d14537c20b0",
             "parentId": "5ad750e6debf0bcd04f3ddd2",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "7b4baff6ed264b3ee802fefd",
             "_tpl": "5df916dfbb49d91fb446d6b9",
             "parentId": "7c9d4b8fd1d5eda76af48eca",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "9e2cff12949b6ef8ab8c9de7",
             "_tpl": "5dfa3d950dee1b22f862eae0",
             "parentId": "7b4baff6ed264b3ee802fefd",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "62f6bb7e7ece58fbef1a5218",
             "_tpl": "5dfa3d7ac41b2312ea33362a",
             "parentId": "7c9d4b8fd1d5eda76af48eca",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "adde9d228b9db55fafaebe2d",
             "_tpl": "5df8e053bb49d91fb446d6a6",
             "parentId": "6e200ac32b7aa75c264d7fdc",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "dfcedcf85a228fa9c7d7d114",
             "_tpl": "5f2a9575926fd9352339381f",
             "parentId": "hideout",
@@ -2550,37 +2885,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ffeabacbab29d415f8ddf68f",
             "_tpl": "5b099ac65acfc400186331e1",
             "parentId": "dfcedcf85a228fa9c7d7d114",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "cccef2ddc1b52f4c612de70d",
             "_tpl": "5f2aa46b878ef416f538b567",
             "parentId": "dfcedcf85a228fa9c7d7d114",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "aac54f2db9aeac23f4acf2c3",
             "_tpl": "5f2aa4464b50c14bcf07acdb",
             "parentId": "cccef2ddc1b52f4c612de70d",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "bb71b3c8a0cd89daefcd899f",
             "_tpl": "5f2aa47a200e2c0ee46efa71",
             "parentId": "dfcedcf85a228fa9c7d7d114",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "57ece36a58ad46e9ab26bcf9",
             "_tpl": "5f2aa493cd375f14e15eea72",
             "parentId": "bb71b3c8a0cd89daefcd899f",
             "slotId": "mod_mount_000"
-        }, {
+        },
+        {
             "_id": "aae2d97fa147d4fbadb477ee",
             "_tpl": "5f2aa49f9b44de6b1b4e68d4",
             "parentId": "dfcedcf85a228fa9c7d7d114",
             "slotId": "mod_mount"
-        }, {
+        },
+        {
             "_id": "f96edd4fe4f26e29b2345e56",
             "_tpl": "5aafa857e5b5b00018480968",
             "parentId": "hideout",
@@ -2591,42 +2933,50 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e41b0cd672b14efc069adc7e",
             "_tpl": "5aaf8a0be5b5b00015693243",
             "parentId": "f96edd4fe4f26e29b2345e56",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "aaceab9b55b15af4df5ddbc1",
             "_tpl": "5aaf8e43e5b5b00015693246",
             "parentId": "f96edd4fe4f26e29b2345e56",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "bfecef02bef664d56393994e",
             "_tpl": "5ab24ef9e5b5b00fe93c9209",
             "parentId": "aaceab9b55b15af4df5ddbc1",
             "slotId": "mod_mount"
-        }, {
+        },
+        {
             "_id": "d5e81ccbdec55ab1bee9ae51",
             "_tpl": "5aaf9d53e5b5b00015042a52",
             "parentId": "f96edd4fe4f26e29b2345e56",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "3e8823fb017a0ad36cee534a",
             "_tpl": "5aafa1c2e5b5b00015042a56",
             "parentId": "d5e81ccbdec55ab1bee9ae51",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "29e2ed2da554ebb731fefbac",
             "_tpl": "5aafa49ae5b5b00015042a58",
             "parentId": "3e8823fb017a0ad36cee534a",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "6e4fa4a61cf3e4f7c7cc2839",
             "_tpl": "5abcbb20d8ce87001773e258",
             "parentId": "f96edd4fe4f26e29b2345e56",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "31ab7e1f41ecfbfaa7f64bab",
             "_tpl": "5c46fbd72e2216398b5a8c9c",
             "parentId": "hideout",
@@ -2637,62 +2987,74 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "5aeb9575fffed61c1340dadd",
             "_tpl": "5c471be12e221602b66cd9ac",
             "parentId": "31ab7e1f41ecfbfaa7f64bab",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "8192b4bccea9a90ebe50cf8d",
             "_tpl": "5c471c442e221602b542a6f8",
             "parentId": "31ab7e1f41ecfbfaa7f64bab",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "1e5eb0bfecbbaf16f9fca2d6",
             "_tpl": "5c471b5d2e221602b21d4e14",
             "parentId": "31ab7e1f41ecfbfaa7f64bab",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "8bbbb18c0d6ff9bfbc808eb9",
             "_tpl": "5c471cb32e221602b177afaa",
             "parentId": "31ab7e1f41ecfbfaa7f64bab",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "9eb6aa8ad53d9c5df9ca09e2",
             "_tpl": "5c471bfc2e221602b21d4e17",
             "parentId": "8bbbb18c0d6ff9bfbc808eb9",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "8aeede9a900143a79afe6e8c",
             "_tpl": "5c471ba12e221602b3137d76",
             "parentId": "9eb6aa8ad53d9c5df9ca09e2",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "0faebe7acc14fafc0acfc6d3",
             "_tpl": "5c471c842e221615214259b5",
             "parentId": "8bbbb18c0d6ff9bfbc808eb9",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "e0fee0bb2be4df212bdfbbbd",
             "_tpl": "5c471c2d2e22164bef5d077f",
             "parentId": "31ab7e1f41ecfbfaa7f64bab",
             "slotId": "mod_mount_001"
-        }, {
+        },
+        {
             "_id": "ea12c07dba740e4aeeaafd9c",
             "_tpl": "5c471c6c2e221602b66cd9ae",
             "parentId": "e0fee0bb2be4df212bdfbbbd",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "8aed80ceac3aeb496eeec0db",
             "_tpl": "5c471b7e2e2216152006e46c",
             "parentId": "e0fee0bb2be4df212bdfbbbd",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "6fb24e1c7093f1fccabdfefa",
             "_tpl": "5c471bd12e221602b4129c3a",
             "parentId": "31ab7e1f41ecfbfaa7f64bab",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "dfceccc7ddacec9fda862394",
             "_tpl": "5df8f535bb49d91fb446d6b0",
             "parentId": "hideout",
@@ -2703,7 +3065,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "cd1c070711aa27a77cd32f1b",
             "_tpl": "5b7bef1e5acfc43d82528402",
             "parentId": "hideout",
@@ -2714,7 +3077,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "977cb75f35769e0530fdd4dd",
             "_tpl": "5aaf8a0be5b5b00015693243",
             "parentId": "hideout",
@@ -2725,7 +3089,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bcc29a9fd5c39954544eabb5",
             "_tpl": "5c471c442e221602b542a6f8",
             "parentId": "hideout",
@@ -2736,7 +3101,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bdff25636c0c9bcc4dddd7f6",
             "_tpl": "5fc22d7c187fea44d52eda44",
             "parentId": "hideout",
@@ -2747,52 +3113,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a5ec1fc36453f02acdc37ea6",
             "_tpl": "57c55efc2459772d2c6271e7",
             "parentId": "bdff25636c0c9bcc4dddd7f6",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "c6d6f1f5adf45c16be5cbdec",
             "_tpl": "5fc23426900b1d5091531e15",
             "parentId": "bdff25636c0c9bcc4dddd7f6",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "fe8efd261ab8bef357b52742",
             "_tpl": "5649be884bdc2d79388b4577",
             "parentId": "bdff25636c0c9bcc4dddd7f6",
             "slotId": "mod_stock_001"
-        }, {
+        },
+        {
             "_id": "a8c9a2be0d5bf5be3efcfc98",
             "_tpl": "5fc2369685fd526b824a5713",
             "parentId": "fe8efd261ab8bef357b52742",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "e4df0b0cc9c300df2e07bd1d",
             "_tpl": "5fc278107283c4046c581489",
             "parentId": "bdff25636c0c9bcc4dddd7f6",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "efe4f5dd1ce63b719bbbe885",
             "_tpl": "5fc23678ab884124df0cd590",
             "parentId": "e4df0b0cc9c300df2e07bd1d",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "afb400d0acfca64dcab24e3a",
             "_tpl": "5fc23636016cce60e8341b05",
             "parentId": "efe4f5dd1ce63b719bbbe885",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "66ec9b2cfde8c6de7241f176",
             "_tpl": "5fc2360f900b1d5091531e19",
             "parentId": "efe4f5dd1ce63b719bbbe885",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "08dbde81688d6fc3a4f0edfd",
             "_tpl": "5fc235db2770a0045c59c683",
             "parentId": "e4df0b0cc9c300df2e07bd1d",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "f5ddeb8ccfdc7dbaec7fbf18",
             "_tpl": "6176aca650224f204c1da3fb",
             "parentId": "hideout",
@@ -2803,72 +3179,86 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ef0a0cb0566c4cc0ca8c743f",
             "_tpl": "6193dcd0f8ee7e52e4210a28",
             "parentId": "f5ddeb8ccfdc7dbaec7fbf18",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "4ed2dbbd33f8fac0ef766b6f",
             "_tpl": "617131a4568c120fdd29482d",
             "parentId": "f5ddeb8ccfdc7dbaec7fbf18",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "6fc5d3722e465f0ceff7bbab",
             "_tpl": "617153016c780c1e710c9a2f",
             "parentId": "f5ddeb8ccfdc7dbaec7fbf18",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "27e53b4a8bce9b919adfda4f",
             "_tpl": "617154aa1cb55961fa0fdb3b",
             "parentId": "6fc5d3722e465f0ceff7bbab",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "2b82ade0f7b7bf2f9356005b",
             "_tpl": "61713a8fd92c473c770214a4",
             "parentId": "f5ddeb8ccfdc7dbaec7fbf18",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "a4ce17fafdc75af0f62f601f",
             "_tpl": "6171407e50224f204c1da3c5",
             "parentId": "2b82ade0f7b7bf2f9356005b",
             "slotId": "mod_scope"
-        }, {
+        },
+        {
             "_id": "b85366553144af37fc3c7cc4",
             "_tpl": "617151c1d92c473c770214ab",
             "parentId": "a4ce17fafdc75af0f62f601f",
             "slotId": "mod_scope_000"
-        }, {
+        },
+        {
             "_id": "1acc73b8ecd1b0042c0cb7eb",
             "_tpl": "61702be9faa1272e431522c3",
             "parentId": "2b82ade0f7b7bf2f9356005b",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "ba634deaaed3c3b68ddf27f0",
             "_tpl": "61713308d92c473c770214a0",
             "parentId": "1acc73b8ecd1b0042c0cb7eb",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "677efa633fd1b3bbfeb6b87e",
             "_tpl": "61702f1b67085e45ef140b26",
             "parentId": "1acc73b8ecd1b0042c0cb7eb",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "b183aaafff5d16bd0eee69eb",
             "_tpl": "61712eae6c780c1e710c9a1d",
             "parentId": "2b82ade0f7b7bf2f9356005b",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "b7868e7dd26e79c4fc60e51b",
             "_tpl": "5bb20e49d4351e3bac1212de",
             "parentId": "2b82ade0f7b7bf2f9356005b",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "caf037cacfbfcff8bc1bbec4",
             "_tpl": "61702d8a67085e45ef140b24",
             "parentId": "f5ddeb8ccfdc7dbaec7fbf18",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "5877e6bf1dd1e928361406c4",
             "_tpl": "5a367e5dc4a282000e49738f",
             "parentId": "hideout",
@@ -2879,47 +3269,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "aa80bef34db009fd0b51a3ec",
             "_tpl": "5a339805c4a2826c6e06d73d",
             "parentId": "5877e6bf1dd1e928361406c4",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "dae7e8c53ed8df6b9a7c974f",
             "_tpl": "5a3501acc4a282000d72293a",
             "parentId": "5877e6bf1dd1e928361406c4",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "c2aaafe9fe79c4dfb5c59ccb",
             "_tpl": "5a33ca0fc4a282000d72292f",
             "parentId": "5877e6bf1dd1e928361406c4",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "8ad7ac45fab8d3cc2843ed19",
             "_tpl": "5a33cae9c4a28232980eb086",
             "parentId": "c2aaafe9fe79c4dfb5c59ccb",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "3e9a099b6bfbfb50c77b1de6",
             "_tpl": "5a329052c4a28200741e22d3",
             "parentId": "5877e6bf1dd1e928361406c4",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "da52df6a8db1565e52b6d17a",
             "_tpl": "5a34fae7c4a2826c6e06d760",
             "parentId": "5877e6bf1dd1e928361406c4",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "f3c0bcff563db7946756e7c8",
             "_tpl": "5a34fd2bc4a282329a73b4c5",
             "parentId": "da52df6a8db1565e52b6d17a",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "935ca4247ed042adeb8daec0",
             "_tpl": "5a34fbadc4a28200741e230a",
             "parentId": "da52df6a8db1565e52b6d17a",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "ae2874d9cdefe6a3038befdf",
             "_tpl": "57838ad32459774a17445cd2",
             "parentId": "hideout",
@@ -2930,32 +3329,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "9e9b5e0eadd3f05cf7aaaa50",
             "_tpl": "57838f0b2459774a256959b2",
             "parentId": "ae2874d9cdefe6a3038befdf",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "99f7c86aae6d7ba629475aad",
             "_tpl": "57838c962459774a1651ec63",
             "parentId": "ae2874d9cdefe6a3038befdf",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "bbae2b9efaab1ab4ac7bfeed",
             "_tpl": "57838e1b2459774a256959b1",
             "parentId": "99f7c86aae6d7ba629475aad",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "8a0fdefc19de2693f21fae7b",
             "_tpl": "578395402459774a256959b5",
             "parentId": "ae2874d9cdefe6a3038befdf",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "adf7a5ea968bb1f9049ef26b",
             "_tpl": "578395e82459774a0e553c7b",
             "parentId": "ae2874d9cdefe6a3038befdf",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "85b6f03df9ecb327dbdfd6a7",
             "_tpl": "5a3501acc4a282000d72293a",
             "parentId": "hideout",
@@ -2966,7 +3371,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "61f7bef9c04afa27ae91fcfd",
             "_tpl": "5fc23426900b1d5091531e15",
             "parentId": "hideout",
@@ -2977,7 +3383,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b6a2f8a5cfe2c78c746dee26",
             "_tpl": "57838f0b2459774a256959b2",
             "parentId": "hideout",
@@ -2988,7 +3395,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "1cbd1cca1aab6f1fcb50fd8a",
             "_tpl": "617130016c780c1e710c9a24",
             "parentId": "hideout",
@@ -2999,7 +3407,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f8de1e7cfad533cdafb11bcc",
             "_tpl": "5de652c31b7e3716273428be",
             "parentId": "hideout",
@@ -3010,32 +3419,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "57ddcad89b77b7d4beba43ea",
             "_tpl": "5de653abf76fdc1ce94a5a2a",
             "parentId": "f8de1e7cfad533cdafb11bcc",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "8aabb7e36a5da5ccf7e5bf0f",
             "_tpl": "5de655be4a9f347bc92edb88",
             "parentId": "f8de1e7cfad533cdafb11bcc",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "7a3b2da7d44e9efbaf68a9cc",
             "_tpl": "5de65547883dde217541644b",
             "parentId": "f8de1e7cfad533cdafb11bcc",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "c814d28a934d38c2edbc9003",
             "_tpl": "5de6556a205ddc616a6bc4f7",
             "parentId": "7a3b2da7d44e9efbaf68a9cc",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "17b7ca73bbc61a28ccde3cf9",
             "_tpl": "5de6558e9f98ac2bc65950fc",
             "parentId": "f8de1e7cfad533cdafb11bcc",
             "slotId": "mod_mount"
-        }, {
+        },
+        {
             "_id": "ff2cac4220f9dfbdbe97b5eb",
             "_tpl": "5ae08f0a5acfc408fb1398a1",
             "parentId": "hideout",
@@ -3046,32 +3461,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7e885f4c14bb3ea735fd37d9",
             "_tpl": "5ae0973a5acfc4001562206c",
             "parentId": "ff2cac4220f9dfbdbe97b5eb",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "fd0dec7e0fce608dbb066799",
             "_tpl": "5ae096d95acfc400185c2c81",
             "parentId": "ff2cac4220f9dfbdbe97b5eb",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "ccd7aeab1b7e71a6695ebc78",
             "_tpl": "5ae09bff5acfc4001562219d",
             "parentId": "ff2cac4220f9dfbdbe97b5eb",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "b4d7e33987f3dc4cdbf2df56",
             "_tpl": "5ae099875acfc4001714e593",
             "parentId": "ccd7aeab1b7e71a6695ebc78",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "dcd8dacafceafa32ddb3b09c",
             "_tpl": "5ae099925acfc4001a5fc7b3",
             "parentId": "ccd7aeab1b7e71a6695ebc78",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "e25c5da0f9e3de58aa32ebcc",
             "_tpl": "5bfd297f0db834001a669119",
             "parentId": "hideout",
@@ -3082,22 +3503,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "0f7aabf9734aaaeb1cae1bfd",
             "_tpl": "5ae0973a5acfc4001562206c",
             "parentId": "e25c5da0f9e3de58aa32ebcc",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "8a1c0a84ce3cfeeec96ad6dd",
             "_tpl": "5bfd36ad0db834001c38ef66",
             "parentId": "e25c5da0f9e3de58aa32ebcc",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "c9b0dabffba80cddbdded5fe",
             "_tpl": "5bfd4cc90db834001d23e846",
             "parentId": "e25c5da0f9e3de58aa32ebcc",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "bc6ca2c2ef6aa46f3ac0fa05",
             "_tpl": "587e02ff24597743df3deaeb",
             "parentId": "hideout",
@@ -3108,47 +3533,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d06",
             "_tpl": "587e0531245977466077a0f7",
             "parentId": "bc6ca2c2ef6aa46f3ac0fa05",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d07",
             "_tpl": "634eff66517ccc8a960fc735",
             "parentId": "bc6ca2c2ef6aa46f3ac0fa05",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d08",
             "_tpl": "634f05a21f9f536910079b56",
             "parentId": "6670e6bb622e80dbf3056d07",
             "slotId": "mod_mount_000"
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d09",
             "_tpl": "634f036a517ccc8a960fc746",
             "parentId": "6670e6bb622e80dbf3056d08",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d0a",
             "_tpl": "634f03d40384a3ba4f06f874",
             "parentId": "6670e6bb622e80dbf3056d09",
             "slotId": "mod_mount_000"
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d0b",
             "_tpl": "574db213245977459a2f3f5d",
             "parentId": "6670e6bb622e80dbf3056d08",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d0c",
             "_tpl": "587df3a12459772c28142567",
             "parentId": "bc6ca2c2ef6aa46f3ac0fa05",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d0d",
             "_tpl": "634f06262e5def262d0b30ca",
             "parentId": "bc6ca2c2ef6aa46f3ac0fa05",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "80b2afafa0c554ef12efafec",
             "_tpl": "574d967124597745970e7c94",
             "parentId": "hideout",
@@ -3159,47 +3593,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d0f",
             "_tpl": "574dad8024597745964bf05c",
             "parentId": "80b2afafa0c554ef12efafec",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d10",
             "_tpl": "634f02331f9f536910079b51",
             "parentId": "80b2afafa0c554ef12efafec",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d11",
             "_tpl": "634f04d82e5def262d0b30c6",
             "parentId": "6670e6bb622e80dbf3056d10",
             "slotId": "mod_mount_000"
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d12",
             "_tpl": "634f02d7517ccc8a960fc744",
             "parentId": "6670e6bb622e80dbf3056d11",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d13",
             "_tpl": "634f08a21f9f536910079b5a",
             "parentId": "6670e6bb622e80dbf3056d12",
             "slotId": "mod_mount_000"
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d14",
             "_tpl": "574db213245977459a2f3f5d",
             "parentId": "6670e6bb622e80dbf3056d11",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d15",
             "_tpl": "587df3a12459772c28142567",
             "parentId": "80b2afafa0c554ef12efafec",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d16",
             "_tpl": "634f05ca517ccc8a960fc748",
             "parentId": "80b2afafa0c554ef12efafec",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "dc232bbf20b811bfcc347f19",
             "_tpl": "5c501a4d2e221602b412b540",
             "parentId": "hideout",
@@ -3210,32 +3653,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "6ae3cae0bc06ade6986c6e0b",
             "_tpl": "5c5039be2e221602b177c9ff",
             "parentId": "dc232bbf20b811bfcc347f19",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "951ce2fdd149259e1289a3cf",
             "_tpl": "5c503d0a2e221602b542b7ef",
             "parentId": "dc232bbf20b811bfcc347f19",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "abeb4c97b8b367b5ab42cbba",
             "_tpl": "5c503b1c2e221602b21d6e9d",
             "parentId": "dc232bbf20b811bfcc347f19",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "fcef3fcc7f103bc675bff3b1",
             "_tpl": "5c503af12e221602b177ca02",
             "parentId": "dc232bbf20b811bfcc347f19",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "2f25eba7c7df00ff51fd5d6f",
             "_tpl": "5c503ac82e221602b21d6e9a",
             "parentId": "dc232bbf20b811bfcc347f19",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "a58eeeaac8bdfeb3ac20c05d",
             "_tpl": "5bfea6e90db834001b7347f3",
             "parentId": "hideout",
@@ -3246,22 +3695,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "1dbf7aca3896d4d1f81fc6bd",
             "_tpl": "5bfea7ad0db834001c38f1ee",
             "parentId": "a58eeeaac8bdfeb3ac20c05d",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "0bec1fcca7acd0015eabb85a",
             "_tpl": "5bfeb32b0db834001a6694d9",
             "parentId": "a58eeeaac8bdfeb3ac20c05d",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "75eac23c3ec7409dae36dbf9",
             "_tpl": "5bfebc320db8340019668d79",
             "parentId": "a58eeeaac8bdfeb3ac20c05d",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "bdc81d1c0a8555706057cefe",
             "_tpl": "5df24cf80dee1b22f862e9bc",
             "parentId": "hideout",
@@ -3272,72 +3725,86 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "73e57cc714dfd56c3586b2c4",
             "_tpl": "5df25b6c0b92095fd441e4cf",
             "parentId": "bdc81d1c0a8555706057cefe",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "e4606adf24cfb5ab28aae471",
             "_tpl": "5df256570dee1b22f862e9c4",
             "parentId": "bdc81d1c0a8555706057cefe",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "6db3fb73b9350db4649ecef9",
             "_tpl": "5df35e7f2a78646d96665dd4",
             "parentId": "e4606adf24cfb5ab28aae471",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "7e9be7deb7b0aacd0f1fce22",
             "_tpl": "5df35e59c41b2312ea3334d5",
             "parentId": "bdc81d1c0a8555706057cefe",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "cddb86cf32ca2ebabc0a1afd",
             "_tpl": "5df25d3bfd6b4e6e2276dc9a",
             "parentId": "7e9be7deb7b0aacd0f1fce22",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "6f1eae7cebddea7e44d33799",
             "_tpl": "5df35eb2b11454561e3923e2",
             "parentId": "cddb86cf32ca2ebabc0a1afd",
             "slotId": "mod_mount_000"
-        }, {
+        },
+        {
             "_id": "438a5deb245ad1dae211edfb",
             "_tpl": "5df35eb2b11454561e3923e2",
             "parentId": "cddb86cf32ca2ebabc0a1afd",
             "slotId": "mod_mount_001"
-        }, {
+        },
+        {
             "_id": "9613abbf85aacc3dde6bcd24",
             "_tpl": "5df35ea9c41b2312ea3334d8",
             "parentId": "cddb86cf32ca2ebabc0a1afd",
             "slotId": "mod_mount_002"
-        }, {
+        },
+        {
             "_id": "dca2c30cbec6ed5c1cdf8a08",
             "_tpl": "5df35eb2b11454561e3923e2",
             "parentId": "cddb86cf32ca2ebabc0a1afd",
             "slotId": "mod_mount_003"
-        }, {
+        },
+        {
             "_id": "cdedc982a7f44cb1be3f1e76",
             "_tpl": "5df36948bb49d91fb446d5ad",
             "parentId": "cddb86cf32ca2ebabc0a1afd",
             "slotId": "mod_foregrip"
-        }, {
+        },
+        {
             "_id": "d0e86ebe7acade6dc484b9af",
             "_tpl": "5df38a5fb74cd90030650cb6",
             "parentId": "7e9be7deb7b0aacd0f1fce22",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "74f8ccefdcfff238ed8a259f",
             "_tpl": "5df35ddddfc58d14537c2036",
             "parentId": "7e9be7deb7b0aacd0f1fce22",
             "slotId": "mod_stock_axis"
-        }, {
+        },
+        {
             "_id": "bafb1a9ec9324ea0e59dacfe",
             "_tpl": "5df35e970b92095fd441e4d2",
             "parentId": "bdc81d1c0a8555706057cefe",
             "slotId": "mod_mount"
-        }, {
+        },
+        {
             "_id": "d9cdd4e5a76c15e542a82e76",
             "_tpl": "55801eed4bdc2d89578b4588",
             "parentId": "hideout",
@@ -3348,37 +3815,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d30",
             "_tpl": "559ba5b34bdc2d1f1a8b4582",
             "parentId": "d9cdd4e5a76c15e542a82e76",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d31",
             "_tpl": "56083e1b4bdc2dc8488b4572",
             "parentId": "d9cdd4e5a76c15e542a82e76",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d32",
             "_tpl": "56083eab4bdc2d26448b456a",
             "parentId": "d9cdd4e5a76c15e542a82e76",
             "slotId": "mod_tactical"
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d33",
             "_tpl": "560e620e4bdc2d724b8b456b",
             "parentId": "d9cdd4e5a76c15e542a82e76",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d34",
             "_tpl": "61faa91878830f069b6b7967",
             "parentId": "d9cdd4e5a76c15e542a82e76",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d35",
             "_tpl": "56ea8222d2720b69698b4567",
             "parentId": "6670e6bb622e80dbf3056d34",
             "slotId": "mod_bipod"
-        }, {
+        },
+        {
             "_id": "74fedc1edf2226e1f33ce2bf",
             "_tpl": "588892092459774ac91d4b11",
             "parentId": "hideout",
@@ -3389,37 +3863,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ccc3f69bcffb2defff8bfaa9",
             "_tpl": "5888988e24597752fe43a6fa",
             "parentId": "74fedc1edf2226e1f33ce2bf",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "3516abecb6fece3c238e0fec",
             "_tpl": "5888956924597752983e182d",
             "parentId": "74fedc1edf2226e1f33ce2bf",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "03ddfaeef7834393faa1f056",
             "_tpl": "5888996c24597754281f9419",
             "parentId": "3516abecb6fece3c238e0fec",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "d7e2edcd219c1e0ca3bfb42b",
             "_tpl": "5888976c24597754281f93f5",
             "parentId": "3516abecb6fece3c238e0fec",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "f0db895c2b9da437d5fab239",
             "_tpl": "57c55f172459772d27602381",
             "parentId": "74fedc1edf2226e1f33ce2bf",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "eb52b3e610ebcd4acc94bb5d",
             "_tpl": "58889d0c2459775bc215d981",
             "parentId": "74fedc1edf2226e1f33ce2bf",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "b58d3a7fdfdaafd12d35c111",
             "_tpl": "5df8ce05b11454561e39243b",
             "parentId": "hideout",
@@ -3430,67 +3911,80 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "2cae112a2ebbc3956bb97f75",
             "_tpl": "55d4b9964bdc2d1d4e8b456e",
             "parentId": "b58d3a7fdfdaafd12d35c111",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "eb1e0d6dc5ee5ae0bdb660d7",
             "_tpl": "5df8f541c41b2312ea3335e3",
             "parentId": "b58d3a7fdfdaafd12d35c111",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "aae883dd1bbe24c30df0b07d",
             "_tpl": "5649be884bdc2d79388b4577",
             "parentId": "b58d3a7fdfdaafd12d35c111",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "e095cbae329de8dbec6d193c",
             "_tpl": "5ae30c9a5acfc408fb139a03",
             "parentId": "aae883dd1bbe24c30df0b07d",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "1cbbcd9126c941bbcd2e3918",
             "_tpl": "5df8e4080b92095fd441e594",
             "parentId": "b58d3a7fdfdaafd12d35c111",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "a87d3e12e2e5dbddd380eec9",
             "_tpl": "5df917564a9f347bc92edca3",
             "parentId": "1cbbcd9126c941bbcd2e3918",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "ed2d64ede4a472217ad90e32",
             "_tpl": "5dfa3cd1b33c0951220c079b",
             "parentId": "a87d3e12e2e5dbddd380eec9",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "55ad9a5ffdbfc28d3999e5ef",
             "_tpl": "5dfa3d45dfc58d14537c20b0",
             "parentId": "a87d3e12e2e5dbddd380eec9",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "ff8f84afd444cbff8eddaaa2",
             "_tpl": "5df916dfbb49d91fb446d6b9",
             "parentId": "1cbbcd9126c941bbcd2e3918",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "aac65f2dba228eb8efa9da3f",
             "_tpl": "5dfa3d950dee1b22f862eae0",
             "parentId": "ff8f84afd444cbff8eddaaa2",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "5b65bcb862d8377e8444f9d2",
             "_tpl": "5dfa3d7ac41b2312ea33362a",
             "parentId": "1cbbcd9126c941bbcd2e3918",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "daef7a5d1a0ed9c7b4d5fbec",
             "_tpl": "5df8e053bb49d91fb446d6a6",
             "parentId": "b58d3a7fdfdaafd12d35c111",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "af0feddae5728df8d5e7c2ca",
             "_tpl": "5f2a9575926fd9352339381f",
             "parentId": "hideout",
@@ -3501,37 +3995,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "569850584f7f960be38df435",
             "_tpl": "5b099ac65acfc400186331e1",
             "parentId": "af0feddae5728df8d5e7c2ca",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "b199cf09ecb4a1cc4a59ca10",
             "_tpl": "5f2aa46b878ef416f538b567",
             "parentId": "af0feddae5728df8d5e7c2ca",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "2abed8b536a2b9fa3dbabd2b",
             "_tpl": "5f2aa4464b50c14bcf07acdb",
             "parentId": "b199cf09ecb4a1cc4a59ca10",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "493a75fde1dea7563f130a59",
             "_tpl": "5f2aa47a200e2c0ee46efa71",
             "parentId": "af0feddae5728df8d5e7c2ca",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "ecb1e5e40cbdbdeca6fdaea4",
             "_tpl": "5f2aa493cd375f14e15eea72",
             "parentId": "493a75fde1dea7563f130a59",
             "slotId": "mod_mount_000"
-        }, {
+        },
+        {
             "_id": "0320b294915be8fb3cb85edc",
             "_tpl": "5f2aa49f9b44de6b1b4e68d4",
             "parentId": "af0feddae5728df8d5e7c2ca",
             "slotId": "mod_mount"
-        }, {
+        },
+        {
             "_id": "b0ce2a2ddbf1abace32836a0",
             "_tpl": "5aafa857e5b5b00018480968",
             "parentId": "hideout",
@@ -3542,42 +4043,50 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "132f5170c210998c3ab8d31d",
             "_tpl": "5aaf8a0be5b5b00015693243",
             "parentId": "b0ce2a2ddbf1abace32836a0",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "8c20fb6cde90458deab3a565",
             "_tpl": "5aaf8e43e5b5b00015693246",
             "parentId": "b0ce2a2ddbf1abace32836a0",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "e3b142756da30aeb84a725bd",
             "_tpl": "5ab24ef9e5b5b00fe93c9209",
             "parentId": "8c20fb6cde90458deab3a565",
             "slotId": "mod_mount"
-        }, {
+        },
+        {
             "_id": "6aefd95acdfa6e0bcc4b3cce",
             "_tpl": "5aaf9d53e5b5b00015042a52",
             "parentId": "b0ce2a2ddbf1abace32836a0",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "f9a1aa68d9c921ccadf4bfe0",
             "_tpl": "5aafa1c2e5b5b00015042a56",
             "parentId": "6aefd95acdfa6e0bcc4b3cce",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "ff7baaf3ac8cefed9cdf2b8c",
             "_tpl": "5aafa49ae5b5b00015042a58",
             "parentId": "f9a1aa68d9c921ccadf4bfe0",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "63aabd5bcbba5a626aaae0bf",
             "_tpl": "5abcbb20d8ce87001773e258",
             "parentId": "b0ce2a2ddbf1abace32836a0",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "5ced8db5a03f6afe5569bbb3",
             "_tpl": "5c46fbd72e2216398b5a8c9c",
             "parentId": "hideout",
@@ -3588,62 +4097,74 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "0d5ede8adc7a6f5fd0237b06",
             "_tpl": "5c471be12e221602b66cd9ac",
             "parentId": "5ced8db5a03f6afe5569bbb3",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "df09ebd46e1abc5cd76dd4fe",
             "_tpl": "5c471c442e221602b542a6f8",
             "parentId": "5ced8db5a03f6afe5569bbb3",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "fa834ed60f73cc9e6ff1a4ff",
             "_tpl": "5c471b5d2e221602b21d4e14",
             "parentId": "5ced8db5a03f6afe5569bbb3",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "3257b178f653f4bfc311da9f",
             "_tpl": "5c471cb32e221602b177afaa",
             "parentId": "5ced8db5a03f6afe5569bbb3",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "1bc7c4e50b5ef535e60dec79",
             "_tpl": "5c471bfc2e221602b21d4e17",
             "parentId": "3257b178f653f4bfc311da9f",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "ee4829c90bcb30b38347d712",
             "_tpl": "5c471ba12e221602b3137d76",
             "parentId": "1bc7c4e50b5ef535e60dec79",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "dc6b7d82d8a60402ffeab211",
             "_tpl": "5c471c842e221615214259b5",
             "parentId": "3257b178f653f4bfc311da9f",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "a1b50ae2e3d795ba66a282a0",
             "_tpl": "5c471c2d2e22164bef5d077f",
             "parentId": "5ced8db5a03f6afe5569bbb3",
             "slotId": "mod_mount_001"
-        }, {
+        },
+        {
             "_id": "1ebfa1b2f27e433e177b3eac",
             "_tpl": "5c471c6c2e221602b66cd9ae",
             "parentId": "a1b50ae2e3d795ba66a282a0",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "aecebd6f89f3d13905b7759f",
             "_tpl": "5c471b7e2e2216152006e46c",
             "parentId": "a1b50ae2e3d795ba66a282a0",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "6dcf9b0a070fbbf1cb98dff7",
             "_tpl": "5c471bd12e221602b4129c3a",
             "parentId": "5ced8db5a03f6afe5569bbb3",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "b51a839b94a75a787a208dbf",
             "_tpl": "5fc22d7c187fea44d52eda44",
             "parentId": "hideout",
@@ -3654,52 +4175,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "11aff8bf6ff33bdcf72b8e2f",
             "_tpl": "57c55efc2459772d2c6271e7",
             "parentId": "b51a839b94a75a787a208dbf",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "cdfa0fffd71b23c24bbece70",
             "_tpl": "5fc23426900b1d5091531e15",
             "parentId": "b51a839b94a75a787a208dbf",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "fdfed103e70af9fec1fc63a7",
             "_tpl": "5649be884bdc2d79388b4577",
             "parentId": "b51a839b94a75a787a208dbf",
             "slotId": "mod_stock_001"
-        }, {
+        },
+        {
             "_id": "2dab001aadaa3a1ee4df8dd2",
             "_tpl": "5fc2369685fd526b824a5713",
             "parentId": "fdfed103e70af9fec1fc63a7",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "7454ebcb0a42a34bccfaaf3b",
             "_tpl": "5fc278107283c4046c581489",
             "parentId": "b51a839b94a75a787a208dbf",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "60354d97fdaab0d99a1212c5",
             "_tpl": "5fc23678ab884124df0cd590",
             "parentId": "7454ebcb0a42a34bccfaaf3b",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "1c4a7a45d3b3b9433bb4e2ca",
             "_tpl": "5fc23636016cce60e8341b05",
             "parentId": "60354d97fdaab0d99a1212c5",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "236dcbdcd8ba1289a67f1b53",
             "_tpl": "5fc2360f900b1d5091531e19",
             "parentId": "60354d97fdaab0d99a1212c5",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "cd9b3ded0edc80d267ed73ab",
             "_tpl": "5fc235db2770a0045c59c683",
             "parentId": "7454ebcb0a42a34bccfaaf3b",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "f2eacf53404dbc5a62b7b1ad",
             "_tpl": "6176aca650224f204c1da3fb",
             "parentId": "hideout",
@@ -3710,72 +4241,86 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b818ebaacd167dabbb3ef1c9",
             "_tpl": "6193dcd0f8ee7e52e4210a28",
             "parentId": "f2eacf53404dbc5a62b7b1ad",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "98633ecdaf91eec904edf93f",
             "_tpl": "617131a4568c120fdd29482d",
             "parentId": "f2eacf53404dbc5a62b7b1ad",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "c8febbea915e2dfb1194c3c2",
             "_tpl": "617153016c780c1e710c9a2f",
             "parentId": "f2eacf53404dbc5a62b7b1ad",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "ba8b6366caaac71ed75a04ab",
             "_tpl": "617154aa1cb55961fa0fdb3b",
             "parentId": "c8febbea915e2dfb1194c3c2",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "62ad2eba04d5c23dcec9a0b0",
             "_tpl": "61713a8fd92c473c770214a4",
             "parentId": "f2eacf53404dbc5a62b7b1ad",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "55d6bdd4b5785de2ae7b05ec",
             "_tpl": "6171407e50224f204c1da3c5",
             "parentId": "62ad2eba04d5c23dcec9a0b0",
             "slotId": "mod_scope"
-        }, {
+        },
+        {
             "_id": "f7fddfc5ab84bd4ddcdd1597",
             "_tpl": "617151c1d92c473c770214ab",
             "parentId": "55d6bdd4b5785de2ae7b05ec",
             "slotId": "mod_scope_000"
-        }, {
+        },
+        {
             "_id": "af85374c67b7c3f3fdf9f7f0",
             "_tpl": "61702be9faa1272e431522c3",
             "parentId": "62ad2eba04d5c23dcec9a0b0",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "eb25fc1251540535978ab8ff",
             "_tpl": "61713308d92c473c770214a0",
             "parentId": "af85374c67b7c3f3fdf9f7f0",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "3c6fd092491c6e110bedb5cb",
             "_tpl": "61702f1b67085e45ef140b26",
             "parentId": "af85374c67b7c3f3fdf9f7f0",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "340cba4bfdbfaa4c58bcfbdd",
             "_tpl": "61712eae6c780c1e710c9a1d",
             "parentId": "62ad2eba04d5c23dcec9a0b0",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "6e7307aeeebd7ddcde77aed6",
             "_tpl": "5bb20e49d4351e3bac1212de",
             "parentId": "62ad2eba04d5c23dcec9a0b0",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "eddfeafedff0d095fc8fdfb6",
             "_tpl": "61702d8a67085e45ef140b24",
             "parentId": "f2eacf53404dbc5a62b7b1ad",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "d713bbbc4cc8dd73af2bd937",
             "_tpl": "5a367e5dc4a282000e49738f",
             "parentId": "hideout",
@@ -3786,47 +4331,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "aec55dab6bb908a99daa2987",
             "_tpl": "5a339805c4a2826c6e06d73d",
             "parentId": "d713bbbc4cc8dd73af2bd937",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "36ccfc3dcf536fa6bab60abc",
             "_tpl": "5a3501acc4a282000d72293a",
             "parentId": "d713bbbc4cc8dd73af2bd937",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "3c1f0b297fcf3fade9e3abfe",
             "_tpl": "5a33ca0fc4a282000d72292f",
             "parentId": "d713bbbc4cc8dd73af2bd937",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "c34bb53652452e84d617e45d",
             "_tpl": "5a33cae9c4a28232980eb086",
             "parentId": "3c1f0b297fcf3fade9e3abfe",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "0dfe6bd19ada17ee4ea5ae78",
             "_tpl": "5a329052c4a28200741e22d3",
             "parentId": "d713bbbc4cc8dd73af2bd937",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "eb6eb24ca88ee1bac5de3bff",
             "_tpl": "5a34fae7c4a2826c6e06d760",
             "parentId": "d713bbbc4cc8dd73af2bd937",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "7c85b3baf63aae8bde93b8fd",
             "_tpl": "5a34fd2bc4a282329a73b4c5",
             "parentId": "eb6eb24ca88ee1bac5de3bff",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "e4dfc3c564632b3f3030a65b",
             "_tpl": "5a34fbadc4a28200741e230a",
             "parentId": "eb6eb24ca88ee1bac5de3bff",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "deaa7060a81e84a6bbbc50af",
             "_tpl": "57838ad32459774a17445cd2",
             "parentId": "hideout",
@@ -3837,32 +4391,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "845dbcbfad07eafe3fa80091",
             "_tpl": "57838f0b2459774a256959b2",
             "parentId": "deaa7060a81e84a6bbbc50af",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "4465e11e6b9d3d47fc9918f0",
             "_tpl": "57838c962459774a1651ec63",
             "parentId": "deaa7060a81e84a6bbbc50af",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "2ce9c70f8d97bb2563f03bb5",
             "_tpl": "57838e1b2459774a256959b1",
             "parentId": "4465e11e6b9d3d47fc9918f0",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "792d4d5ebb8a6c10698cabca",
             "_tpl": "578395402459774a256959b5",
             "parentId": "deaa7060a81e84a6bbbc50af",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "ce9ce676dcc4d614d52ebeaf",
             "_tpl": "578395e82459774a0e553c7b",
             "parentId": "deaa7060a81e84a6bbbc50af",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "dfcd1a2b8aefb3d55b86a0df",
             "_tpl": "57c44b372459772d2b39b8ce",
             "parentId": "hideout",
@@ -3873,37 +4433,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "23dbb69c1fc9aaa8fdde4a26",
             "_tpl": "57c44dd02459772d2e0ae249",
             "parentId": "dfcd1a2b8aefb3d55b86a0df",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "dd7c6ed2a8085a99cab16d7f",
             "_tpl": "57c44e7b2459772d28133248",
             "parentId": "23dbb69c1fc9aaa8fdde4a26",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "62b18a7dfd3a53c2a106fdb6",
             "_tpl": "57c44f4f2459772d2c627113",
             "parentId": "dfcd1a2b8aefb3d55b86a0df",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "9afc1a359adba8aacedccbff",
             "_tpl": "57838f9f2459774a150289a0",
             "parentId": "dfcd1a2b8aefb3d55b86a0df",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "dcdfce0859b3c6ab9fc0d51e",
             "_tpl": "57c44fa82459772d2d75e415",
             "parentId": "dfcd1a2b8aefb3d55b86a0df",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "0f0aac3b8af71e651e1a4ad2",
             "_tpl": "57c450252459772d28133253",
             "parentId": "dfcd1a2b8aefb3d55b86a0df",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "3cc5f9d9ccbb41ffacb3e8f9",
             "_tpl": "57c44b372459772d2b39b8ce",
             "parentId": "hideout",
@@ -3914,37 +4481,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "eaf9551400e0218d74997bb4",
             "_tpl": "57c44dd02459772d2e0ae249",
             "parentId": "3cc5f9d9ccbb41ffacb3e8f9",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "38ddeee9eabaaf825abfa1da",
             "_tpl": "57c44e7b2459772d28133248",
             "parentId": "eaf9551400e0218d74997bb4",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "b5b31f001d435ea1af1d8bb2",
             "_tpl": "57c44f4f2459772d2c627113",
             "parentId": "3cc5f9d9ccbb41ffacb3e8f9",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "a7c069df40eac8baf074b1b7",
             "_tpl": "57838f9f2459774a150289a0",
             "parentId": "3cc5f9d9ccbb41ffacb3e8f9",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "eddf8c3b0ad772acdcaecbd2",
             "_tpl": "57c44fa82459772d2d75e415",
             "parentId": "3cc5f9d9ccbb41ffacb3e8f9",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "5fe5b58548c9385cb0b93f5c",
             "_tpl": "57c450252459772d28133253",
             "parentId": "3cc5f9d9ccbb41ffacb3e8f9",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "70de7dfe8e6b0ed0794e2d19",
             "_tpl": "64b8f7968532cf95ee0a0dbf",
             "parentId": "hideout",
@@ -3955,7 +4529,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e4ded52bfbe5b42c294f0ffe",
             "_tpl": "64b8f7968532cf95ee0a0dbf",
             "parentId": "hideout",
@@ -3966,7 +4541,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "3fe2f21b9b0d86dff054ffe4",
             "_tpl": "64b8f7b5389d7ffd620ccba2",
             "parentId": "hideout",
@@ -3977,7 +4553,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "be48b7ccd293d9f2e5546e8d",
             "_tpl": "64b8f7b5389d7ffd620ccba2",
             "parentId": "hideout",
@@ -3988,7 +4565,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f65fa316c9cb7fd50034f7cb",
             "_tpl": "64b8f7c241772715af0f9c3d",
             "parentId": "hideout",
@@ -3999,7 +4577,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ada484f2dcba351b1ede85f0",
             "_tpl": "64b8f7c241772715af0f9c3d",
             "parentId": "hideout",
@@ -4010,7 +4589,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bcd8abaf2db0f2bdc8ddbdc6",
             "_tpl": "56e33634d2720bd8058b456b",
             "parentId": "hideout",
@@ -4021,7 +4601,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fbe194db904dd12abc8c4a9f",
             "_tpl": "56e33634d2720bd8058b456b",
             "parentId": "hideout",
@@ -4032,7 +4613,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "058da8bb6cea515b80eabf4b",
             "_tpl": "56e335e4d2720b6c058b456d",
             "parentId": "hideout",
@@ -4043,7 +4625,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "aac9cfafd213af399be3722d",
             "_tpl": "56e335e4d2720b6c058b456d",
             "parentId": "hideout",
@@ -4054,7 +4637,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "194a1e97f6d112880c100284",
             "_tpl": "5e9dcf5986f7746c417435b3",
             "parentId": "hideout",
@@ -4065,7 +4649,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fa2dac4fadacaaafec31cbde",
             "_tpl": "5e9dcf5986f7746c417435b3",
             "parentId": "hideout",
@@ -4076,7 +4661,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d37f2c22c97cb77aa78ddacf",
             "_tpl": "6038d614d10cbf667352dd44",
             "parentId": "hideout",
@@ -4087,7 +4673,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "4e80ce2f131e3305dc6c5dea",
             "_tpl": "6038d614d10cbf667352dd44",
             "parentId": "hideout",
@@ -4098,7 +4685,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "8ee57a37dfdc46cb2ae27fcc",
             "_tpl": "656ddcf0f02d7bcea90bf395",
             "parentId": "hideout",
@@ -4109,7 +4697,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "dbe8dd4dcfec2cdbdf6ecf2a",
             "_tpl": "656ddcf0f02d7bcea90bf395",
             "parentId": "hideout",
@@ -4120,7 +4709,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fbade5bda9fe6bb2a236dd1f",
             "_tpl": "656f198fb27298d6fd005466",
             "parentId": "hideout",
@@ -4131,7 +4721,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b1e20be1e2ea02ee63d6fbd1",
             "_tpl": "656f198fb27298d6fd005466",
             "parentId": "hideout",
@@ -4142,7 +4733,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a55fcbaa1ab2ca7ebfceca03",
             "_tpl": "619cf0335771dd3c390269ae",
             "parentId": "hideout",
@@ -4153,7 +4745,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "0ccb05c2c9ba1a5959c324d1",
             "_tpl": "619cf0335771dd3c390269ae",
             "parentId": "hideout",
@@ -4164,7 +4757,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e781e5573e2c5c3ce62aaba2",
             "_tpl": "618bb76513f5097c8d5aa2d5",
             "parentId": "hideout",
@@ -4175,7 +4769,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f7bb73f55d746cfbf1a5476b",
             "_tpl": "618bb76513f5097c8d5aa2d5",
             "parentId": "hideout",
@@ -4186,7 +4781,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "eab787b9fb1dd688fbc3e267",
             "_tpl": "628e1ffc83ec92260c0f437f",
             "parentId": "hideout",
@@ -4197,7 +4793,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "5eddfef14fbcef75abb19cf2",
             "_tpl": "628e1ffc83ec92260c0f437f",
             "parentId": "hideout",
@@ -4208,7 +4805,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ee2a5e834ba218c63dacbbeb",
             "_tpl": "62a1b7fbc30cfa1d366af586",
             "parentId": "hideout",
@@ -4219,7 +4817,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "8b154d0ef5be36aec1c5a388",
             "_tpl": "62a1b7fbc30cfa1d366af586",
             "parentId": "hideout",
@@ -4230,7 +4829,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "cc0ad6e59c08ac28ed713ebb",
             "_tpl": "5f5e467b0bc58666c37e7821",
             "parentId": "hideout",
@@ -4241,7 +4841,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "6b4c4e83bbffd4e6dcdfb5e8",
             "_tpl": "5f5e467b0bc58666c37e7821",
             "parentId": "hideout",
@@ -4252,7 +4853,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "2aaec2a0f01689f75c7d327b",
             "_tpl": "5ab8ebf186f7742d8b372e80",
             "parentId": "hideout",
@@ -4263,7 +4865,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ad13ca88ce67db71cac9bac9",
             "_tpl": "5ab8ebf186f7742d8b372e80",
             "parentId": "hideout",
@@ -4274,7 +4877,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "8d1cbe53be42e0ce71ebb90a",
             "_tpl": "639346cc1c8f182ad90c8972",
             "parentId": "hideout",
@@ -4285,7 +4889,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "af5f3cfda9449b2b7befc5d1",
             "_tpl": "639346cc1c8f182ad90c8972",
             "parentId": "hideout",
@@ -4296,7 +4901,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b722a58fb68eedcaec08388d",
             "_tpl": "656e0436d44a1bb4220303a0",
             "parentId": "hideout",
@@ -4307,7 +4913,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "cd1d3f7fd0ef4b7a42f9734c",
             "_tpl": "656e0436d44a1bb4220303a0",
             "parentId": "hideout",
@@ -4318,7 +4925,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "dbe67442de3cf36b0e2acdd0",
             "_tpl": "628bc7fb408e2b2e9c0801b1",
             "parentId": "hideout",
@@ -4329,7 +4937,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bb3090d5b8e9cbf2fa977bfd",
             "_tpl": "628bc7fb408e2b2e9c0801b1",
             "parentId": "hideout",
@@ -4340,7 +4949,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "9f73e7bb5ff3fae70beecc63",
             "_tpl": "5e997f0b86f7741ac73993e2",
             "parentId": "hideout",
@@ -4351,7 +4961,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "4cb54d4faefafe34b2d0fba0",
             "_tpl": "5e997f0b86f7741ac73993e2",
             "parentId": "hideout",
@@ -4362,7 +4973,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "05ab0dd0f83897027adb14b4",
             "_tpl": "61b9e1aaef9a1b5d6a79899a",
             "parentId": "hideout",
@@ -4373,7 +4985,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "dfebbc2c79d7da7caee7f46e",
             "_tpl": "61b9e1aaef9a1b5d6a79899a",
             "parentId": "hideout",
@@ -4384,7 +4997,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d589abf8bd03bbbf7fd9fd58",
             "_tpl": "643ea5b23db6f9f57107d9fd",
             "parentId": "hideout",
@@ -4395,42 +5009,50 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "704bd8eaa2de709f9ffbb503",
             "_tpl": "6410745d5dd49d77bd078485",
             "parentId": "d589abf8bd03bbbf7fd9fd58",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "6f9fcbe00c58be20c3b51194",
             "_tpl": "6410758c857473525b08bb77",
             "parentId": "d589abf8bd03bbbf7fd9fd58",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "ee7b6cbc3e7becb5d0060cfb",
             "_tpl": "64119d90dcf48d656f0aa275",
             "parentId": "6f9fcbe00c58be20c3b51194",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "c27a1e91c5e325deaceae6ad",
             "_tpl": "64119d1f2c6d6f921a0929f8",
             "parentId": "6f9fcbe00c58be20c3b51194",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "bbde738bf9e0e3eae4899bed",
             "_tpl": "64119d672c6d6f921a0929fb",
             "parentId": "c27a1e91c5e325deaceae6ad",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "e1deca362409a4a70a15dc6c",
             "_tpl": "64119cdbdcf48d656f0aa272",
             "parentId": "d589abf8bd03bbbf7fd9fd58",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "0c11cfdfcfaed6e2ec337b91",
             "_tpl": "6422e1ea3c0f06190302161a",
             "parentId": "d589abf8bd03bbbf7fd9fd58",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "6bf919996e3f7d9442b4f4bf",
             "_tpl": "643ea5b23db6f9f57107d9fd",
             "parentId": "hideout",
@@ -4441,42 +5063,50 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ae2cdeb813929f2aef4ee4ae",
             "_tpl": "6410745d5dd49d77bd078485",
             "parentId": "6bf919996e3f7d9442b4f4bf",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "8ccbd2a96ae9cbf246fc669a",
             "_tpl": "6410758c857473525b08bb77",
             "parentId": "6bf919996e3f7d9442b4f4bf",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "e7e977ab51daac30ca0b3be9",
             "_tpl": "64119d90dcf48d656f0aa275",
             "parentId": "8ccbd2a96ae9cbf246fc669a",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "7a9696fc3b7836bacbd7a42e",
             "_tpl": "64119d1f2c6d6f921a0929f8",
             "parentId": "8ccbd2a96ae9cbf246fc669a",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "cf7aba3aa84aa69f5dff9b34",
             "_tpl": "64119d672c6d6f921a0929fb",
             "parentId": "7a9696fc3b7836bacbd7a42e",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "c4e5c5ad1e855a768bbc56b1",
             "_tpl": "64119cdbdcf48d656f0aa272",
             "parentId": "6bf919996e3f7d9442b4f4bf",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "d6cbc1d390eae5cada0d0050",
             "_tpl": "6422e1ea3c0f06190302161a",
             "parentId": "6bf919996e3f7d9442b4f4bf",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "638dae2266adbbef13f6a57d",
             "_tpl": "644674a13d52156624001fbc",
             "parentId": "hideout",
@@ -4487,37 +5117,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "8eaaef2e44b6a397ff8b1d98",
             "_tpl": "6450ec2e7da7133e5a09ca96",
             "parentId": "638dae2266adbbef13f6a57d",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "f3e5dfe8ef0a990bdaac06ec",
             "_tpl": "6450f21a3d52156624001fcf",
             "parentId": "638dae2266adbbef13f6a57d",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "b991aeffdd451938d001a43e",
             "_tpl": "6451167ad4928d46d30be3fd",
             "parentId": "638dae2266adbbef13f6a57d",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "b4747b9acf0e6559fbac5d5f",
             "_tpl": "645122f6d4928d46d30be3ff",
             "parentId": "638dae2266adbbef13f6a57d",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "cc57063e77eeafd6180e2de1",
             "_tpl": "644675573d52156624001fc9",
             "parentId": "b4747b9acf0e6559fbac5d5f",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "bebcf7d87fa162fe9bb6febf",
             "_tpl": "64527a263d52156624001fd7",
             "parentId": "b4747b9acf0e6559fbac5d5f",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "d3b6abcadbdfb0c1deeeaf4c",
             "_tpl": "645e0c6b3b381ede770e1cc9",
             "parentId": "hideout",
@@ -4528,32 +5165,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "cc7c8fddd907bbcedb06d2f4",
             "_tpl": "6450ec2e7da7133e5a09ca96",
             "parentId": "d3b6abcadbdfb0c1deeeaf4c",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "f303682a50e9cedddfca3e78",
             "_tpl": "6452519e3d52156624001fd5",
             "parentId": "d3b6abcadbdfb0c1deeeaf4c",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "c4fa145d87eb1f8394ba0b22",
             "_tpl": "645123013d52156624001fd1",
             "parentId": "d3b6abcadbdfb0c1deeeaf4c",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "2c2aacbbaa9ceed2fbaa24bb",
             "_tpl": "6448f2f6d4928d46d30be3f6",
             "parentId": "c4fa145d87eb1f8394ba0b22",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "c22aaf597040de64e62ba5b8",
             "_tpl": "64527a263d52156624001fd7",
             "parentId": "c4fa145d87eb1f8394ba0b22",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "bf8a68cc1c5b35a8a27c7eed",
             "_tpl": "6410733d5dd49d77bd07847e",
             "parentId": "hideout",
@@ -4564,42 +5207,50 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b4563c50f0ad60fcfaf46f01",
             "_tpl": "6410745d5dd49d77bd078485",
             "parentId": "bf8a68cc1c5b35a8a27c7eed",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "fb9b03fe2d7591e47fecd710",
             "_tpl": "6410758c857473525b08bb77",
             "parentId": "bf8a68cc1c5b35a8a27c7eed",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "5fe9afde44a2ede7b09be5f2",
             "_tpl": "64119d90dcf48d656f0aa275",
             "parentId": "fb9b03fe2d7591e47fecd710",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "73af0fe0d8c612ba5d652f8e",
             "_tpl": "64119d1f2c6d6f921a0929f8",
             "parentId": "fb9b03fe2d7591e47fecd710",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "fc5431cde636917a86a63ac3",
             "_tpl": "64119d672c6d6f921a0929fb",
             "parentId": "73af0fe0d8c612ba5d652f8e",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "67fbcae44a1a08e4ce9420ca",
             "_tpl": "64119cdbdcf48d656f0aa272",
             "parentId": "bf8a68cc1c5b35a8a27c7eed",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "f0454067b9a2d883b82d3306",
             "_tpl": "641074a07fd350b98c0b3f96",
             "parentId": "bf8a68cc1c5b35a8a27c7eed",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "0a6c89c0beff4a99a1218348",
             "_tpl": "627e14b21713922ded6f2c15",
             "parentId": "hideout",
@@ -4610,82 +5261,98 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "66b6b70faee2020aec876c9a",
             "_tpl": "628120fd5631d45211793c9f",
             "parentId": "0a6c89c0beff4a99a1218348",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "c8e2e805fcec10ab6acec860",
             "_tpl": "62811f828193841aca4a45c3",
             "parentId": "cb66d8e84e0053e6dd8d52cd",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "2d2dc1ee4ee961236fcbf50f",
             "_tpl": "628120c21d5df4475f46a337",
             "parentId": "27deb8df4545e701fde3be7f",
             "slotId": "mod_mount_000"
-        }, {
+        },
+        {
             "_id": "dc0b1a482ae11aefca60c3c3",
             "_tpl": "628120d309427b40ab14e76d",
             "parentId": "27deb8df4545e701fde3be7f",
             "slotId": "mod_mount_001"
-        }, {
+        },
+        {
             "_id": "2ff9e9afe4ac3bbf2b294ae8",
             "_tpl": "628120d309427b40ab14e76d",
             "parentId": "27deb8df4545e701fde3be7f",
             "slotId": "mod_mount_002"
-        }, {
+        },
+        {
             "_id": "e7e3cafeb1397764a4ae6183",
             "_tpl": "628120dd308cb521f87a8fa1",
             "parentId": "27deb8df4545e701fde3be7f",
             "slotId": "mod_mount_003"
-        }, {
+        },
+        {
             "_id": "27deb8df4545e701fde3be7f",
             "_tpl": "6281209662cba23f6c4d7a19",
             "parentId": "cc67e8677fcd1eebcaa1b4e7",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "84ad035a6094cdf7efd34dce",
             "_tpl": "6281212a09427b40ab14e770",
             "parentId": "cc67e8677fcd1eebcaa1b4e7",
             "slotId": "mod_foregrip"
-        }, {
+        },
+        {
             "_id": "c865989edf78b4cecc4f5d0d",
             "_tpl": "628120621d5df4475f46a335",
             "parentId": "da4bd6bcd6aeefbfa5d1ba3d",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "da4bd6bcd6aeefbfa5d1ba3d",
             "_tpl": "62812081d23f207deb0ab216",
             "parentId": "70bcfe7afedd8fefb8add4ca",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "70bcfe7afedd8fefb8add4ca",
             "_tpl": "628121434fa03b6b6c35dc6a",
             "parentId": "dbd0cfcfc47ae321cba15ef0",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "dbd0cfcfc47ae321cba15ef0",
             "_tpl": "62811fbf09427b40ab14e767",
             "parentId": "cc67e8677fcd1eebcaa1b4e7",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "cc67e8677fcd1eebcaa1b4e7",
             "_tpl": "6281204f308cb521f87a8f9b",
             "parentId": "cb66d8e84e0053e6dd8d52cd",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "cb66d8e84e0053e6dd8d52cd",
             "_tpl": "62811e2510e26c1f344e6554",
             "parentId": "0a6c89c0beff4a99a1218348",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "67a178932abd35e54c29ceae",
             "_tpl": "62811cd7308cb521f87a8f99",
             "parentId": "0a6c89c0beff4a99a1218348",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "fe7eb0f3e1ee7dbd49dbed3a",
             "_tpl": "644674a13d52156624001fbc",
             "parentId": "hideout",
@@ -4696,37 +5363,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "31cef3ec0e08041968ffe3c4",
             "_tpl": "6450ec2e7da7133e5a09ca96",
             "parentId": "fe7eb0f3e1ee7dbd49dbed3a",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "ed7fb5e1ca0523f1c594e06b",
             "_tpl": "6450f21a3d52156624001fcf",
             "parentId": "fe7eb0f3e1ee7dbd49dbed3a",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "01ee02d9aadff33d8f2cccf8",
             "_tpl": "6451167ad4928d46d30be3fd",
             "parentId": "fe7eb0f3e1ee7dbd49dbed3a",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "ed3aea1a0ca8cbccd2483e5c",
             "_tpl": "645122f6d4928d46d30be3ff",
             "parentId": "fe7eb0f3e1ee7dbd49dbed3a",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "9d9fef5fbb2f12db1a66601f",
             "_tpl": "644675573d52156624001fc9",
             "parentId": "ed3aea1a0ca8cbccd2483e5c",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "63e92ce1881af0bfd60ddb2c",
             "_tpl": "64527a263d52156624001fd7",
             "parentId": "ed3aea1a0ca8cbccd2483e5c",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "2464cf8a8e8a1fbfd0f9eba0",
             "_tpl": "645e0c6b3b381ede770e1cc9",
             "parentId": "hideout",
@@ -4737,32 +5411,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "0ada1b25fe758bdc54b9fdef",
             "_tpl": "6450ec2e7da7133e5a09ca96",
             "parentId": "2464cf8a8e8a1fbfd0f9eba0",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "acab91acd8f3a26dc696ef8d",
             "_tpl": "6452519e3d52156624001fd5",
             "parentId": "2464cf8a8e8a1fbfd0f9eba0",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "ed6fedaf9bd29e0cef1a725a",
             "_tpl": "645123013d52156624001fd1",
             "parentId": "2464cf8a8e8a1fbfd0f9eba0",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "2ceccc6ad3dbfeff71eecac6",
             "_tpl": "6448f2f6d4928d46d30be3f6",
             "parentId": "ed6fedaf9bd29e0cef1a725a",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "d50d091c6f5b6b31bf15a0be",
             "_tpl": "64527a263d52156624001fd7",
             "parentId": "ed6fedaf9bd29e0cef1a725a",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "003c2c9db2b8dde27cc21c7c",
             "_tpl": "6410733d5dd49d77bd07847e",
             "parentId": "hideout",
@@ -4773,42 +5453,50 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "5df6a6baefe2ea293edcc801",
             "_tpl": "6410745d5dd49d77bd078485",
             "parentId": "003c2c9db2b8dde27cc21c7c",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "d88050bbafb7315caa0dee0a",
             "_tpl": "6410758c857473525b08bb77",
             "parentId": "003c2c9db2b8dde27cc21c7c",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "c3a45ac9effb8e7ee45ec8fe",
             "_tpl": "64119d90dcf48d656f0aa275",
             "parentId": "d88050bbafb7315caa0dee0a",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "e8109c294c702cbbedbf4e24",
             "_tpl": "64119d1f2c6d6f921a0929f8",
             "parentId": "d88050bbafb7315caa0dee0a",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "60d0528bdbaa58ec70e1d8bd",
             "_tpl": "64119d672c6d6f921a0929fb",
             "parentId": "e8109c294c702cbbedbf4e24",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "698b35e7073c979ea26ee11c",
             "_tpl": "64119cdbdcf48d656f0aa272",
             "parentId": "003c2c9db2b8dde27cc21c7c",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "c6804b1bdd1e5dafb41b6919",
             "_tpl": "641074a07fd350b98c0b3f96",
             "parentId": "003c2c9db2b8dde27cc21c7c",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "f02daaee0df5d4e6bb4cfafd",
             "_tpl": "627e14b21713922ded6f2c15",
             "parentId": "hideout",
@@ -4819,82 +5507,98 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "de49cadbaedbae2d26c61eee",
             "_tpl": "628120fd5631d45211793c9f",
             "parentId": "f02daaee0df5d4e6bb4cfafd",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "f1afcfc1c19e44d1dac700ad",
             "_tpl": "62811f828193841aca4a45c3",
             "parentId": "1bcf0a88750fe0a1a19f6dba",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "cfad20fbb4e217dacc85a3d4",
             "_tpl": "628120c21d5df4475f46a337",
             "parentId": "5aec2a8ffe40cf1bb94b7efe",
             "slotId": "mod_mount_000"
-        }, {
+        },
+        {
             "_id": "115fb977a2cbb321b178cda9",
             "_tpl": "628120d309427b40ab14e76d",
             "parentId": "5aec2a8ffe40cf1bb94b7efe",
             "slotId": "mod_mount_001"
-        }, {
+        },
+        {
             "_id": "159a35d18d0bedcea2ebccb2",
             "_tpl": "628120d309427b40ab14e76d",
             "parentId": "5aec2a8ffe40cf1bb94b7efe",
             "slotId": "mod_mount_002"
-        }, {
+        },
+        {
             "_id": "6b899bad7dcce22cb653efff",
             "_tpl": "628120dd308cb521f87a8fa1",
             "parentId": "5aec2a8ffe40cf1bb94b7efe",
             "slotId": "mod_mount_003"
-        }, {
+        },
+        {
             "_id": "5aec2a8ffe40cf1bb94b7efe",
             "_tpl": "6281209662cba23f6c4d7a19",
             "parentId": "a0a3995b5addbef0ecbaffba",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "5e5e342add89308e8f7dde56",
             "_tpl": "6281212a09427b40ab14e770",
             "parentId": "a0a3995b5addbef0ecbaffba",
             "slotId": "mod_foregrip"
-        }, {
+        },
+        {
             "_id": "c95ab98bc272a47ea4cc7fac",
             "_tpl": "628120621d5df4475f46a335",
             "parentId": "b68dbe59abfa96d46b7d4bed",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "b68dbe59abfa96d46b7d4bed",
             "_tpl": "62812081d23f207deb0ab216",
             "parentId": "dba43d5ba99e8adcd8066f5e",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "dba43d5ba99e8adcd8066f5e",
             "_tpl": "628121434fa03b6b6c35dc6a",
             "parentId": "9ffc165e4ddeb74acee4d6ff",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "9ffc165e4ddeb74acee4d6ff",
             "_tpl": "62811fbf09427b40ab14e767",
             "parentId": "a0a3995b5addbef0ecbaffba",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "a0a3995b5addbef0ecbaffba",
             "_tpl": "6281204f308cb521f87a8f9b",
             "parentId": "1bcf0a88750fe0a1a19f6dba",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "1bcf0a88750fe0a1a19f6dba",
             "_tpl": "62811e2510e26c1f344e6554",
             "parentId": "f02daaee0df5d4e6bb4cfafd",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "f09a11ce5d904a8abadf2afc",
             "_tpl": "62811cd7308cb521f87a8f99",
             "parentId": "f02daaee0df5d4e6bb4cfafd",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "40bcd1980b5274f896bbecb7",
             "_tpl": "628120fd5631d45211793c9f",
             "parentId": "hideout",
@@ -4905,7 +5609,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "0e3e5dcab535dab6f281dc5c",
             "_tpl": "641074a07fd350b98c0b3f96",
             "parentId": "hideout",
@@ -4916,7 +5621,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "5b1c1f7b7d3ea76eb4f868ae",
             "_tpl": "6422e1ea3c0f06190302161a",
             "parentId": "hideout",
@@ -4927,7 +5633,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "8a624d589119c4d2a24de9b5",
             "_tpl": "6450ec2e7da7133e5a09ca96",
             "parentId": "hideout",
@@ -4938,7 +5645,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "79b74f9a54adcd8671d3eda0",
             "_tpl": "5c5970672e221602b21d7855",
             "parentId": "hideout",
@@ -4949,7 +5657,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f42ab266eb5d079fef2f8ffc",
             "_tpl": "587df583245977373c4f1129",
             "parentId": "hideout",
@@ -4960,7 +5669,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a331bf1a7c88cdcbe0d7a957",
             "_tpl": "5bfea7ad0db834001c38f1ee",
             "parentId": "hideout",
@@ -4971,7 +5681,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "eaaa847ac7c8cebfb5b1a59b",
             "_tpl": "5bfeaa0f0db834001b734927",
             "parentId": "hideout",

--- a/db/traders/6765fbd20fdc7eb79b00000b/assort.json
+++ b/db/traders/6765fbd20fdc7eb79b00000b/assort.json
@@ -1,1460 +1,1275 @@
 {
     "barter_scheme": {
         "eaaa4f07dde2f2931f8bdde4": [
-            [
-                {
+            [{
                     "_tpl": "56742c284bdc2d98058b456d",
                     "count": 5
                 }
             ]
         ],
         "b92dab04f7c919f620a2bec5": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 18000
                 }
             ]
         ],
         "a3ee33b02afcd42acc10a0fc": [
-            [
-                {
+            [{
                     "_tpl": "5d0378d486f77420421a5ff4",
                     "count": 2
                 }
             ]
         ],
         "d467fa8da6ff089edbfa7fe1": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 57000
                 }
             ]
         ],
         "fb52f9d44e810c41abfed05c": [
-            [
-                {
+            [{
                     "_tpl": "56742c2e4bdc2d95058b456d",
                     "count": 3
-                },
-                {
+                }, {
                     "_tpl": "5d1b313086f77425227d1678",
                     "count": 3
                 }
             ]
         ],
         "d9cdd4e5a76c15e542a82e76": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 36000
                 }
             ]
         ],
         "e4dcd1aae831dae84eca05cf": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3600
                 }
             ]
         ],
         "457322ec97ddfa2bd5c5bdd7": [
-            [
-                {
+            [{
                     "_tpl": "5887431f2459777e1612938f",
                     "count": 3
                 }
             ]
         ],
         "8aa340a5caf5b3dc3bd6f1e0": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1350
                 }
             ]
         ],
         "a707e551bf09eed6a32da74a": [
-            [
-                {
+            [{
                     "_tpl": "59e3577886f774176a362503",
                     "count": 1
                 }
             ]
         ],
         "cf5af2b57b78d9cc8b0e3c9f": [
-            [
-                {
+            [{
                     "_tpl": "572b7d8524597762b472f9d1",
                     "count": 3
                 }
             ]
         ],
         "62eba6bffdd622a4f6aadf45": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 8200
                 }
             ]
         ],
         "80b2afafa0c554ef12efafec": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 27000
                 }
             ]
         ],
         "ae2874d9cdefe6a3038befdf": [
-            [
-                {
+            [{
                     "_tpl": "5e2aee0a86f774755a234b62",
                     "count": 1
-                },
-                {
+                }, {
                     "_tpl": "5d03784a86f774203e7e0c4d",
                     "count": 1
                 }
             ]
         ],
         "deaa7060a81e84a6bbbc50af": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 90000
                 }
             ]
         ],
         "b6a2f8a5cfe2c78c746dee26": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 4400
                 }
             ]
         ],
         "3cc5f9d9ccbb41ffacb3e8f9": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 90000
                 }
             ]
         ],
         "dfcd1a2b8aefb3d55b86a0df": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "d9a8cac1b6edac29bc959d5d": [
-            [
-                {
+            [{
                     "_tpl": "57347d7224597744596b4e72",
                     "count": 2
-                },
-                {
+                }, {
                     "_tpl": "57347d8724597744596b4e76",
                     "count": 2
                 }
             ]
         ],
         "bc6ca2c2ef6aa46f3ac0fa05": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 30000
                 }
             ]
         ],
         "e9beeeced0b3cb909ef6ab4f": [
-            [
-                {
+            [{
                     "_tpl": "5e023cf8186a883be655e54f",
                     "count": 2
                 }
             ]
         ],
         "d76acd135e9606c5aa44ae60": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1300
                 }
             ]
         ],
         "dd6d3f7ecdfecd47f7d25322": [
-            [
-                {
+            [{
                     "_tpl": "5d235b4d86f7742e017bc88a",
                     "count": 5
                 }
             ]
         ],
         "74fedc1edf2226e1f33ce2bf": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 90000
                 }
             ]
         ],
         "f8f55d5ca1fd93019399d7fb": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 4200
                 }
             ]
         ],
         "fc4b0dfcfcb6ee9ffef903c2": [
-            [
-                {
+            [{
                     "_tpl": "57371f8d24597761006c6a81",
                     "count": 3
                 }
             ]
         ],
         "cd5d1e86edd1d11c4ae29e8f": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 75
                 }
             ]
         ],
         "2c063c6a7bc0f6df076cee60": [
-            [
-                {
+            [{
                     "_tpl": "59e6542b86f77411dc52a77a",
                     "count": 3
                 }
             ]
         ],
         "482d4fef762d731c600a97ea": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 105
                 }
             ]
         ],
         "bb4e0d27bfddf187408a79db": [
-            [
-                {
+            [{
                     "_tpl": "59e655cb86f77411dc52a77b",
                     "count": 6
                 }
             ]
         ],
         "94f8fb3791baa4f5acbb80dd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 75
                 }
             ]
         ],
         "254a6fb5a09ba346ada90813": [
-            [
-                {
+            [{
                     "_tpl": "5d1b39a386f774252339976f",
                     "count": 4
                 }
             ]
         ],
         "aac930d9f0f1293c50bb27ec": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 75000
                 }
             ]
         ],
         "b0da7a4cbde0d4f3d5c2bacf": [
-            [
-                {
+            [{
                     "_tpl": "560d61e84bdc2da74d8b4571",
                     "count": 3
                 }
             ]
         ],
         "41fbbf09de967378d627f968": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 855
                 }
             ]
         ],
         "85b6f03df9ecb327dbdfd6a7": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3200
                 }
             ]
         ],
         "5877e6bf1dd1e928361406c4": [
-            [
-                {
+            [{
                     "_tpl": "5d1b32c186f774252167a530",
                     "count": 5
                 }
             ]
         ],
         "d713bbbc4cc8dd73af2bd937": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 144000
                 }
             ]
         ],
         "977cb75f35769e0530fdd4dd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3000
                 }
             ]
         ],
         "f96edd4fe4f26e29b2345e56": [
-            [
-                {
+            [{
                     "_tpl": "5d0378d486f77420421a5ff4",
                     "count": 2
                 }
             ]
         ],
         "b0ce2a2ddbf1abace32836a0": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 68000
                 }
             ]
         ],
         "03de69cdaf82c89d5182df63": [
-            [
-                {
+            [{
                     "_tpl": "59e7708286f7742cbd762753",
                     "count": 3
                 }
             ]
         ],
         "0aee122fb0e3a09281697eff": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 7500
                 }
             ]
         ],
         "a4139dcac0782aaee3bd038d": [
-            [
-                {
+            [{
                     "_tpl": "5c13cef886f774072e618e82",
                     "count": 1
                 }
             ]
         ],
         "ebd3b7ec97a29dd3ccae9c84": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5600
                 }
             ]
         ],
         "4c8ddcf45edc5d3adbbd9edf": [
-            [
-                {
+            [{
                     "_tpl": "57347d7224597744596b4e72",
                     "count": 2
-                },
-                {
+                }, {
                     "_tpl": "57347d90245977448f7b7f65",
                     "count": 2
                 }
             ]
         ],
         "ff2cac4220f9dfbdbe97b5eb": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24000
                 }
             ]
         ],
         "5e2cdef9eee7633c9026fcfe": [
-            [
-                {
+            [{
                     "_tpl": "5d0375ff86f774186372f685",
                     "count": 1
-                },
-                {
+                }, {
                     "_tpl": "59e36c6f86f774176c10a2a7",
                     "count": 3
                 }
             ]
         ],
         "74db8832db8e346bffd5fe46": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 64000
                 }
             ]
         ],
         "cd1c070711aa27a77cd32f1b": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2000
                 }
             ]
         ],
         "6c4ef36ca1f6071dea1eaef0": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 6000
                 }
             ]
         ],
         "e25c5da0f9e3de58aa32ebcc": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 15000
                 }
             ]
         ],
         "2ec7bae63f35bd6be2aeb2f4": [
-            [
-                {
+            [{
                     "_tpl": "5d0376a486f7747d8050965c",
                     "count": 2
                 }
             ]
         ],
         "a58eeeaac8bdfeb3ac20c05d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 42000
                 }
             ]
         ],
         "1c45bc6bde85da1a3ac51d00": [
-            [
-                {
+            [{
                     "_tpl": "5d1b327086f7742525194449",
                     "count": 3
                 }
             ]
         ],
         "ecbf4c0367f5eb0b36f1ccdf": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 120000
                 }
             ]
         ],
         "ab5cf0b95ddc9c4f93f5bd04": [
-            [
-                {
+            [{
                     "_tpl": "5bd06f5d86f77427101ad47c",
                     "count": 3
                 }
             ]
         ],
         "57d4075f2eafaea98dcfae41": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 55000
                 }
             ]
         ],
         "31ab7e1f41ecfbfaa7f64bab": [
-            [
-                {
+            [{
                     "_tpl": "5734758f24597738025ee253",
                     "count": 3
                 }
             ]
         ],
         "5ced8db5a03f6afe5569bbb3": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 36000
                 }
             ]
         ],
         "bcc29a9fd5c39954544eabb5": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3600
                 }
             ]
         ],
         "538dfbc148f169d4c1294ceb": [
-            [
-                {
+            [{
                     "_tpl": "5d1b309586f77425227d1676",
                     "count": 3
                 }
             ]
         ],
         "dc232bbf20b811bfcc347f19": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 39000
                 }
             ]
         ],
         "76cd0aaef5bdede9d7f964d7": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1050
                 }
             ]
         ],
         "d4d6ddadea6b1fabaa08df93": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 9500
                 }
             ]
         ],
         "1d72cd9321b71e773dd77f9b": [
-            [
-                {
+            [{
                     "_tpl": "5ab8f4ff86f77431c60d91ba",
                     "count": 4
                 }
             ]
         ],
         "04ad2e8dc93c6cada0d3efdf": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 21000
                 }
             ]
         ],
         "7799bf35faafcdac4d7fad1e": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2700
                 }
             ]
         ],
         "d9b1f7643c6256e3b2d9d48f": [
-            [
-                {
+            [{
                     "_tpl": "590a3b0486f7743954552bdb",
                     "count": 5
                 }
             ]
         ],
         "b93de025c5ae0dcf4ddcc70f": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 50000
                 }
             ]
         ],
         "9dc68e0bc4bfee5eeff97dfb": [
-            [
-                {
+            [{
                     "_tpl": "575062b524597720a31c09a1",
                     "count": 4
                 }
             ]
         ],
         "f8de1e7cfad533cdafb11bcc": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 15000
                 }
             ]
         ],
         "4547c7f4e129efe87b8cadec": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1100
                 }
             ]
         ],
         "53dcbbeaf1a94d638cec299a": [
-            [
-                {
+            [{
                     "_tpl": "590a3b0486f7743954552bdb",
                     "count": 7
                 }
             ]
         ],
         "bdc81d1c0a8555706057cefe": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 72000
                 }
             ]
         ],
         "c030cb8697857ca8abadb81e": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2000
                 }
             ]
         ],
         "4e48ecaceb793ec9edbd6c7a": [
-            [
-                {
+            [{
                     "_tpl": "5c12613b86f7743bbe2c3f76",
                     "count": 1
                 }
             ]
         ],
         "9b5acf1bd712b23fc7bfdc74": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 135000
                 }
             ]
         ],
         "6e200ac32b7aa75c264d7fdc": [
-            [
-                {
+            [{
                     "_tpl": "619cbfeb6b8a1b37a54eebfa",
                     "count": 2
                 }
             ]
         ],
         "b58d3a7fdfdaafd12d35c111": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 96000
                 }
             ]
         ],
         "dfceccc7ddacec9fda862394": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1800
                 }
             ]
         ],
         "5f2eea4230cb688d19bcdffc": [
-            [
-                {
+            [{
                     "_tpl": "573603c924597764442bd9cb",
                     "count": 5
                 }
             ]
         ],
         "e1fc3c7e3e530cdc1fe9ad8f": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 330
                 }
             ]
         ],
         "dcd883de4eac0c9ceefe4e9b": [
-            [
-                {
+            [{
                     "_tpl": "59e77a2386f7742ee578960a",
                     "count": 2
                 }
             ]
         ],
         "be69cf6df3680ddbc8c0e39c": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1100
                 }
             ]
         ],
         "2edc91e27fcbcf23fbb997aa": [
-            [
-                {
+            [{
                     "_tpl": "5e023d34e8a400319a28ed44",
                     "count": 4
                 }
             ]
         ],
         "ff067fabc0caf50c8d0dd1e1": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1850
                 }
             ]
         ],
         "c923d6b01cab59a721ceacfd": [
-            [
-                {
+            [{
                     "_tpl": "5bc9be8fd4351e00334cae6e",
                     "count": 5
                 }
             ]
         ],
         "412b47756e68e3dcbab74cbb": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 19000
                 }
             ]
         ],
         "da8a2bd3c0bea312bbcd3e74": [
-            [
-                {
+            [{
                     "_tpl": "59e6658b86f77411d949b250",
                     "count": 5
                 }
             ]
         ],
         "8d694d5f50ffa2449f6f9fbb": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 700
                 }
             ]
         ],
         "dfcedcf85a228fa9c7d7d114": [
-            [
-                {
+            [{
                     "_tpl": "5e2af29386f7746d4159f077",
                     "count": 4
                 }
             ]
         ],
         "af0feddae5728df8d5e7c2ca": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 54000
                 }
             ]
         ],
         "5b8e8cea43272d4e44aaf540": [
-            [
-                {
+            [{
                     "_tpl": "5b4329075acfc400153b78ff",
                     "count": 4
                 }
             ]
         ],
         "07e8bdbc54ffec30531821f8": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 16000
                 }
             ]
         ],
         "f9052d17426eab4a97c8cea2": [
-            [
-                {
+            [{
                     "_tpl": "5b43575a86f77424f443fe62",
                     "count": 4
                 }
             ]
         ],
         "2008e929887d0fee68eef7dc": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 84000
                 }
             ]
         ],
         "bdff25636c0c9bcc4dddd7f6": [
-            [
-                {
+            [{
                     "_tpl": "5d1b327086f7742525194449",
                     "count": 5
                 }
             ]
         ],
         "b51a839b94a75a787a208dbf": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 206000
                 }
             ]
         ],
         "61f7bef9c04afa27ae91fcfd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 14000
                 }
             ]
         ],
         "2a3def3e8473ea8ad3d7ee9a": [
-            [
-                {
+            [{
                     "_tpl": "5fc382b6d6fa9c00c571bbc3",
                     "count": 15
                 }
             ]
         ],
         "bfcb182d41414b1af00c5aa4": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1700
                 }
             ]
         ],
         "0fe7e0e2c768a24dfbdf4bbb": [
-            [
-                {
+            [{
                     "_tpl": "5fc275cf85fd526b824a571a",
                     "count": 5
                 }
             ]
         ],
         "66ffc62dc5bdad9cf3fc9e78": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 4500
                 }
             ]
         ],
         "1eb98bc6bd7fa14adeaae79b": [
-            [
-                {
+            [{
                     "_tpl": "5fc382c1016cce60e8341b20",
                     "count": 4
                 }
             ]
         ],
         "adda4698b69d08ccecab2468": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 700
                 }
             ]
         ],
         "d0da2cfbbb47e16fbcafc761": [
-            [
-                {
+            [{
                     "_tpl": "56742c284bdc2d98058b456d",
                     "count": 1
                 }
             ]
         ],
         "fbaccb9eae1be092833ec45d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 780
                 }
             ]
         ],
         "d4bf97cfacae69bfd1c75636": [
-            [
-                {
+            [{
                     "_tpl": "5bc9c29cd4351e003562b8a3",
                     "count": 6
                 }
             ]
         ],
         "dcde076bf069b7efde4bfcfe": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 25500
                 }
             ]
         ],
         "01b6dd97d9e8d2bee3fdf73c": [
-            [
-                {
+            [{
                     "_tpl": "590c651286f7741e566b6461",
                     "count": 3
                 }
             ]
         ],
         "ae4fcda9fedd3afa9ffeeaeb": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 57000
                 }
             ]
         ],
         "4dafe80ace8bbd86c85d0fde": [
-            [
-                {
+            [{
                     "_tpl": "5bc9b355d4351e6d1509862a",
                     "count": 1
                 }
             ]
         ],
         "ca3dc4093fc1ae5683f89e4f": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 28000
                 }
             ]
         ],
         "adec1bf1d41f0cf2f4afe3ae": [
-            [
-                {
+            [{
                     "_tpl": "590c5c9f86f77477c91c36e7",
                     "count": 1
                 }
             ]
         ],
         "98caede86cabc99dee96a95c": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 20000
                 }
             ]
         ],
         "1cbd1cca1aab6f1fcb50fd8a": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2000
                 }
             ]
         ],
         "f5ddeb8ccfdc7dbaec7fbf18": [
-            [
-                {
+            [{
                     "_tpl": "61bf83814088ec1a363d7097",
                     "count": 6
                 }
             ]
         ],
         "f2eacf53404dbc5a62b7b1ad": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 160000
                 }
             ]
         ],
         "c51bb3702304ece7edcd76dd": [
-            [
-                {
+            [{
                     "_tpl": "573477e124597737dd42e191",
                     "count": 6
                 }
             ]
         ],
         "aad9edc3287b4ce81e9707ca": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 27000
                 }
             ]
         ],
         "70de7dfe8e6b0ed0794e2d19": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "e4ded52bfbe5b42c294f0ffe": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 250
                 }
             ]
         ],
         "3fe2f21b9b0d86dff054ffe4": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "be48b7ccd293d9f2e5546e8d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 225
                 }
             ]
         ],
         "f65fa316c9cb7fd50034f7cb": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "ada484f2dcba351b1ede85f0": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 180
                 }
             ]
         ],
         "bcd8abaf2db0f2bdc8ddbdc6": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "fbe194db904dd12abc8c4a9f": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 10500
                 }
             ]
         ],
         "058da8bb6cea515b80eabf4b": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "aac9cfafd213af399be3722d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 19000
                 }
             ]
         ],
         "194a1e97f6d112880c100284": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "fa2dac4fadacaaafec31cbde": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 21000
                 }
             ]
         ],
         "d37f2c22c97cb77aa78ddacf": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "4e80ce2f131e3305dc6c5dea": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 25500
                 }
             ]
         ],
         "8ee57a37dfdc46cb2ae27fcc": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "dbe8dd4dcfec2cdbdf6ecf2a": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 25500
                 }
             ]
         ],
         "fbade5bda9fe6bb2a236dd1f": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "b1e20be1e2ea02ee63d6fbd1": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 28500
                 }
             ]
         ],
         "a55fcbaa1ab2ca7ebfceca03": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "0ccb05c2c9ba1a5959c324d1": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24500
                 }
             ]
         ],
         "e781e5573e2c5c3ce62aaba2": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "f7bb73f55d746cfbf1a5476b": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24500
                 }
             ]
         ],
         "eab787b9fb1dd688fbc3e267": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "5eddfef14fbcef75abb19cf2": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60000
                 }
             ]
         ],
         "ee2a5e834ba218c63dacbbeb": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "8b154d0ef5be36aec1c5a388": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60000
                 }
             ]
         ],
         "cc0ad6e59c08ac28ed713ebb": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "6b4c4e83bbffd4e6dcdfb5e8": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 55000
                 }
             ]
         ],
         "2aaec2a0f01689f75c7d327b": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "ad13ca88ce67db71cac9bac9": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 81000
                 }
             ]
         ],
         "8d1cbe53be42e0ce71ebb90a": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "af5f3cfda9449b2b7befc5d1": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 73000
                 }
             ]
         ],
         "b722a58fb68eedcaec08388d": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "cd1d3f7fd0ef4b7a42f9734c": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 84000
                 }
             ]
         ],
         "dbe67442de3cf36b0e2acdd0": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "bb3090d5b8e9cbf2fa977bfd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 174000
                 }
             ]
         ],
         "9f73e7bb5ff3fae70beecc63": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "4cb54d4faefafe34b2d0fba0": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 43000
                 }
             ]
         ],
         "05ab0dd0f83897027adb14b4": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "dfebbc2c79d7da7caee7f46e": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 57000
                 }
             ]
         ],
         "6bf919996e3f7d9442b4f4bf": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "d589abf8bd03bbbf7fd9fd58": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 39000
                 }
             ]
         ],
         "2464cf8a8e8a1fbfd0f9eba0": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "d3b6abcadbdfb0c1deeeaf4c": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 78000
                 }
             ]
         ],
         "fe7eb0f3e1ee7dbd49dbed3a": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "638dae2266adbbef13f6a57d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 80000
                 }
             ]
         ],
         "003c2c9db2b8dde27cc21c7c": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "bf8a68cc1c5b35a8a27c7eed": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 38500
                 }
             ]
         ],
         "f02daaee0df5d4e6bb4cfafd": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "0a6c89c0beff4a99a1218348": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 135000
                 }
             ]
         ],
         "40bcd1980b5274f896bbecb7": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 9000
                 }
             ]
         ],
         "0e3e5dcab535dab6f281dc5c": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5400
                 }
             ]
         ],
         "5b1c1f7b7d3ea76eb4f868ae": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5400
                 }
             ]
         ],
         "8a624d589119c4d2a24de9b5": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 4200
                 }
             ]
-        ],        
+        ],
         "79b74f9a54adcd8671d3eda0": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 15500
                 }
             ]
         ],
         "f42ab266eb5d079fef2f8ffc": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5300
                 }
             ]
         ],
         "a331bf1a7c88cdcbe0d7a957": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1600
                 }
             ]
         ],
         "eaaa847ac7c8cebfb5b1a59b": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3200
                 }
             ]
         ]
     },
-    "items": [
-        {
+    "items": [{
             "_id": "a4139dcac0782aaee3bd038d",
             "_tpl": "5ab8f04f86f774585f4237d8",
             "parentId": "hideout",
@@ -1465,8 +1280,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "03de69cdaf82c89d5182df63",
             "_tpl": "5ab8ee7786f7742d8f33f0b9",
             "parentId": "hideout",
@@ -1477,8 +1291,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "cf5af2b57b78d9cc8b0e3c9f",
             "_tpl": "56e33680d2720be2748b4576",
             "parentId": "hideout",
@@ -1489,8 +1302,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "5b8e8cea43272d4e44aaf540",
             "_tpl": "5f5e45cc5021ce62144be7aa",
             "parentId": "hideout",
@@ -1501,8 +1313,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "eaaa4f07dde2f2931f8bdde4",
             "_tpl": "544a5cde4bdc2d39388b456b",
             "parentId": "hideout",
@@ -1513,8 +1324,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "1d72cd9321b71e773dd77f9b",
             "_tpl": "5ca20d5986f774331e7c9602",
             "parentId": "hideout",
@@ -1525,8 +1335,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "adec1bf1d41f0cf2f4afe3ae",
             "_tpl": "60a2828e8689911a226117f9",
             "parentId": "hideout",
@@ -1537,8 +1346,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d4bf97cfacae69bfd1c75636",
             "_tpl": "6034d103ca006d2dca39b3f0",
             "parentId": "hideout",
@@ -1549,8 +1357,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "4dafe80ace8bbd86c85d0fde",
             "_tpl": "60a272cc93ef783291411d8e",
             "parentId": "hideout",
@@ -1561,8 +1368,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c51bb3702304ece7edcd76dd",
             "_tpl": "618cfae774bb2d036a049e7c",
             "parentId": "hideout",
@@ -1573,8 +1379,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d9b1f7643c6256e3b2d9d48f",
             "_tpl": "5d5d940f86f7742797262046",
             "parentId": "hideout",
@@ -1585,8 +1390,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c923d6b01cab59a721ceacfd",
             "_tpl": "5e4abc6786f77406812bd572",
             "parentId": "hideout",
@@ -1597,8 +1401,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a3ee33b02afcd42acc10a0fc",
             "_tpl": "545cdae64bdc2d39198b4568",
             "parentId": "hideout",
@@ -1609,8 +1412,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "5e2cdef9eee7633c9026fcfe",
             "_tpl": "5b44c6ae86f7742d1627baea",
             "parentId": "hideout",
@@ -1621,8 +1423,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ab5cf0b95ddc9c4f93f5bd04",
             "_tpl": "5c0e805e86f774683f3dd637",
             "parentId": "hideout",
@@ -1633,8 +1434,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "01b6dd97d9e8d2bee3fdf73c",
             "_tpl": "6034d2d697633951dc245ea6",
             "parentId": "hideout",
@@ -1645,8 +1445,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f9052d17426eab4a97c8cea2",
             "_tpl": "5f5e46b96bdad616ad46d613",
             "parentId": "hideout",
@@ -1657,8 +1456,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "254a6fb5a09ba346ada90813",
             "_tpl": "59e763f286f7742ee57895da",
             "parentId": "hideout",
@@ -1669,8 +1467,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "1c45bc6bde85da1a3ac51d00",
             "_tpl": "5c0e774286f77468413cc5b2",
             "parentId": "hideout",
@@ -1681,8 +1478,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "4e48ecaceb793ec9edbd6c7a",
             "_tpl": "5df8a4d786f77412672a1e3b",
             "parentId": "hideout",
@@ -1693,8 +1489,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ebd3b7ec97a29dd3ccae9c84",
             "_tpl": "5ab8f04f86f774585f4237d8",
             "parentId": "hideout",
@@ -1705,8 +1500,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "0aee122fb0e3a09281697eff",
             "_tpl": "5ab8ee7786f7742d8f33f0b9",
             "parentId": "hideout",
@@ -1717,8 +1511,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "62eba6bffdd622a4f6aadf45",
             "_tpl": "56e33680d2720be2748b4576",
             "parentId": "hideout",
@@ -1729,8 +1522,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "07e8bdbc54ffec30531821f8",
             "_tpl": "5f5e45cc5021ce62144be7aa",
             "parentId": "hideout",
@@ -1741,8 +1533,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b92dab04f7c919f620a2bec5",
             "_tpl": "544a5cde4bdc2d39388b456b",
             "parentId": "hideout",
@@ -1753,8 +1544,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "04ad2e8dc93c6cada0d3efdf",
             "_tpl": "5ca20d5986f774331e7c9602",
             "parentId": "hideout",
@@ -1765,8 +1555,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "98caede86cabc99dee96a95c",
             "_tpl": "60a2828e8689911a226117f9",
             "parentId": "hideout",
@@ -1777,8 +1566,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "dcde076bf069b7efde4bfcfe",
             "_tpl": "6034d103ca006d2dca39b3f0",
             "parentId": "hideout",
@@ -1789,8 +1577,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ca3dc4093fc1ae5683f89e4f",
             "_tpl": "60a272cc93ef783291411d8e",
             "parentId": "hideout",
@@ -1801,8 +1588,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "aad9edc3287b4ce81e9707ca",
             "_tpl": "618cfae774bb2d036a049e7c",
             "parentId": "hideout",
@@ -1813,8 +1599,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b93de025c5ae0dcf4ddcc70f",
             "_tpl": "5d5d940f86f7742797262046",
             "parentId": "hideout",
@@ -1825,8 +1610,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "412b47756e68e3dcbab74cbb",
             "_tpl": "5e4abc6786f77406812bd572",
             "parentId": "hideout",
@@ -1837,8 +1621,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d467fa8da6ff089edbfa7fe1",
             "_tpl": "545cdae64bdc2d39198b4568",
             "parentId": "hideout",
@@ -1849,8 +1632,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "74db8832db8e346bffd5fe46",
             "_tpl": "5b44c6ae86f7742d1627baea",
             "parentId": "hideout",
@@ -1861,8 +1643,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "57d4075f2eafaea98dcfae41",
             "_tpl": "5c0e805e86f774683f3dd637",
             "parentId": "hideout",
@@ -1873,8 +1654,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ae4fcda9fedd3afa9ffeeaeb",
             "_tpl": "6034d2d697633951dc245ea6",
             "parentId": "hideout",
@@ -1885,8 +1665,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "2008e929887d0fee68eef7dc",
             "_tpl": "5f5e46b96bdad616ad46d613",
             "parentId": "hideout",
@@ -1897,8 +1676,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "aac930d9f0f1293c50bb27ec",
             "_tpl": "59e763f286f7742ee57895da",
             "parentId": "hideout",
@@ -1909,8 +1687,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ecbf4c0367f5eb0b36f1ccdf",
             "_tpl": "5c0e774286f77468413cc5b2",
             "parentId": "hideout",
@@ -1921,8 +1698,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "9b5acf1bd712b23fc7bfdc74",
             "_tpl": "5df8a4d786f77412672a1e3b",
             "parentId": "hideout",
@@ -1933,8 +1709,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fc4b0dfcfcb6ee9ffef903c2",
             "_tpl": "59e6542b86f77411dc52a77a",
             "parentId": "hideout",
@@ -1945,8 +1720,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "2c063c6a7bc0f6df076cee60",
             "_tpl": "59e655cb86f77411dc52a77b",
             "parentId": "hideout",
@@ -1957,8 +1731,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bb4e0d27bfddf187408a79db",
             "_tpl": "59e6658b86f77411d949b250",
             "parentId": "hideout",
@@ -1969,8 +1742,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "da8a2bd3c0bea312bbcd3e74",
             "_tpl": "5f0596629e22f464da6bbdd9",
             "parentId": "hideout",
@@ -1981,8 +1753,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "cd5d1e86edd1d11c4ae29e8f",
             "_tpl": "59e6542b86f77411dc52a77a",
             "parentId": "hideout",
@@ -1993,8 +1764,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "482d4fef762d731c600a97ea",
             "_tpl": "59e655cb86f77411dc52a77b",
             "parentId": "hideout",
@@ -2005,8 +1775,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "94f8fb3791baa4f5acbb80dd",
             "_tpl": "59e6658b86f77411d949b250",
             "parentId": "hideout",
@@ -2017,8 +1786,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "8d694d5f50ffa2449f6f9fbb",
             "_tpl": "5f0596629e22f464da6bbdd9",
             "parentId": "hideout",
@@ -2029,8 +1797,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "5f2eea4230cb688d19bcdffc",
             "_tpl": "5e023cf8186a883be655e54f",
             "parentId": "hideout",
@@ -2041,8 +1808,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e9beeeced0b3cb909ef6ab4f",
             "_tpl": "5887431f2459777e1612938f",
             "parentId": "hideout",
@@ -2053,8 +1819,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "457322ec97ddfa2bd5c5bdd7",
             "_tpl": "560d61e84bdc2da74d8b4571",
             "parentId": "hideout",
@@ -2065,8 +1830,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a707e551bf09eed6a32da74a",
             "_tpl": "560d75f54bdc2da74d8b4573",
             "parentId": "hideout",
@@ -2077,14 +1841,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "9a6f2dcaeeaed51a70d96c60",
             "_tpl": "560d61e84bdc2da74d8b4571",
             "parentId": "a707e551bf09eed6a32da74a",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 20
+            }
+        }, {
             "_id": "6c4ef36ca1f6071dea1eaef0",
             "_tpl": "5bae13ded4351e44f824bf38",
             "parentId": "hideout",
@@ -2095,8 +1861,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b0da7a4cbde0d4f3d5c2bacf",
             "_tpl": "59e77a2386f7742ee578960a",
             "parentId": "hideout",
@@ -2107,8 +1872,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d4d6ddadea6b1fabaa08df93",
             "_tpl": "5c88f24b2e22160bc12c69a6",
             "parentId": "hideout",
@@ -2119,8 +1883,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "dcd883de4eac0c9ceefe4e9b",
             "_tpl": "5e023d34e8a400319a28ed44",
             "parentId": "hideout",
@@ -2131,8 +1894,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "2edc91e27fcbcf23fbb997aa",
             "_tpl": "5e023d48186a883be655e551",
             "parentId": "hideout",
@@ -2143,8 +1905,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e1fc3c7e3e530cdc1fe9ad8f",
             "_tpl": "5e023cf8186a883be655e54f",
             "parentId": "hideout",
@@ -2155,8 +1916,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d76acd135e9606c5aa44ae60",
             "_tpl": "5887431f2459777e1612938f",
             "parentId": "hideout",
@@ -2167,8 +1927,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "8aa340a5caf5b3dc3bd6f1e0",
             "_tpl": "560d61e84bdc2da74d8b4571",
             "parentId": "hideout",
@@ -2179,8 +1938,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "41fbbf09de967378d627f968",
             "_tpl": "59e77a2386f7742ee578960a",
             "parentId": "hideout",
@@ -2191,8 +1949,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "be69cf6df3680ddbc8c0e39c",
             "_tpl": "5e023d34e8a400319a28ed44",
             "parentId": "hideout",
@@ -2203,8 +1960,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ff067fabc0caf50c8d0dd1e1",
             "_tpl": "5e023d48186a883be655e551",
             "parentId": "hideout",
@@ -2215,8 +1971,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d0da2cfbbb47e16fbcafc761",
             "_tpl": "5fc382c1016cce60e8341b20",
             "parentId": "hideout",
@@ -2227,8 +1982,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "1eb98bc6bd7fa14adeaae79b",
             "_tpl": "5fc382b6d6fa9c00c571bbc3",
             "parentId": "hideout",
@@ -2239,8 +1993,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "2a3def3e8473ea8ad3d7ee9a",
             "_tpl": "5fc275cf85fd526b824a571a",
             "parentId": "hideout",
@@ -2251,8 +2004,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "0fe7e0e2c768a24dfbdf4bbb",
             "_tpl": "5fc382a9d724d907e2077dab",
             "parentId": "hideout",
@@ -2263,8 +2015,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fbaccb9eae1be092833ec45d",
             "_tpl": "5fc382c1016cce60e8341b20",
             "parentId": "hideout",
@@ -2275,8 +2026,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "adda4698b69d08ccecab2468",
             "_tpl": "5fc382b6d6fa9c00c571bbc3",
             "parentId": "hideout",
@@ -2287,8 +2037,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bfcb182d41414b1af00c5aa4",
             "_tpl": "5fc275cf85fd526b824a571a",
             "parentId": "hideout",
@@ -2299,8 +2048,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "66ffc62dc5bdad9cf3fc9e78",
             "_tpl": "5fc382a9d724d907e2077dab",
             "parentId": "hideout",
@@ -2311,8 +2059,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "9dc68e0bc4bfee5eeff97dfb",
             "_tpl": "5de652c31b7e3716273428be",
             "parentId": "hideout",
@@ -2323,38 +2070,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b9a674eebbfc0a0804ed7f2c",
             "_tpl": "5de653abf76fdc1ce94a5a2a",
             "parentId": "9dc68e0bc4bfee5eeff97dfb",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "b22eadc8f42be036a16e51c5",
             "_tpl": "5de655be4a9f347bc92edb88",
             "parentId": "9dc68e0bc4bfee5eeff97dfb",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "506aeb9bdce5e6cdd76bcf70",
             "_tpl": "5de65547883dde217541644b",
             "parentId": "9dc68e0bc4bfee5eeff97dfb",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "8d7331caafee9ef437c748ea",
             "_tpl": "5de6556a205ddc616a6bc4f7",
             "parentId": "506aeb9bdce5e6cdd76bcf70",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "8f2ced5bedf1fbb87aaf9f4c",
             "_tpl": "5de6558e9f98ac2bc65950fc",
             "parentId": "9dc68e0bc4bfee5eeff97dfb",
             "slotId": "mod_mount"
-        },
-        {
+        }, {
             "_id": "4c8ddcf45edc5d3adbbd9edf",
             "_tpl": "5ae08f0a5acfc408fb1398a1",
             "parentId": "hideout",
@@ -2365,38 +2106,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7f7b9dfe7b94466fd0b32aa6",
             "_tpl": "5ae0973a5acfc4001562206c",
             "parentId": "4c8ddcf45edc5d3adbbd9edf",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "e09bdcacaef4bdb17c2ceecc",
             "_tpl": "5ae096d95acfc400185c2c81",
             "parentId": "4c8ddcf45edc5d3adbbd9edf",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "d6f7d1bf85eb8bea45b548df",
             "_tpl": "5ae09bff5acfc4001562219d",
             "parentId": "4c8ddcf45edc5d3adbbd9edf",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "fadc04ab3bee00bc7d21c404",
             "_tpl": "5ae099875acfc4001714e593",
             "parentId": "d6f7d1bf85eb8bea45b548df",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "bc344d05868b33f79bcdcc2d",
             "_tpl": "5ae099925acfc4001a5fc7b3",
             "parentId": "d6f7d1bf85eb8bea45b548df",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "d9a8cac1b6edac29bc959d5d",
             "_tpl": "587e02ff24597743df3deaeb",
             "parentId": "hideout",
@@ -2407,56 +2142,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "6670e1e2622e80dbf3056c2f",
-          "_tpl": "587e0531245977466077a0f7",
-          "parentId": "d9a8cac1b6edac29bc959d5d",
-          "slotId": "mod_stock"
-        },
-        {
-          "_id": "6670e1e2622e80dbf3056c30",
-          "_tpl": "634eff66517ccc8a960fc735",
-          "parentId": "d9a8cac1b6edac29bc959d5d",
-          "slotId": "mod_barrel"
-        },
-        {
-          "_id": "6670e1e2622e80dbf3056c31",
-          "_tpl": "634f05a21f9f536910079b56",
-          "parentId": "6670e1e2622e80dbf3056c30",
-          "slotId": "mod_mount_000"
-        },
-        {
-          "_id": "6670e1e2622e80dbf3056c32",
-          "_tpl": "634f036a517ccc8a960fc746",
-          "parentId": "6670e1e2622e80dbf3056c31",
-          "slotId": "mod_gas_block"
-        },
-        {
-          "_id": "6670e1e2622e80dbf3056c33",
-          "_tpl": "634f03d40384a3ba4f06f874",
-          "parentId": "6670e1e2622e80dbf3056c32",
-          "slotId": "mod_mount_000"
-        },
-        {
-          "_id": "6670e1e2622e80dbf3056c34",
-          "_tpl": "574db213245977459a2f3f5d",
-          "parentId": "6670e1e2622e80dbf3056c31",
-          "slotId": "mod_sight_rear"
-        },
-        {
-          "_id": "6670e1e2622e80dbf3056c35",
-          "_tpl": "587df3a12459772c28142567",
-          "parentId": "d9a8cac1b6edac29bc959d5d",
-          "slotId": "mod_magazine"
-        },
-        {
-          "_id": "6670e1e2622e80dbf3056c36",
-          "_tpl": "634f06262e5def262d0b30ca",
-          "parentId": "d9a8cac1b6edac29bc959d5d",
-          "slotId": "mod_reciever"
-        },
-        {
+        }, {
+            "_id": "6670e1e2622e80dbf3056c2f",
+            "_tpl": "587e0531245977466077a0f7",
+            "parentId": "d9a8cac1b6edac29bc959d5d",
+            "slotId": "mod_stock"
+        }, {
+            "_id": "6670e1e2622e80dbf3056c30",
+            "_tpl": "634eff66517ccc8a960fc735",
+            "parentId": "d9a8cac1b6edac29bc959d5d",
+            "slotId": "mod_barrel"
+        }, {
+            "_id": "6670e1e2622e80dbf3056c31",
+            "_tpl": "634f05a21f9f536910079b56",
+            "parentId": "6670e1e2622e80dbf3056c30",
+            "slotId": "mod_mount_000"
+        }, {
+            "_id": "6670e1e2622e80dbf3056c32",
+            "_tpl": "634f036a517ccc8a960fc746",
+            "parentId": "6670e1e2622e80dbf3056c31",
+            "slotId": "mod_gas_block"
+        }, {
+            "_id": "6670e1e2622e80dbf3056c33",
+            "_tpl": "634f03d40384a3ba4f06f874",
+            "parentId": "6670e1e2622e80dbf3056c32",
+            "slotId": "mod_mount_000"
+        }, {
+            "_id": "6670e1e2622e80dbf3056c34",
+            "_tpl": "574db213245977459a2f3f5d",
+            "parentId": "6670e1e2622e80dbf3056c31",
+            "slotId": "mod_sight_rear"
+        }, {
+            "_id": "6670e1e2622e80dbf3056c35",
+            "_tpl": "587df3a12459772c28142567",
+            "parentId": "d9a8cac1b6edac29bc959d5d",
+            "slotId": "mod_magazine"
+        }, {
+            "_id": "6670e1e2622e80dbf3056c36",
+            "_tpl": "634f06262e5def262d0b30ca",
+            "parentId": "d9a8cac1b6edac29bc959d5d",
+            "slotId": "mod_reciever"
+        }, {
             "_id": "538dfbc148f169d4c1294ceb",
             "_tpl": "5c501a4d2e221602b412b540",
             "parentId": "hideout",
@@ -2467,38 +2193,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "eec55cdba1af63daa1ede81e",
             "_tpl": "5c5039be2e221602b177c9ff",
             "parentId": "538dfbc148f169d4c1294ceb",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "c4fcebd9fc4cdd8478cf5daa",
             "_tpl": "5c503d0a2e221602b542b7ef",
             "parentId": "538dfbc148f169d4c1294ceb",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "4b0e6947546a3cdefe78f5e4",
             "_tpl": "5c503b1c2e221602b21d6e9d",
             "parentId": "538dfbc148f169d4c1294ceb",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "8cb42a7a07f689dcbebe1e52",
             "_tpl": "5c503af12e221602b177ca02",
             "parentId": "538dfbc148f169d4c1294ceb",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "e6cb1491044aee8cffb27b46",
             "_tpl": "5c503ac82e221602b21d6e9a",
             "parentId": "538dfbc148f169d4c1294ceb",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "4547c7f4e129efe87b8cadec",
             "_tpl": "5de653abf76fdc1ce94a5a2a",
             "parentId": "hideout",
@@ -2509,8 +2229,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "76cd0aaef5bdede9d7f964d7",
             "_tpl": "5c503ac82e221602b21d6e9a",
             "parentId": "hideout",
@@ -2521,8 +2240,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "2ec7bae63f35bd6be2aeb2f4",
             "_tpl": "5bfea6e90db834001b7347f3",
             "parentId": "hideout",
@@ -2533,26 +2251,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "cc8f8f7c0a8bc8f6ff8a8edd",
             "_tpl": "5bfea7ad0db834001c38f1ee",
             "parentId": "2ec7bae63f35bd6be2aeb2f4",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "02e62cdd906befce5a7a6bcc",
             "_tpl": "5bfeb32b0db834001a6694d9",
             "parentId": "2ec7bae63f35bd6be2aeb2f4",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "d074c3ecaa4b7abeeae4b4ce",
             "_tpl": "5bfebc320db8340019668d79",
             "parentId": "2ec7bae63f35bd6be2aeb2f4",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "53dcbbeaf1a94d638cec299a",
             "_tpl": "5df24cf80dee1b22f862e9bc",
             "parentId": "hideout",
@@ -2563,86 +2277,72 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "94c1dfb4a4c92e93b00eab63",
             "_tpl": "5df25b6c0b92095fd441e4cf",
             "parentId": "53dcbbeaf1a94d638cec299a",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "bdcba0eea275eaa07e6ffc9f",
             "_tpl": "5df256570dee1b22f862e9c4",
             "parentId": "53dcbbeaf1a94d638cec299a",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "ece5f2d24fb2f06ff86fcc0e",
             "_tpl": "5df35e7f2a78646d96665dd4",
             "parentId": "bdcba0eea275eaa07e6ffc9f",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "acf3ef4a85ed32fecdc322fd",
             "_tpl": "5df35e59c41b2312ea3334d5",
             "parentId": "53dcbbeaf1a94d638cec299a",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "edcb4fa5a5bbdeabda5d11bd",
             "_tpl": "5df25d3bfd6b4e6e2276dc9a",
             "parentId": "acf3ef4a85ed32fecdc322fd",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "35c6a4bb5e3d66a57cbbeb15",
             "_tpl": "5df35eb2b11454561e3923e2",
             "parentId": "edcb4fa5a5bbdeabda5d11bd",
             "slotId": "mod_mount_000"
-        },
-        {
+        }, {
             "_id": "bff4c8d49fd75ec669344bd7",
             "_tpl": "5df35eb2b11454561e3923e2",
             "parentId": "edcb4fa5a5bbdeabda5d11bd",
             "slotId": "mod_mount_001"
-        },
-        {
+        }, {
             "_id": "f8b5ad9c9afc9838dfe40fdb",
             "_tpl": "5df35ea9c41b2312ea3334d8",
             "parentId": "edcb4fa5a5bbdeabda5d11bd",
             "slotId": "mod_mount_002"
-        },
-        {
+        }, {
             "_id": "76f6fafdeabda3d7ac800cc5",
             "_tpl": "5df35eb2b11454561e3923e2",
             "parentId": "edcb4fa5a5bbdeabda5d11bd",
             "slotId": "mod_mount_003"
-        },
-        {
+        }, {
             "_id": "1d7a3d67d70eb782becd0dce",
             "_tpl": "5df36948bb49d91fb446d5ad",
             "parentId": "edcb4fa5a5bbdeabda5d11bd",
             "slotId": "mod_foregrip"
-        },
-        {
+        }, {
             "_id": "b0fa9fb8cb423fe835fc7d3f",
             "_tpl": "5df38a5fb74cd90030650cb6",
             "parentId": "acf3ef4a85ed32fecdc322fd",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "eeb1a114dced5c09587df0b2",
             "_tpl": "5df35ddddfc58d14537c2036",
             "parentId": "acf3ef4a85ed32fecdc322fd",
             "slotId": "mod_stock_axis"
-        },
-        {
+        }, {
             "_id": "76247094fd8e73c4a4c7b8fc",
             "_tpl": "5df35e970b92095fd441e4d2",
             "parentId": "53dcbbeaf1a94d638cec299a",
             "slotId": "mod_mount"
-        },
-        {
+        }, {
             "_id": "fb52f9d44e810c41abfed05c",
             "_tpl": "55801eed4bdc2d89578b4588",
             "parentId": "hideout",
@@ -2653,44 +2353,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d29",
-          "_tpl": "559ba5b34bdc2d1f1a8b4582",
-          "parentId": "fb52f9d44e810c41abfed05c",
-          "slotId": "mod_magazine"
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d2a",
-          "_tpl": "56083e1b4bdc2dc8488b4572",
-          "parentId": "fb52f9d44e810c41abfed05c",
-          "slotId": "mod_sight_rear"
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d2b",
-          "_tpl": "56083eab4bdc2d26448b456a",
-          "parentId": "fb52f9d44e810c41abfed05c",
-          "slotId": "mod_tactical"
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d2c",
-          "_tpl": "560e620e4bdc2d724b8b456b",
-          "parentId": "fb52f9d44e810c41abfed05c",
-          "slotId": "mod_muzzle"
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d2f",
-          "_tpl": "61faa91878830f069b6b7967",
-          "parentId": "fb52f9d44e810c41abfed05c",
-          "slotId": "mod_stock"
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d2e",
-          "_tpl": "56ea8222d2720b69698b4567",
-          "parentId": "6670e6bb622e80dbf3056d2f",
-          "slotId": "mod_bipod"
-        },
-        {
+        }, {
+            "_id": "6670e6bb622e80dbf3056d29",
+            "_tpl": "559ba5b34bdc2d1f1a8b4582",
+            "parentId": "fb52f9d44e810c41abfed05c",
+            "slotId": "mod_magazine"
+        }, {
+            "_id": "6670e6bb622e80dbf3056d2a",
+            "_tpl": "56083e1b4bdc2dc8488b4572",
+            "parentId": "fb52f9d44e810c41abfed05c",
+            "slotId": "mod_sight_rear"
+        }, {
+            "_id": "6670e6bb622e80dbf3056d2b",
+            "_tpl": "56083eab4bdc2d26448b456a",
+            "parentId": "fb52f9d44e810c41abfed05c",
+            "slotId": "mod_tactical"
+        }, {
+            "_id": "6670e6bb622e80dbf3056d2c",
+            "_tpl": "560e620e4bdc2d724b8b456b",
+            "parentId": "fb52f9d44e810c41abfed05c",
+            "slotId": "mod_muzzle"
+        }, {
+            "_id": "6670e6bb622e80dbf3056d2f",
+            "_tpl": "61faa91878830f069b6b7967",
+            "parentId": "fb52f9d44e810c41abfed05c",
+            "slotId": "mod_stock"
+        }, {
+            "_id": "6670e6bb622e80dbf3056d2e",
+            "_tpl": "56ea8222d2720b69698b4567",
+            "parentId": "6670e6bb622e80dbf3056d2f",
+            "slotId": "mod_bipod"
+        }, {
             "_id": "dd6d3f7ecdfecd47f7d25322",
             "_tpl": "588892092459774ac91d4b11",
             "parentId": "hideout",
@@ -2701,44 +2394,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e8c0defe3ee1b99e151df88e",
             "_tpl": "5888988e24597752fe43a6fa",
             "parentId": "dd6d3f7ecdfecd47f7d25322",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "c5ff4a6fed96f59fbdf82f96",
             "_tpl": "5888956924597752983e182d",
             "parentId": "dd6d3f7ecdfecd47f7d25322",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "cd788634830c8ac92d83a75f",
             "_tpl": "5888996c24597754281f9419",
             "parentId": "c5ff4a6fed96f59fbdf82f96",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "bdf332a9f17fae262fdecc9f",
             "_tpl": "5888976c24597754281f93f5",
             "parentId": "c5ff4a6fed96f59fbdf82f96",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "c2d2dfba6c879cb0bc75fdd7",
             "_tpl": "57c55f172459772d27602381",
             "parentId": "dd6d3f7ecdfecd47f7d25322",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "f5e83423d0ef0122e64fff6b",
             "_tpl": "58889d0c2459775bc215d981",
             "parentId": "dd6d3f7ecdfecd47f7d25322",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "f8f55d5ca1fd93019399d7fb",
             "_tpl": "5888988e24597752fe43a6fa",
             "parentId": "hideout",
@@ -2749,8 +2435,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7799bf35faafcdac4d7fad1e",
             "_tpl": "5ce69cbad7f00c00b61c5098",
             "parentId": "hideout",
@@ -2761,8 +2446,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c030cb8697857ca8abadb81e",
             "_tpl": "5df25b6c0b92095fd441e4cf",
             "parentId": "hideout",
@@ -2773,8 +2457,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e4dcd1aae831dae84eca05cf",
             "_tpl": "559ba5b34bdc2d1f1a8b4582",
             "parentId": "hideout",
@@ -2785,8 +2468,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "6e200ac32b7aa75c264d7fdc",
             "_tpl": "5df8ce05b11454561e39243b",
             "parentId": "hideout",
@@ -2797,80 +2479,67 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "80aa75ab820ad3e892d74d8a",
             "_tpl": "55d4b9964bdc2d1d4e8b456e",
             "parentId": "6e200ac32b7aa75c264d7fdc",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "9cb0b801fa96620ac9460eca",
             "_tpl": "5df8f541c41b2312ea3335e3",
             "parentId": "6e200ac32b7aa75c264d7fdc",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "ccfe9a0cbc4bd7bebd89e16e",
             "_tpl": "5649be884bdc2d79388b4577",
             "parentId": "6e200ac32b7aa75c264d7fdc",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "fafe18face50dbadcc1ce873",
             "_tpl": "5ae30c9a5acfc408fb139a03",
             "parentId": "ccfe9a0cbc4bd7bebd89e16e",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "7c9d4b8fd1d5eda76af48eca",
             "_tpl": "5df8e4080b92095fd441e594",
             "parentId": "6e200ac32b7aa75c264d7fdc",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "5ad750e6debf0bcd04f3ddd2",
             "_tpl": "5df917564a9f347bc92edca3",
             "parentId": "7c9d4b8fd1d5eda76af48eca",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "efaefbaf8a51782e2ac2db19",
             "_tpl": "5dfa3cd1b33c0951220c079b",
             "parentId": "5ad750e6debf0bcd04f3ddd2",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "6de6673521a024e920eca5cb",
             "_tpl": "5dfa3d45dfc58d14537c20b0",
             "parentId": "5ad750e6debf0bcd04f3ddd2",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "7b4baff6ed264b3ee802fefd",
             "_tpl": "5df916dfbb49d91fb446d6b9",
             "parentId": "7c9d4b8fd1d5eda76af48eca",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "9e2cff12949b6ef8ab8c9de7",
             "_tpl": "5dfa3d950dee1b22f862eae0",
             "parentId": "7b4baff6ed264b3ee802fefd",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "62f6bb7e7ece58fbef1a5218",
             "_tpl": "5dfa3d7ac41b2312ea33362a",
             "parentId": "7c9d4b8fd1d5eda76af48eca",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "adde9d228b9db55fafaebe2d",
             "_tpl": "5df8e053bb49d91fb446d6a6",
             "parentId": "6e200ac32b7aa75c264d7fdc",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "dfcedcf85a228fa9c7d7d114",
             "_tpl": "5f2a9575926fd9352339381f",
             "parentId": "hideout",
@@ -2881,44 +2550,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ffeabacbab29d415f8ddf68f",
             "_tpl": "5b099ac65acfc400186331e1",
             "parentId": "dfcedcf85a228fa9c7d7d114",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "cccef2ddc1b52f4c612de70d",
             "_tpl": "5f2aa46b878ef416f538b567",
             "parentId": "dfcedcf85a228fa9c7d7d114",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "aac54f2db9aeac23f4acf2c3",
             "_tpl": "5f2aa4464b50c14bcf07acdb",
             "parentId": "cccef2ddc1b52f4c612de70d",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "bb71b3c8a0cd89daefcd899f",
             "_tpl": "5f2aa47a200e2c0ee46efa71",
             "parentId": "dfcedcf85a228fa9c7d7d114",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "57ece36a58ad46e9ab26bcf9",
             "_tpl": "5f2aa493cd375f14e15eea72",
             "parentId": "bb71b3c8a0cd89daefcd899f",
             "slotId": "mod_mount_000"
-        },
-        {
+        }, {
             "_id": "aae2d97fa147d4fbadb477ee",
             "_tpl": "5f2aa49f9b44de6b1b4e68d4",
             "parentId": "dfcedcf85a228fa9c7d7d114",
             "slotId": "mod_mount"
-        },
-        {
+        }, {
             "_id": "f96edd4fe4f26e29b2345e56",
             "_tpl": "5aafa857e5b5b00018480968",
             "parentId": "hideout",
@@ -2929,50 +2591,42 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e41b0cd672b14efc069adc7e",
             "_tpl": "5aaf8a0be5b5b00015693243",
             "parentId": "f96edd4fe4f26e29b2345e56",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "aaceab9b55b15af4df5ddbc1",
             "_tpl": "5aaf8e43e5b5b00015693246",
             "parentId": "f96edd4fe4f26e29b2345e56",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "bfecef02bef664d56393994e",
             "_tpl": "5ab24ef9e5b5b00fe93c9209",
             "parentId": "aaceab9b55b15af4df5ddbc1",
             "slotId": "mod_mount"
-        },
-        {
+        }, {
             "_id": "d5e81ccbdec55ab1bee9ae51",
             "_tpl": "5aaf9d53e5b5b00015042a52",
             "parentId": "f96edd4fe4f26e29b2345e56",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "3e8823fb017a0ad36cee534a",
             "_tpl": "5aafa1c2e5b5b00015042a56",
             "parentId": "d5e81ccbdec55ab1bee9ae51",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "29e2ed2da554ebb731fefbac",
             "_tpl": "5aafa49ae5b5b00015042a58",
             "parentId": "3e8823fb017a0ad36cee534a",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "6e4fa4a61cf3e4f7c7cc2839",
             "_tpl": "5abcbb20d8ce87001773e258",
             "parentId": "f96edd4fe4f26e29b2345e56",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "31ab7e1f41ecfbfaa7f64bab",
             "_tpl": "5c46fbd72e2216398b5a8c9c",
             "parentId": "hideout",
@@ -2983,74 +2637,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "5aeb9575fffed61c1340dadd",
             "_tpl": "5c471be12e221602b66cd9ac",
             "parentId": "31ab7e1f41ecfbfaa7f64bab",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "8192b4bccea9a90ebe50cf8d",
             "_tpl": "5c471c442e221602b542a6f8",
             "parentId": "31ab7e1f41ecfbfaa7f64bab",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "1e5eb0bfecbbaf16f9fca2d6",
             "_tpl": "5c471b5d2e221602b21d4e14",
             "parentId": "31ab7e1f41ecfbfaa7f64bab",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "8bbbb18c0d6ff9bfbc808eb9",
             "_tpl": "5c471cb32e221602b177afaa",
             "parentId": "31ab7e1f41ecfbfaa7f64bab",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "9eb6aa8ad53d9c5df9ca09e2",
             "_tpl": "5c471bfc2e221602b21d4e17",
             "parentId": "8bbbb18c0d6ff9bfbc808eb9",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "8aeede9a900143a79afe6e8c",
             "_tpl": "5c471ba12e221602b3137d76",
             "parentId": "9eb6aa8ad53d9c5df9ca09e2",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "0faebe7acc14fafc0acfc6d3",
             "_tpl": "5c471c842e221615214259b5",
             "parentId": "8bbbb18c0d6ff9bfbc808eb9",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "e0fee0bb2be4df212bdfbbbd",
             "_tpl": "5c471c2d2e22164bef5d077f",
             "parentId": "31ab7e1f41ecfbfaa7f64bab",
             "slotId": "mod_mount_001"
-        },
-        {
+        }, {
             "_id": "ea12c07dba740e4aeeaafd9c",
             "_tpl": "5c471c6c2e221602b66cd9ae",
             "parentId": "e0fee0bb2be4df212bdfbbbd",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "8aed80ceac3aeb496eeec0db",
             "_tpl": "5c471b7e2e2216152006e46c",
             "parentId": "e0fee0bb2be4df212bdfbbbd",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "6fb24e1c7093f1fccabdfefa",
             "_tpl": "5c471bd12e221602b4129c3a",
             "parentId": "31ab7e1f41ecfbfaa7f64bab",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "dfceccc7ddacec9fda862394",
             "_tpl": "5df8f535bb49d91fb446d6b0",
             "parentId": "hideout",
@@ -3061,8 +2703,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "cd1c070711aa27a77cd32f1b",
             "_tpl": "5b7bef1e5acfc43d82528402",
             "parentId": "hideout",
@@ -3073,8 +2714,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "977cb75f35769e0530fdd4dd",
             "_tpl": "5aaf8a0be5b5b00015693243",
             "parentId": "hideout",
@@ -3085,8 +2725,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bcc29a9fd5c39954544eabb5",
             "_tpl": "5c471c442e221602b542a6f8",
             "parentId": "hideout",
@@ -3097,8 +2736,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bdff25636c0c9bcc4dddd7f6",
             "_tpl": "5fc22d7c187fea44d52eda44",
             "parentId": "hideout",
@@ -3109,62 +2747,52 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a5ec1fc36453f02acdc37ea6",
             "_tpl": "57c55efc2459772d2c6271e7",
             "parentId": "bdff25636c0c9bcc4dddd7f6",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "c6d6f1f5adf45c16be5cbdec",
             "_tpl": "5fc23426900b1d5091531e15",
             "parentId": "bdff25636c0c9bcc4dddd7f6",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "fe8efd261ab8bef357b52742",
             "_tpl": "5649be884bdc2d79388b4577",
             "parentId": "bdff25636c0c9bcc4dddd7f6",
             "slotId": "mod_stock_001"
-        },
-        {
+        }, {
             "_id": "a8c9a2be0d5bf5be3efcfc98",
             "_tpl": "5fc2369685fd526b824a5713",
             "parentId": "fe8efd261ab8bef357b52742",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "e4df0b0cc9c300df2e07bd1d",
             "_tpl": "5fc278107283c4046c581489",
             "parentId": "bdff25636c0c9bcc4dddd7f6",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "efe4f5dd1ce63b719bbbe885",
             "_tpl": "5fc23678ab884124df0cd590",
             "parentId": "e4df0b0cc9c300df2e07bd1d",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "afb400d0acfca64dcab24e3a",
             "_tpl": "5fc23636016cce60e8341b05",
             "parentId": "efe4f5dd1ce63b719bbbe885",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "66ec9b2cfde8c6de7241f176",
             "_tpl": "5fc2360f900b1d5091531e19",
             "parentId": "efe4f5dd1ce63b719bbbe885",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "08dbde81688d6fc3a4f0edfd",
             "_tpl": "5fc235db2770a0045c59c683",
             "parentId": "e4df0b0cc9c300df2e07bd1d",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "f5ddeb8ccfdc7dbaec7fbf18",
             "_tpl": "6176aca650224f204c1da3fb",
             "parentId": "hideout",
@@ -3175,86 +2803,72 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ef0a0cb0566c4cc0ca8c743f",
             "_tpl": "6193dcd0f8ee7e52e4210a28",
             "parentId": "f5ddeb8ccfdc7dbaec7fbf18",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "4ed2dbbd33f8fac0ef766b6f",
             "_tpl": "617131a4568c120fdd29482d",
             "parentId": "f5ddeb8ccfdc7dbaec7fbf18",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "6fc5d3722e465f0ceff7bbab",
             "_tpl": "617153016c780c1e710c9a2f",
             "parentId": "f5ddeb8ccfdc7dbaec7fbf18",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "27e53b4a8bce9b919adfda4f",
             "_tpl": "617154aa1cb55961fa0fdb3b",
             "parentId": "6fc5d3722e465f0ceff7bbab",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "2b82ade0f7b7bf2f9356005b",
             "_tpl": "61713a8fd92c473c770214a4",
             "parentId": "f5ddeb8ccfdc7dbaec7fbf18",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "a4ce17fafdc75af0f62f601f",
             "_tpl": "6171407e50224f204c1da3c5",
             "parentId": "2b82ade0f7b7bf2f9356005b",
             "slotId": "mod_scope"
-        },
-        {
+        }, {
             "_id": "b85366553144af37fc3c7cc4",
             "_tpl": "617151c1d92c473c770214ab",
             "parentId": "a4ce17fafdc75af0f62f601f",
             "slotId": "mod_scope_000"
-        },
-        {
+        }, {
             "_id": "1acc73b8ecd1b0042c0cb7eb",
             "_tpl": "61702be9faa1272e431522c3",
             "parentId": "2b82ade0f7b7bf2f9356005b",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "ba634deaaed3c3b68ddf27f0",
             "_tpl": "61713308d92c473c770214a0",
             "parentId": "1acc73b8ecd1b0042c0cb7eb",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "677efa633fd1b3bbfeb6b87e",
             "_tpl": "61702f1b67085e45ef140b26",
             "parentId": "1acc73b8ecd1b0042c0cb7eb",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "b183aaafff5d16bd0eee69eb",
             "_tpl": "61712eae6c780c1e710c9a1d",
             "parentId": "2b82ade0f7b7bf2f9356005b",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "b7868e7dd26e79c4fc60e51b",
             "_tpl": "5bb20e49d4351e3bac1212de",
             "parentId": "2b82ade0f7b7bf2f9356005b",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "caf037cacfbfcff8bc1bbec4",
             "_tpl": "61702d8a67085e45ef140b24",
             "parentId": "f5ddeb8ccfdc7dbaec7fbf18",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "5877e6bf1dd1e928361406c4",
             "_tpl": "5a367e5dc4a282000e49738f",
             "parentId": "hideout",
@@ -3265,56 +2879,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "aa80bef34db009fd0b51a3ec",
             "_tpl": "5a339805c4a2826c6e06d73d",
             "parentId": "5877e6bf1dd1e928361406c4",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "dae7e8c53ed8df6b9a7c974f",
             "_tpl": "5a3501acc4a282000d72293a",
             "parentId": "5877e6bf1dd1e928361406c4",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "c2aaafe9fe79c4dfb5c59ccb",
             "_tpl": "5a33ca0fc4a282000d72292f",
             "parentId": "5877e6bf1dd1e928361406c4",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "8ad7ac45fab8d3cc2843ed19",
             "_tpl": "5a33cae9c4a28232980eb086",
             "parentId": "c2aaafe9fe79c4dfb5c59ccb",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "3e9a099b6bfbfb50c77b1de6",
             "_tpl": "5a329052c4a28200741e22d3",
             "parentId": "5877e6bf1dd1e928361406c4",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "da52df6a8db1565e52b6d17a",
             "_tpl": "5a34fae7c4a2826c6e06d760",
             "parentId": "5877e6bf1dd1e928361406c4",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "f3c0bcff563db7946756e7c8",
             "_tpl": "5a34fd2bc4a282329a73b4c5",
             "parentId": "da52df6a8db1565e52b6d17a",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "935ca4247ed042adeb8daec0",
             "_tpl": "5a34fbadc4a28200741e230a",
             "parentId": "da52df6a8db1565e52b6d17a",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "ae2874d9cdefe6a3038befdf",
             "_tpl": "57838ad32459774a17445cd2",
             "parentId": "hideout",
@@ -3325,38 +2930,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "9e9b5e0eadd3f05cf7aaaa50",
             "_tpl": "57838f0b2459774a256959b2",
             "parentId": "ae2874d9cdefe6a3038befdf",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "99f7c86aae6d7ba629475aad",
             "_tpl": "57838c962459774a1651ec63",
             "parentId": "ae2874d9cdefe6a3038befdf",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "bbae2b9efaab1ab4ac7bfeed",
             "_tpl": "57838e1b2459774a256959b1",
             "parentId": "99f7c86aae6d7ba629475aad",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "8a0fdefc19de2693f21fae7b",
             "_tpl": "578395402459774a256959b5",
             "parentId": "ae2874d9cdefe6a3038befdf",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "adf7a5ea968bb1f9049ef26b",
             "_tpl": "578395e82459774a0e553c7b",
             "parentId": "ae2874d9cdefe6a3038befdf",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "85b6f03df9ecb327dbdfd6a7",
             "_tpl": "5a3501acc4a282000d72293a",
             "parentId": "hideout",
@@ -3367,8 +2966,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "61f7bef9c04afa27ae91fcfd",
             "_tpl": "5fc23426900b1d5091531e15",
             "parentId": "hideout",
@@ -3379,8 +2977,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b6a2f8a5cfe2c78c746dee26",
             "_tpl": "57838f0b2459774a256959b2",
             "parentId": "hideout",
@@ -3391,8 +2988,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "1cbd1cca1aab6f1fcb50fd8a",
             "_tpl": "617130016c780c1e710c9a24",
             "parentId": "hideout",
@@ -3403,8 +2999,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f8de1e7cfad533cdafb11bcc",
             "_tpl": "5de652c31b7e3716273428be",
             "parentId": "hideout",
@@ -3415,38 +3010,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "57ddcad89b77b7d4beba43ea",
             "_tpl": "5de653abf76fdc1ce94a5a2a",
             "parentId": "f8de1e7cfad533cdafb11bcc",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "8aabb7e36a5da5ccf7e5bf0f",
             "_tpl": "5de655be4a9f347bc92edb88",
             "parentId": "f8de1e7cfad533cdafb11bcc",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "7a3b2da7d44e9efbaf68a9cc",
             "_tpl": "5de65547883dde217541644b",
             "parentId": "f8de1e7cfad533cdafb11bcc",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "c814d28a934d38c2edbc9003",
             "_tpl": "5de6556a205ddc616a6bc4f7",
             "parentId": "7a3b2da7d44e9efbaf68a9cc",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "17b7ca73bbc61a28ccde3cf9",
             "_tpl": "5de6558e9f98ac2bc65950fc",
             "parentId": "f8de1e7cfad533cdafb11bcc",
             "slotId": "mod_mount"
-        },
-        {
+        }, {
             "_id": "ff2cac4220f9dfbdbe97b5eb",
             "_tpl": "5ae08f0a5acfc408fb1398a1",
             "parentId": "hideout",
@@ -3457,38 +3046,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7e885f4c14bb3ea735fd37d9",
             "_tpl": "5ae0973a5acfc4001562206c",
             "parentId": "ff2cac4220f9dfbdbe97b5eb",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "fd0dec7e0fce608dbb066799",
             "_tpl": "5ae096d95acfc400185c2c81",
             "parentId": "ff2cac4220f9dfbdbe97b5eb",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "ccd7aeab1b7e71a6695ebc78",
             "_tpl": "5ae09bff5acfc4001562219d",
             "parentId": "ff2cac4220f9dfbdbe97b5eb",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "b4d7e33987f3dc4cdbf2df56",
             "_tpl": "5ae099875acfc4001714e593",
             "parentId": "ccd7aeab1b7e71a6695ebc78",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "dcd8dacafceafa32ddb3b09c",
             "_tpl": "5ae099925acfc4001a5fc7b3",
             "parentId": "ccd7aeab1b7e71a6695ebc78",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "e25c5da0f9e3de58aa32ebcc",
             "_tpl": "5bfd297f0db834001a669119",
             "parentId": "hideout",
@@ -3499,26 +3082,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "0f7aabf9734aaaeb1cae1bfd",
             "_tpl": "5ae0973a5acfc4001562206c",
             "parentId": "e25c5da0f9e3de58aa32ebcc",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "8a1c0a84ce3cfeeec96ad6dd",
             "_tpl": "5bfd36ad0db834001c38ef66",
             "parentId": "e25c5da0f9e3de58aa32ebcc",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "c9b0dabffba80cddbdded5fe",
             "_tpl": "5bfd4cc90db834001d23e846",
             "parentId": "e25c5da0f9e3de58aa32ebcc",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "bc6ca2c2ef6aa46f3ac0fa05",
             "_tpl": "587e02ff24597743df3deaeb",
             "parentId": "hideout",
@@ -3529,56 +3108,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d06",
-          "_tpl": "587e0531245977466077a0f7",
-          "parentId": "bc6ca2c2ef6aa46f3ac0fa05",
-          "slotId": "mod_stock"
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d07",
-          "_tpl": "634eff66517ccc8a960fc735",
-          "parentId": "bc6ca2c2ef6aa46f3ac0fa05",
-          "slotId": "mod_barrel"
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d08",
-          "_tpl": "634f05a21f9f536910079b56",
-          "parentId": "6670e6bb622e80dbf3056d07",
-          "slotId": "mod_mount_000"
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d09",
-          "_tpl": "634f036a517ccc8a960fc746",
-          "parentId": "6670e6bb622e80dbf3056d08",
-          "slotId": "mod_gas_block"
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d0a",
-          "_tpl": "634f03d40384a3ba4f06f874",
-          "parentId": "6670e6bb622e80dbf3056d09",
-          "slotId": "mod_mount_000"
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d0b",
-          "_tpl": "574db213245977459a2f3f5d",
-          "parentId": "6670e6bb622e80dbf3056d08",
-          "slotId": "mod_sight_rear"
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d0c",
-          "_tpl": "587df3a12459772c28142567",
-          "parentId": "bc6ca2c2ef6aa46f3ac0fa05",
-          "slotId": "mod_magazine"
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d0d",
-          "_tpl": "634f06262e5def262d0b30ca",
-          "parentId": "bc6ca2c2ef6aa46f3ac0fa05",
-          "slotId": "mod_reciever"
-        },
-        {
+        }, {
+            "_id": "6670e6bb622e80dbf3056d06",
+            "_tpl": "587e0531245977466077a0f7",
+            "parentId": "bc6ca2c2ef6aa46f3ac0fa05",
+            "slotId": "mod_stock"
+        }, {
+            "_id": "6670e6bb622e80dbf3056d07",
+            "_tpl": "634eff66517ccc8a960fc735",
+            "parentId": "bc6ca2c2ef6aa46f3ac0fa05",
+            "slotId": "mod_barrel"
+        }, {
+            "_id": "6670e6bb622e80dbf3056d08",
+            "_tpl": "634f05a21f9f536910079b56",
+            "parentId": "6670e6bb622e80dbf3056d07",
+            "slotId": "mod_mount_000"
+        }, {
+            "_id": "6670e6bb622e80dbf3056d09",
+            "_tpl": "634f036a517ccc8a960fc746",
+            "parentId": "6670e6bb622e80dbf3056d08",
+            "slotId": "mod_gas_block"
+        }, {
+            "_id": "6670e6bb622e80dbf3056d0a",
+            "_tpl": "634f03d40384a3ba4f06f874",
+            "parentId": "6670e6bb622e80dbf3056d09",
+            "slotId": "mod_mount_000"
+        }, {
+            "_id": "6670e6bb622e80dbf3056d0b",
+            "_tpl": "574db213245977459a2f3f5d",
+            "parentId": "6670e6bb622e80dbf3056d08",
+            "slotId": "mod_sight_rear"
+        }, {
+            "_id": "6670e6bb622e80dbf3056d0c",
+            "_tpl": "587df3a12459772c28142567",
+            "parentId": "bc6ca2c2ef6aa46f3ac0fa05",
+            "slotId": "mod_magazine"
+        }, {
+            "_id": "6670e6bb622e80dbf3056d0d",
+            "_tpl": "634f06262e5def262d0b30ca",
+            "parentId": "bc6ca2c2ef6aa46f3ac0fa05",
+            "slotId": "mod_reciever"
+        }, {
             "_id": "80b2afafa0c554ef12efafec",
             "_tpl": "574d967124597745970e7c94",
             "parentId": "hideout",
@@ -3589,56 +3159,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d0f",
-          "_tpl": "574dad8024597745964bf05c",
-          "parentId": "80b2afafa0c554ef12efafec",
-          "slotId": "mod_stock"
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d10",
-          "_tpl": "634f02331f9f536910079b51",
-          "parentId": "80b2afafa0c554ef12efafec",
-          "slotId": "mod_barrel"
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d11",
-          "_tpl": "634f04d82e5def262d0b30c6",
-          "parentId": "6670e6bb622e80dbf3056d10",
-          "slotId": "mod_mount_000"
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d12",
-          "_tpl": "634f02d7517ccc8a960fc744",
-          "parentId": "6670e6bb622e80dbf3056d11",
-          "slotId": "mod_gas_block"
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d13",
-          "_tpl": "634f08a21f9f536910079b5a",
-          "parentId": "6670e6bb622e80dbf3056d12",
-          "slotId": "mod_mount_000"
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d14",
-          "_tpl": "574db213245977459a2f3f5d",
-          "parentId": "6670e6bb622e80dbf3056d11",
-          "slotId": "mod_sight_rear"
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d15",
-          "_tpl": "587df3a12459772c28142567",
-          "parentId": "80b2afafa0c554ef12efafec",
-          "slotId": "mod_magazine"
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d16",
-          "_tpl": "634f05ca517ccc8a960fc748",
-          "parentId": "80b2afafa0c554ef12efafec",
-          "slotId": "mod_reciever"
-        },
-        {
+        }, {
+            "_id": "6670e6bb622e80dbf3056d0f",
+            "_tpl": "574dad8024597745964bf05c",
+            "parentId": "80b2afafa0c554ef12efafec",
+            "slotId": "mod_stock"
+        }, {
+            "_id": "6670e6bb622e80dbf3056d10",
+            "_tpl": "634f02331f9f536910079b51",
+            "parentId": "80b2afafa0c554ef12efafec",
+            "slotId": "mod_barrel"
+        }, {
+            "_id": "6670e6bb622e80dbf3056d11",
+            "_tpl": "634f04d82e5def262d0b30c6",
+            "parentId": "6670e6bb622e80dbf3056d10",
+            "slotId": "mod_mount_000"
+        }, {
+            "_id": "6670e6bb622e80dbf3056d12",
+            "_tpl": "634f02d7517ccc8a960fc744",
+            "parentId": "6670e6bb622e80dbf3056d11",
+            "slotId": "mod_gas_block"
+        }, {
+            "_id": "6670e6bb622e80dbf3056d13",
+            "_tpl": "634f08a21f9f536910079b5a",
+            "parentId": "6670e6bb622e80dbf3056d12",
+            "slotId": "mod_mount_000"
+        }, {
+            "_id": "6670e6bb622e80dbf3056d14",
+            "_tpl": "574db213245977459a2f3f5d",
+            "parentId": "6670e6bb622e80dbf3056d11",
+            "slotId": "mod_sight_rear"
+        }, {
+            "_id": "6670e6bb622e80dbf3056d15",
+            "_tpl": "587df3a12459772c28142567",
+            "parentId": "80b2afafa0c554ef12efafec",
+            "slotId": "mod_magazine"
+        }, {
+            "_id": "6670e6bb622e80dbf3056d16",
+            "_tpl": "634f05ca517ccc8a960fc748",
+            "parentId": "80b2afafa0c554ef12efafec",
+            "slotId": "mod_reciever"
+        }, {
             "_id": "dc232bbf20b811bfcc347f19",
             "_tpl": "5c501a4d2e221602b412b540",
             "parentId": "hideout",
@@ -3649,38 +3210,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "6ae3cae0bc06ade6986c6e0b",
             "_tpl": "5c5039be2e221602b177c9ff",
             "parentId": "dc232bbf20b811bfcc347f19",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "951ce2fdd149259e1289a3cf",
             "_tpl": "5c503d0a2e221602b542b7ef",
             "parentId": "dc232bbf20b811bfcc347f19",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "abeb4c97b8b367b5ab42cbba",
             "_tpl": "5c503b1c2e221602b21d6e9d",
             "parentId": "dc232bbf20b811bfcc347f19",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "fcef3fcc7f103bc675bff3b1",
             "_tpl": "5c503af12e221602b177ca02",
             "parentId": "dc232bbf20b811bfcc347f19",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "2f25eba7c7df00ff51fd5d6f",
             "_tpl": "5c503ac82e221602b21d6e9a",
             "parentId": "dc232bbf20b811bfcc347f19",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "a58eeeaac8bdfeb3ac20c05d",
             "_tpl": "5bfea6e90db834001b7347f3",
             "parentId": "hideout",
@@ -3691,26 +3246,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "1dbf7aca3896d4d1f81fc6bd",
             "_tpl": "5bfea7ad0db834001c38f1ee",
             "parentId": "a58eeeaac8bdfeb3ac20c05d",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "0bec1fcca7acd0015eabb85a",
             "_tpl": "5bfeb32b0db834001a6694d9",
             "parentId": "a58eeeaac8bdfeb3ac20c05d",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "75eac23c3ec7409dae36dbf9",
             "_tpl": "5bfebc320db8340019668d79",
             "parentId": "a58eeeaac8bdfeb3ac20c05d",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "bdc81d1c0a8555706057cefe",
             "_tpl": "5df24cf80dee1b22f862e9bc",
             "parentId": "hideout",
@@ -3721,86 +3272,72 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "73e57cc714dfd56c3586b2c4",
             "_tpl": "5df25b6c0b92095fd441e4cf",
             "parentId": "bdc81d1c0a8555706057cefe",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "e4606adf24cfb5ab28aae471",
             "_tpl": "5df256570dee1b22f862e9c4",
             "parentId": "bdc81d1c0a8555706057cefe",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "6db3fb73b9350db4649ecef9",
             "_tpl": "5df35e7f2a78646d96665dd4",
             "parentId": "e4606adf24cfb5ab28aae471",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "7e9be7deb7b0aacd0f1fce22",
             "_tpl": "5df35e59c41b2312ea3334d5",
             "parentId": "bdc81d1c0a8555706057cefe",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "cddb86cf32ca2ebabc0a1afd",
             "_tpl": "5df25d3bfd6b4e6e2276dc9a",
             "parentId": "7e9be7deb7b0aacd0f1fce22",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "6f1eae7cebddea7e44d33799",
             "_tpl": "5df35eb2b11454561e3923e2",
             "parentId": "cddb86cf32ca2ebabc0a1afd",
             "slotId": "mod_mount_000"
-        },
-        {
+        }, {
             "_id": "438a5deb245ad1dae211edfb",
             "_tpl": "5df35eb2b11454561e3923e2",
             "parentId": "cddb86cf32ca2ebabc0a1afd",
             "slotId": "mod_mount_001"
-        },
-        {
+        }, {
             "_id": "9613abbf85aacc3dde6bcd24",
             "_tpl": "5df35ea9c41b2312ea3334d8",
             "parentId": "cddb86cf32ca2ebabc0a1afd",
             "slotId": "mod_mount_002"
-        },
-        {
+        }, {
             "_id": "dca2c30cbec6ed5c1cdf8a08",
             "_tpl": "5df35eb2b11454561e3923e2",
             "parentId": "cddb86cf32ca2ebabc0a1afd",
             "slotId": "mod_mount_003"
-        },
-        {
+        }, {
             "_id": "cdedc982a7f44cb1be3f1e76",
             "_tpl": "5df36948bb49d91fb446d5ad",
             "parentId": "cddb86cf32ca2ebabc0a1afd",
             "slotId": "mod_foregrip"
-        },
-        {
+        }, {
             "_id": "d0e86ebe7acade6dc484b9af",
             "_tpl": "5df38a5fb74cd90030650cb6",
             "parentId": "7e9be7deb7b0aacd0f1fce22",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "74f8ccefdcfff238ed8a259f",
             "_tpl": "5df35ddddfc58d14537c2036",
             "parentId": "7e9be7deb7b0aacd0f1fce22",
             "slotId": "mod_stock_axis"
-        },
-        {
+        }, {
             "_id": "bafb1a9ec9324ea0e59dacfe",
             "_tpl": "5df35e970b92095fd441e4d2",
             "parentId": "bdc81d1c0a8555706057cefe",
             "slotId": "mod_mount"
-        },
-        {
+        }, {
             "_id": "d9cdd4e5a76c15e542a82e76",
             "_tpl": "55801eed4bdc2d89578b4588",
             "parentId": "hideout",
@@ -3811,44 +3348,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d30",
-          "_tpl": "559ba5b34bdc2d1f1a8b4582",
-          "parentId": "d9cdd4e5a76c15e542a82e76",
-          "slotId": "mod_magazine"
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d31",
-          "_tpl": "56083e1b4bdc2dc8488b4572",
-          "parentId": "d9cdd4e5a76c15e542a82e76",
-          "slotId": "mod_sight_rear"
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d32",
-          "_tpl": "56083eab4bdc2d26448b456a",
-          "parentId": "d9cdd4e5a76c15e542a82e76",
-          "slotId": "mod_tactical"
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d33",
-          "_tpl": "560e620e4bdc2d724b8b456b",
-          "parentId": "d9cdd4e5a76c15e542a82e76",
-          "slotId": "mod_muzzle"
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d34",
-          "_tpl": "61faa91878830f069b6b7967",
-          "parentId": "d9cdd4e5a76c15e542a82e76",
-          "slotId": "mod_stock"
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d35",
-          "_tpl": "56ea8222d2720b69698b4567",
-          "parentId": "6670e6bb622e80dbf3056d34",
-          "slotId": "mod_bipod"
-        },
-        {
+        }, {
+            "_id": "6670e6bb622e80dbf3056d30",
+            "_tpl": "559ba5b34bdc2d1f1a8b4582",
+            "parentId": "d9cdd4e5a76c15e542a82e76",
+            "slotId": "mod_magazine"
+        }, {
+            "_id": "6670e6bb622e80dbf3056d31",
+            "_tpl": "56083e1b4bdc2dc8488b4572",
+            "parentId": "d9cdd4e5a76c15e542a82e76",
+            "slotId": "mod_sight_rear"
+        }, {
+            "_id": "6670e6bb622e80dbf3056d32",
+            "_tpl": "56083eab4bdc2d26448b456a",
+            "parentId": "d9cdd4e5a76c15e542a82e76",
+            "slotId": "mod_tactical"
+        }, {
+            "_id": "6670e6bb622e80dbf3056d33",
+            "_tpl": "560e620e4bdc2d724b8b456b",
+            "parentId": "d9cdd4e5a76c15e542a82e76",
+            "slotId": "mod_muzzle"
+        }, {
+            "_id": "6670e6bb622e80dbf3056d34",
+            "_tpl": "61faa91878830f069b6b7967",
+            "parentId": "d9cdd4e5a76c15e542a82e76",
+            "slotId": "mod_stock"
+        }, {
+            "_id": "6670e6bb622e80dbf3056d35",
+            "_tpl": "56ea8222d2720b69698b4567",
+            "parentId": "6670e6bb622e80dbf3056d34",
+            "slotId": "mod_bipod"
+        }, {
             "_id": "74fedc1edf2226e1f33ce2bf",
             "_tpl": "588892092459774ac91d4b11",
             "parentId": "hideout",
@@ -3859,44 +3389,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ccc3f69bcffb2defff8bfaa9",
             "_tpl": "5888988e24597752fe43a6fa",
             "parentId": "74fedc1edf2226e1f33ce2bf",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "3516abecb6fece3c238e0fec",
             "_tpl": "5888956924597752983e182d",
             "parentId": "74fedc1edf2226e1f33ce2bf",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "03ddfaeef7834393faa1f056",
             "_tpl": "5888996c24597754281f9419",
             "parentId": "3516abecb6fece3c238e0fec",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "d7e2edcd219c1e0ca3bfb42b",
             "_tpl": "5888976c24597754281f93f5",
             "parentId": "3516abecb6fece3c238e0fec",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "f0db895c2b9da437d5fab239",
             "_tpl": "57c55f172459772d27602381",
             "parentId": "74fedc1edf2226e1f33ce2bf",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "eb52b3e610ebcd4acc94bb5d",
             "_tpl": "58889d0c2459775bc215d981",
             "parentId": "74fedc1edf2226e1f33ce2bf",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "b58d3a7fdfdaafd12d35c111",
             "_tpl": "5df8ce05b11454561e39243b",
             "parentId": "hideout",
@@ -3907,80 +3430,67 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "2cae112a2ebbc3956bb97f75",
             "_tpl": "55d4b9964bdc2d1d4e8b456e",
             "parentId": "b58d3a7fdfdaafd12d35c111",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "eb1e0d6dc5ee5ae0bdb660d7",
             "_tpl": "5df8f541c41b2312ea3335e3",
             "parentId": "b58d3a7fdfdaafd12d35c111",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "aae883dd1bbe24c30df0b07d",
             "_tpl": "5649be884bdc2d79388b4577",
             "parentId": "b58d3a7fdfdaafd12d35c111",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "e095cbae329de8dbec6d193c",
             "_tpl": "5ae30c9a5acfc408fb139a03",
             "parentId": "aae883dd1bbe24c30df0b07d",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "1cbbcd9126c941bbcd2e3918",
             "_tpl": "5df8e4080b92095fd441e594",
             "parentId": "b58d3a7fdfdaafd12d35c111",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "a87d3e12e2e5dbddd380eec9",
             "_tpl": "5df917564a9f347bc92edca3",
             "parentId": "1cbbcd9126c941bbcd2e3918",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "ed2d64ede4a472217ad90e32",
             "_tpl": "5dfa3cd1b33c0951220c079b",
             "parentId": "a87d3e12e2e5dbddd380eec9",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "55ad9a5ffdbfc28d3999e5ef",
             "_tpl": "5dfa3d45dfc58d14537c20b0",
             "parentId": "a87d3e12e2e5dbddd380eec9",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "ff8f84afd444cbff8eddaaa2",
             "_tpl": "5df916dfbb49d91fb446d6b9",
             "parentId": "1cbbcd9126c941bbcd2e3918",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "aac65f2dba228eb8efa9da3f",
             "_tpl": "5dfa3d950dee1b22f862eae0",
             "parentId": "ff8f84afd444cbff8eddaaa2",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "5b65bcb862d8377e8444f9d2",
             "_tpl": "5dfa3d7ac41b2312ea33362a",
             "parentId": "1cbbcd9126c941bbcd2e3918",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "daef7a5d1a0ed9c7b4d5fbec",
             "_tpl": "5df8e053bb49d91fb446d6a6",
             "parentId": "b58d3a7fdfdaafd12d35c111",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "af0feddae5728df8d5e7c2ca",
             "_tpl": "5f2a9575926fd9352339381f",
             "parentId": "hideout",
@@ -3991,44 +3501,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "569850584f7f960be38df435",
             "_tpl": "5b099ac65acfc400186331e1",
             "parentId": "af0feddae5728df8d5e7c2ca",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "b199cf09ecb4a1cc4a59ca10",
             "_tpl": "5f2aa46b878ef416f538b567",
             "parentId": "af0feddae5728df8d5e7c2ca",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "2abed8b536a2b9fa3dbabd2b",
             "_tpl": "5f2aa4464b50c14bcf07acdb",
             "parentId": "b199cf09ecb4a1cc4a59ca10",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "493a75fde1dea7563f130a59",
             "_tpl": "5f2aa47a200e2c0ee46efa71",
             "parentId": "af0feddae5728df8d5e7c2ca",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "ecb1e5e40cbdbdeca6fdaea4",
             "_tpl": "5f2aa493cd375f14e15eea72",
             "parentId": "493a75fde1dea7563f130a59",
             "slotId": "mod_mount_000"
-        },
-        {
+        }, {
             "_id": "0320b294915be8fb3cb85edc",
             "_tpl": "5f2aa49f9b44de6b1b4e68d4",
             "parentId": "af0feddae5728df8d5e7c2ca",
             "slotId": "mod_mount"
-        },
-        {
+        }, {
             "_id": "b0ce2a2ddbf1abace32836a0",
             "_tpl": "5aafa857e5b5b00018480968",
             "parentId": "hideout",
@@ -4039,50 +3542,42 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "132f5170c210998c3ab8d31d",
             "_tpl": "5aaf8a0be5b5b00015693243",
             "parentId": "b0ce2a2ddbf1abace32836a0",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "8c20fb6cde90458deab3a565",
             "_tpl": "5aaf8e43e5b5b00015693246",
             "parentId": "b0ce2a2ddbf1abace32836a0",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "e3b142756da30aeb84a725bd",
             "_tpl": "5ab24ef9e5b5b00fe93c9209",
             "parentId": "8c20fb6cde90458deab3a565",
             "slotId": "mod_mount"
-        },
-        {
+        }, {
             "_id": "6aefd95acdfa6e0bcc4b3cce",
             "_tpl": "5aaf9d53e5b5b00015042a52",
             "parentId": "b0ce2a2ddbf1abace32836a0",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "f9a1aa68d9c921ccadf4bfe0",
             "_tpl": "5aafa1c2e5b5b00015042a56",
             "parentId": "6aefd95acdfa6e0bcc4b3cce",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "ff7baaf3ac8cefed9cdf2b8c",
             "_tpl": "5aafa49ae5b5b00015042a58",
             "parentId": "f9a1aa68d9c921ccadf4bfe0",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "63aabd5bcbba5a626aaae0bf",
             "_tpl": "5abcbb20d8ce87001773e258",
             "parentId": "b0ce2a2ddbf1abace32836a0",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "5ced8db5a03f6afe5569bbb3",
             "_tpl": "5c46fbd72e2216398b5a8c9c",
             "parentId": "hideout",
@@ -4093,74 +3588,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "0d5ede8adc7a6f5fd0237b06",
             "_tpl": "5c471be12e221602b66cd9ac",
             "parentId": "5ced8db5a03f6afe5569bbb3",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "df09ebd46e1abc5cd76dd4fe",
             "_tpl": "5c471c442e221602b542a6f8",
             "parentId": "5ced8db5a03f6afe5569bbb3",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "fa834ed60f73cc9e6ff1a4ff",
             "_tpl": "5c471b5d2e221602b21d4e14",
             "parentId": "5ced8db5a03f6afe5569bbb3",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "3257b178f653f4bfc311da9f",
             "_tpl": "5c471cb32e221602b177afaa",
             "parentId": "5ced8db5a03f6afe5569bbb3",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "1bc7c4e50b5ef535e60dec79",
             "_tpl": "5c471bfc2e221602b21d4e17",
             "parentId": "3257b178f653f4bfc311da9f",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "ee4829c90bcb30b38347d712",
             "_tpl": "5c471ba12e221602b3137d76",
             "parentId": "1bc7c4e50b5ef535e60dec79",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "dc6b7d82d8a60402ffeab211",
             "_tpl": "5c471c842e221615214259b5",
             "parentId": "3257b178f653f4bfc311da9f",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "a1b50ae2e3d795ba66a282a0",
             "_tpl": "5c471c2d2e22164bef5d077f",
             "parentId": "5ced8db5a03f6afe5569bbb3",
             "slotId": "mod_mount_001"
-        },
-        {
+        }, {
             "_id": "1ebfa1b2f27e433e177b3eac",
             "_tpl": "5c471c6c2e221602b66cd9ae",
             "parentId": "a1b50ae2e3d795ba66a282a0",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "aecebd6f89f3d13905b7759f",
             "_tpl": "5c471b7e2e2216152006e46c",
             "parentId": "a1b50ae2e3d795ba66a282a0",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "6dcf9b0a070fbbf1cb98dff7",
             "_tpl": "5c471bd12e221602b4129c3a",
             "parentId": "5ced8db5a03f6afe5569bbb3",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "b51a839b94a75a787a208dbf",
             "_tpl": "5fc22d7c187fea44d52eda44",
             "parentId": "hideout",
@@ -4171,62 +3654,52 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "11aff8bf6ff33bdcf72b8e2f",
             "_tpl": "57c55efc2459772d2c6271e7",
             "parentId": "b51a839b94a75a787a208dbf",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "cdfa0fffd71b23c24bbece70",
             "_tpl": "5fc23426900b1d5091531e15",
             "parentId": "b51a839b94a75a787a208dbf",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "fdfed103e70af9fec1fc63a7",
             "_tpl": "5649be884bdc2d79388b4577",
             "parentId": "b51a839b94a75a787a208dbf",
             "slotId": "mod_stock_001"
-        },
-        {
+        }, {
             "_id": "2dab001aadaa3a1ee4df8dd2",
             "_tpl": "5fc2369685fd526b824a5713",
             "parentId": "fdfed103e70af9fec1fc63a7",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "7454ebcb0a42a34bccfaaf3b",
             "_tpl": "5fc278107283c4046c581489",
             "parentId": "b51a839b94a75a787a208dbf",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "60354d97fdaab0d99a1212c5",
             "_tpl": "5fc23678ab884124df0cd590",
             "parentId": "7454ebcb0a42a34bccfaaf3b",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "1c4a7a45d3b3b9433bb4e2ca",
             "_tpl": "5fc23636016cce60e8341b05",
             "parentId": "60354d97fdaab0d99a1212c5",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "236dcbdcd8ba1289a67f1b53",
             "_tpl": "5fc2360f900b1d5091531e19",
             "parentId": "60354d97fdaab0d99a1212c5",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "cd9b3ded0edc80d267ed73ab",
             "_tpl": "5fc235db2770a0045c59c683",
             "parentId": "7454ebcb0a42a34bccfaaf3b",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "f2eacf53404dbc5a62b7b1ad",
             "_tpl": "6176aca650224f204c1da3fb",
             "parentId": "hideout",
@@ -4237,86 +3710,72 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b818ebaacd167dabbb3ef1c9",
             "_tpl": "6193dcd0f8ee7e52e4210a28",
             "parentId": "f2eacf53404dbc5a62b7b1ad",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "98633ecdaf91eec904edf93f",
             "_tpl": "617131a4568c120fdd29482d",
             "parentId": "f2eacf53404dbc5a62b7b1ad",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "c8febbea915e2dfb1194c3c2",
             "_tpl": "617153016c780c1e710c9a2f",
             "parentId": "f2eacf53404dbc5a62b7b1ad",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "ba8b6366caaac71ed75a04ab",
             "_tpl": "617154aa1cb55961fa0fdb3b",
             "parentId": "c8febbea915e2dfb1194c3c2",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "62ad2eba04d5c23dcec9a0b0",
             "_tpl": "61713a8fd92c473c770214a4",
             "parentId": "f2eacf53404dbc5a62b7b1ad",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "55d6bdd4b5785de2ae7b05ec",
             "_tpl": "6171407e50224f204c1da3c5",
             "parentId": "62ad2eba04d5c23dcec9a0b0",
             "slotId": "mod_scope"
-        },
-        {
+        }, {
             "_id": "f7fddfc5ab84bd4ddcdd1597",
             "_tpl": "617151c1d92c473c770214ab",
             "parentId": "55d6bdd4b5785de2ae7b05ec",
             "slotId": "mod_scope_000"
-        },
-        {
+        }, {
             "_id": "af85374c67b7c3f3fdf9f7f0",
             "_tpl": "61702be9faa1272e431522c3",
             "parentId": "62ad2eba04d5c23dcec9a0b0",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "eb25fc1251540535978ab8ff",
             "_tpl": "61713308d92c473c770214a0",
             "parentId": "af85374c67b7c3f3fdf9f7f0",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "3c6fd092491c6e110bedb5cb",
             "_tpl": "61702f1b67085e45ef140b26",
             "parentId": "af85374c67b7c3f3fdf9f7f0",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "340cba4bfdbfaa4c58bcfbdd",
             "_tpl": "61712eae6c780c1e710c9a1d",
             "parentId": "62ad2eba04d5c23dcec9a0b0",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "6e7307aeeebd7ddcde77aed6",
             "_tpl": "5bb20e49d4351e3bac1212de",
             "parentId": "62ad2eba04d5c23dcec9a0b0",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "eddfeafedff0d095fc8fdfb6",
             "_tpl": "61702d8a67085e45ef140b24",
             "parentId": "f2eacf53404dbc5a62b7b1ad",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "d713bbbc4cc8dd73af2bd937",
             "_tpl": "5a367e5dc4a282000e49738f",
             "parentId": "hideout",
@@ -4327,56 +3786,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "aec55dab6bb908a99daa2987",
             "_tpl": "5a339805c4a2826c6e06d73d",
             "parentId": "d713bbbc4cc8dd73af2bd937",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "36ccfc3dcf536fa6bab60abc",
             "_tpl": "5a3501acc4a282000d72293a",
             "parentId": "d713bbbc4cc8dd73af2bd937",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "3c1f0b297fcf3fade9e3abfe",
             "_tpl": "5a33ca0fc4a282000d72292f",
             "parentId": "d713bbbc4cc8dd73af2bd937",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "c34bb53652452e84d617e45d",
             "_tpl": "5a33cae9c4a28232980eb086",
             "parentId": "3c1f0b297fcf3fade9e3abfe",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "0dfe6bd19ada17ee4ea5ae78",
             "_tpl": "5a329052c4a28200741e22d3",
             "parentId": "d713bbbc4cc8dd73af2bd937",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "eb6eb24ca88ee1bac5de3bff",
             "_tpl": "5a34fae7c4a2826c6e06d760",
             "parentId": "d713bbbc4cc8dd73af2bd937",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "7c85b3baf63aae8bde93b8fd",
             "_tpl": "5a34fd2bc4a282329a73b4c5",
             "parentId": "eb6eb24ca88ee1bac5de3bff",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "e4dfc3c564632b3f3030a65b",
             "_tpl": "5a34fbadc4a28200741e230a",
             "parentId": "eb6eb24ca88ee1bac5de3bff",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "deaa7060a81e84a6bbbc50af",
             "_tpl": "57838ad32459774a17445cd2",
             "parentId": "hideout",
@@ -4387,38 +3837,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "845dbcbfad07eafe3fa80091",
             "_tpl": "57838f0b2459774a256959b2",
             "parentId": "deaa7060a81e84a6bbbc50af",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "4465e11e6b9d3d47fc9918f0",
             "_tpl": "57838c962459774a1651ec63",
             "parentId": "deaa7060a81e84a6bbbc50af",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "2ce9c70f8d97bb2563f03bb5",
             "_tpl": "57838e1b2459774a256959b1",
             "parentId": "4465e11e6b9d3d47fc9918f0",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "792d4d5ebb8a6c10698cabca",
             "_tpl": "578395402459774a256959b5",
             "parentId": "deaa7060a81e84a6bbbc50af",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "ce9ce676dcc4d614d52ebeaf",
             "_tpl": "578395e82459774a0e553c7b",
             "parentId": "deaa7060a81e84a6bbbc50af",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "dfcd1a2b8aefb3d55b86a0df",
             "_tpl": "57c44b372459772d2b39b8ce",
             "parentId": "hideout",
@@ -4429,44 +3873,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "23dbb69c1fc9aaa8fdde4a26",
             "_tpl": "57c44dd02459772d2e0ae249",
             "parentId": "dfcd1a2b8aefb3d55b86a0df",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "dd7c6ed2a8085a99cab16d7f",
             "_tpl": "57c44e7b2459772d28133248",
             "parentId": "23dbb69c1fc9aaa8fdde4a26",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "62b18a7dfd3a53c2a106fdb6",
             "_tpl": "57c44f4f2459772d2c627113",
             "parentId": "dfcd1a2b8aefb3d55b86a0df",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "9afc1a359adba8aacedccbff",
             "_tpl": "57838f9f2459774a150289a0",
             "parentId": "dfcd1a2b8aefb3d55b86a0df",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "dcdfce0859b3c6ab9fc0d51e",
             "_tpl": "57c44fa82459772d2d75e415",
             "parentId": "dfcd1a2b8aefb3d55b86a0df",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "0f0aac3b8af71e651e1a4ad2",
             "_tpl": "57c450252459772d28133253",
             "parentId": "dfcd1a2b8aefb3d55b86a0df",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "3cc5f9d9ccbb41ffacb3e8f9",
             "_tpl": "57c44b372459772d2b39b8ce",
             "parentId": "hideout",
@@ -4477,44 +3914,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "eaf9551400e0218d74997bb4",
             "_tpl": "57c44dd02459772d2e0ae249",
             "parentId": "3cc5f9d9ccbb41ffacb3e8f9",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "38ddeee9eabaaf825abfa1da",
             "_tpl": "57c44e7b2459772d28133248",
             "parentId": "eaf9551400e0218d74997bb4",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "b5b31f001d435ea1af1d8bb2",
             "_tpl": "57c44f4f2459772d2c627113",
             "parentId": "3cc5f9d9ccbb41ffacb3e8f9",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "a7c069df40eac8baf074b1b7",
             "_tpl": "57838f9f2459774a150289a0",
             "parentId": "3cc5f9d9ccbb41ffacb3e8f9",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "eddf8c3b0ad772acdcaecbd2",
             "_tpl": "57c44fa82459772d2d75e415",
             "parentId": "3cc5f9d9ccbb41ffacb3e8f9",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "5fe5b58548c9385cb0b93f5c",
             "_tpl": "57c450252459772d28133253",
             "parentId": "3cc5f9d9ccbb41ffacb3e8f9",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "70de7dfe8e6b0ed0794e2d19",
             "_tpl": "64b8f7968532cf95ee0a0dbf",
             "parentId": "hideout",
@@ -4525,8 +3955,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e4ded52bfbe5b42c294f0ffe",
             "_tpl": "64b8f7968532cf95ee0a0dbf",
             "parentId": "hideout",
@@ -4537,8 +3966,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "3fe2f21b9b0d86dff054ffe4",
             "_tpl": "64b8f7b5389d7ffd620ccba2",
             "parentId": "hideout",
@@ -4549,8 +3977,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "be48b7ccd293d9f2e5546e8d",
             "_tpl": "64b8f7b5389d7ffd620ccba2",
             "parentId": "hideout",
@@ -4561,8 +3988,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f65fa316c9cb7fd50034f7cb",
             "_tpl": "64b8f7c241772715af0f9c3d",
             "parentId": "hideout",
@@ -4573,8 +3999,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ada484f2dcba351b1ede85f0",
             "_tpl": "64b8f7c241772715af0f9c3d",
             "parentId": "hideout",
@@ -4585,8 +4010,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bcd8abaf2db0f2bdc8ddbdc6",
             "_tpl": "56e33634d2720bd8058b456b",
             "parentId": "hideout",
@@ -4597,8 +4021,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fbe194db904dd12abc8c4a9f",
             "_tpl": "56e33634d2720bd8058b456b",
             "parentId": "hideout",
@@ -4609,8 +4032,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "058da8bb6cea515b80eabf4b",
             "_tpl": "56e335e4d2720b6c058b456d",
             "parentId": "hideout",
@@ -4621,8 +4043,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "aac9cfafd213af399be3722d",
             "_tpl": "56e335e4d2720b6c058b456d",
             "parentId": "hideout",
@@ -4633,8 +4054,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "194a1e97f6d112880c100284",
             "_tpl": "5e9dcf5986f7746c417435b3",
             "parentId": "hideout",
@@ -4645,8 +4065,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fa2dac4fadacaaafec31cbde",
             "_tpl": "5e9dcf5986f7746c417435b3",
             "parentId": "hideout",
@@ -4657,8 +4076,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d37f2c22c97cb77aa78ddacf",
             "_tpl": "6038d614d10cbf667352dd44",
             "parentId": "hideout",
@@ -4669,8 +4087,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "4e80ce2f131e3305dc6c5dea",
             "_tpl": "6038d614d10cbf667352dd44",
             "parentId": "hideout",
@@ -4681,8 +4098,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "8ee57a37dfdc46cb2ae27fcc",
             "_tpl": "656ddcf0f02d7bcea90bf395",
             "parentId": "hideout",
@@ -4693,8 +4109,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "dbe8dd4dcfec2cdbdf6ecf2a",
             "_tpl": "656ddcf0f02d7bcea90bf395",
             "parentId": "hideout",
@@ -4705,8 +4120,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fbade5bda9fe6bb2a236dd1f",
             "_tpl": "656f198fb27298d6fd005466",
             "parentId": "hideout",
@@ -4717,8 +4131,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b1e20be1e2ea02ee63d6fbd1",
             "_tpl": "656f198fb27298d6fd005466",
             "parentId": "hideout",
@@ -4729,8 +4142,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a55fcbaa1ab2ca7ebfceca03",
             "_tpl": "619cf0335771dd3c390269ae",
             "parentId": "hideout",
@@ -4741,8 +4153,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "0ccb05c2c9ba1a5959c324d1",
             "_tpl": "619cf0335771dd3c390269ae",
             "parentId": "hideout",
@@ -4753,8 +4164,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e781e5573e2c5c3ce62aaba2",
             "_tpl": "618bb76513f5097c8d5aa2d5",
             "parentId": "hideout",
@@ -4765,8 +4175,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f7bb73f55d746cfbf1a5476b",
             "_tpl": "618bb76513f5097c8d5aa2d5",
             "parentId": "hideout",
@@ -4777,8 +4186,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "eab787b9fb1dd688fbc3e267",
             "_tpl": "628e1ffc83ec92260c0f437f",
             "parentId": "hideout",
@@ -4789,8 +4197,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "5eddfef14fbcef75abb19cf2",
             "_tpl": "628e1ffc83ec92260c0f437f",
             "parentId": "hideout",
@@ -4801,8 +4208,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ee2a5e834ba218c63dacbbeb",
             "_tpl": "62a1b7fbc30cfa1d366af586",
             "parentId": "hideout",
@@ -4813,8 +4219,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "8b154d0ef5be36aec1c5a388",
             "_tpl": "62a1b7fbc30cfa1d366af586",
             "parentId": "hideout",
@@ -4825,8 +4230,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "cc0ad6e59c08ac28ed713ebb",
             "_tpl": "5f5e467b0bc58666c37e7821",
             "parentId": "hideout",
@@ -4837,8 +4241,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "6b4c4e83bbffd4e6dcdfb5e8",
             "_tpl": "5f5e467b0bc58666c37e7821",
             "parentId": "hideout",
@@ -4849,8 +4252,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "2aaec2a0f01689f75c7d327b",
             "_tpl": "5ab8ebf186f7742d8b372e80",
             "parentId": "hideout",
@@ -4861,8 +4263,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ad13ca88ce67db71cac9bac9",
             "_tpl": "5ab8ebf186f7742d8b372e80",
             "parentId": "hideout",
@@ -4873,8 +4274,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "8d1cbe53be42e0ce71ebb90a",
             "_tpl": "639346cc1c8f182ad90c8972",
             "parentId": "hideout",
@@ -4885,8 +4285,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "af5f3cfda9449b2b7befc5d1",
             "_tpl": "639346cc1c8f182ad90c8972",
             "parentId": "hideout",
@@ -4897,8 +4296,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b722a58fb68eedcaec08388d",
             "_tpl": "656e0436d44a1bb4220303a0",
             "parentId": "hideout",
@@ -4909,8 +4307,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "cd1d3f7fd0ef4b7a42f9734c",
             "_tpl": "656e0436d44a1bb4220303a0",
             "parentId": "hideout",
@@ -4921,8 +4318,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "dbe67442de3cf36b0e2acdd0",
             "_tpl": "628bc7fb408e2b2e9c0801b1",
             "parentId": "hideout",
@@ -4933,8 +4329,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bb3090d5b8e9cbf2fa977bfd",
             "_tpl": "628bc7fb408e2b2e9c0801b1",
             "parentId": "hideout",
@@ -4945,8 +4340,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "9f73e7bb5ff3fae70beecc63",
             "_tpl": "5e997f0b86f7741ac73993e2",
             "parentId": "hideout",
@@ -4957,8 +4351,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "4cb54d4faefafe34b2d0fba0",
             "_tpl": "5e997f0b86f7741ac73993e2",
             "parentId": "hideout",
@@ -4969,8 +4362,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "05ab0dd0f83897027adb14b4",
             "_tpl": "61b9e1aaef9a1b5d6a79899a",
             "parentId": "hideout",
@@ -4981,8 +4373,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "dfebbc2c79d7da7caee7f46e",
             "_tpl": "61b9e1aaef9a1b5d6a79899a",
             "parentId": "hideout",
@@ -4993,8 +4384,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-	    {
+        }, {
             "_id": "d589abf8bd03bbbf7fd9fd58",
             "_tpl": "643ea5b23db6f9f57107d9fd",
             "parentId": "hideout",
@@ -5005,50 +4395,42 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "704bd8eaa2de709f9ffbb503",
             "_tpl": "6410745d5dd49d77bd078485",
             "parentId": "d589abf8bd03bbbf7fd9fd58",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "6f9fcbe00c58be20c3b51194",
             "_tpl": "6410758c857473525b08bb77",
             "parentId": "d589abf8bd03bbbf7fd9fd58",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "ee7b6cbc3e7becb5d0060cfb",
             "_tpl": "64119d90dcf48d656f0aa275",
             "parentId": "6f9fcbe00c58be20c3b51194",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "c27a1e91c5e325deaceae6ad",
             "_tpl": "64119d1f2c6d6f921a0929f8",
             "parentId": "6f9fcbe00c58be20c3b51194",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "bbde738bf9e0e3eae4899bed",
             "_tpl": "64119d672c6d6f921a0929fb",
             "parentId": "c27a1e91c5e325deaceae6ad",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "e1deca362409a4a70a15dc6c",
             "_tpl": "64119cdbdcf48d656f0aa272",
             "parentId": "d589abf8bd03bbbf7fd9fd58",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "0c11cfdfcfaed6e2ec337b91",
             "_tpl": "6422e1ea3c0f06190302161a",
             "parentId": "d589abf8bd03bbbf7fd9fd58",
             "slotId": "mod_magazine"
-        },
-	    {
+        }, {
             "_id": "6bf919996e3f7d9442b4f4bf",
             "_tpl": "643ea5b23db6f9f57107d9fd",
             "parentId": "hideout",
@@ -5059,50 +4441,42 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ae2cdeb813929f2aef4ee4ae",
             "_tpl": "6410745d5dd49d77bd078485",
             "parentId": "6bf919996e3f7d9442b4f4bf",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "8ccbd2a96ae9cbf246fc669a",
             "_tpl": "6410758c857473525b08bb77",
             "parentId": "6bf919996e3f7d9442b4f4bf",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "e7e977ab51daac30ca0b3be9",
             "_tpl": "64119d90dcf48d656f0aa275",
             "parentId": "8ccbd2a96ae9cbf246fc669a",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "7a9696fc3b7836bacbd7a42e",
             "_tpl": "64119d1f2c6d6f921a0929f8",
             "parentId": "8ccbd2a96ae9cbf246fc669a",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "cf7aba3aa84aa69f5dff9b34",
             "_tpl": "64119d672c6d6f921a0929fb",
             "parentId": "7a9696fc3b7836bacbd7a42e",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "c4e5c5ad1e855a768bbc56b1",
             "_tpl": "64119cdbdcf48d656f0aa272",
             "parentId": "6bf919996e3f7d9442b4f4bf",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "d6cbc1d390eae5cada0d0050",
             "_tpl": "6422e1ea3c0f06190302161a",
             "parentId": "6bf919996e3f7d9442b4f4bf",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "638dae2266adbbef13f6a57d",
             "_tpl": "644674a13d52156624001fbc",
             "parentId": "hideout",
@@ -5113,44 +4487,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "8eaaef2e44b6a397ff8b1d98",
             "_tpl": "6450ec2e7da7133e5a09ca96",
             "parentId": "638dae2266adbbef13f6a57d",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "f3e5dfe8ef0a990bdaac06ec",
             "_tpl": "6450f21a3d52156624001fcf",
             "parentId": "638dae2266adbbef13f6a57d",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "b991aeffdd451938d001a43e",
             "_tpl": "6451167ad4928d46d30be3fd",
             "parentId": "638dae2266adbbef13f6a57d",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "b4747b9acf0e6559fbac5d5f",
             "_tpl": "645122f6d4928d46d30be3ff",
             "parentId": "638dae2266adbbef13f6a57d",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "cc57063e77eeafd6180e2de1",
             "_tpl": "644675573d52156624001fc9",
             "parentId": "b4747b9acf0e6559fbac5d5f",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "bebcf7d87fa162fe9bb6febf",
             "_tpl": "64527a263d52156624001fd7",
             "parentId": "b4747b9acf0e6559fbac5d5f",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "d3b6abcadbdfb0c1deeeaf4c",
             "_tpl": "645e0c6b3b381ede770e1cc9",
             "parentId": "hideout",
@@ -5161,38 +4528,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "cc7c8fddd907bbcedb06d2f4",
             "_tpl": "6450ec2e7da7133e5a09ca96",
             "parentId": "d3b6abcadbdfb0c1deeeaf4c",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "f303682a50e9cedddfca3e78",
             "_tpl": "6452519e3d52156624001fd5",
             "parentId": "d3b6abcadbdfb0c1deeeaf4c",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "c4fa145d87eb1f8394ba0b22",
             "_tpl": "645123013d52156624001fd1",
             "parentId": "d3b6abcadbdfb0c1deeeaf4c",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "2c2aacbbaa9ceed2fbaa24bb",
             "_tpl": "6448f2f6d4928d46d30be3f6",
             "parentId": "c4fa145d87eb1f8394ba0b22",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "c22aaf597040de64e62ba5b8",
             "_tpl": "64527a263d52156624001fd7",
             "parentId": "c4fa145d87eb1f8394ba0b22",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "bf8a68cc1c5b35a8a27c7eed",
             "_tpl": "6410733d5dd49d77bd07847e",
             "parentId": "hideout",
@@ -5203,50 +4564,42 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b4563c50f0ad60fcfaf46f01",
             "_tpl": "6410745d5dd49d77bd078485",
             "parentId": "bf8a68cc1c5b35a8a27c7eed",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "fb9b03fe2d7591e47fecd710",
             "_tpl": "6410758c857473525b08bb77",
             "parentId": "bf8a68cc1c5b35a8a27c7eed",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "5fe9afde44a2ede7b09be5f2",
             "_tpl": "64119d90dcf48d656f0aa275",
             "parentId": "fb9b03fe2d7591e47fecd710",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "73af0fe0d8c612ba5d652f8e",
             "_tpl": "64119d1f2c6d6f921a0929f8",
             "parentId": "fb9b03fe2d7591e47fecd710",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "fc5431cde636917a86a63ac3",
             "_tpl": "64119d672c6d6f921a0929fb",
             "parentId": "73af0fe0d8c612ba5d652f8e",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "67fbcae44a1a08e4ce9420ca",
             "_tpl": "64119cdbdcf48d656f0aa272",
             "parentId": "bf8a68cc1c5b35a8a27c7eed",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "f0454067b9a2d883b82d3306",
             "_tpl": "641074a07fd350b98c0b3f96",
             "parentId": "bf8a68cc1c5b35a8a27c7eed",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "0a6c89c0beff4a99a1218348",
             "_tpl": "627e14b21713922ded6f2c15",
             "parentId": "hideout",
@@ -5257,98 +4610,82 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "66b6b70faee2020aec876c9a",
             "_tpl": "628120fd5631d45211793c9f",
             "parentId": "0a6c89c0beff4a99a1218348",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "c8e2e805fcec10ab6acec860",
             "_tpl": "62811f828193841aca4a45c3",
             "parentId": "cb66d8e84e0053e6dd8d52cd",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "2d2dc1ee4ee961236fcbf50f",
             "_tpl": "628120c21d5df4475f46a337",
             "parentId": "27deb8df4545e701fde3be7f",
             "slotId": "mod_mount_000"
-        },
-        {
+        }, {
             "_id": "dc0b1a482ae11aefca60c3c3",
             "_tpl": "628120d309427b40ab14e76d",
             "parentId": "27deb8df4545e701fde3be7f",
             "slotId": "mod_mount_001"
-        },
-        {
+        }, {
             "_id": "2ff9e9afe4ac3bbf2b294ae8",
             "_tpl": "628120d309427b40ab14e76d",
             "parentId": "27deb8df4545e701fde3be7f",
             "slotId": "mod_mount_002"
-        },
-        {
+        }, {
             "_id": "e7e3cafeb1397764a4ae6183",
             "_tpl": "628120dd308cb521f87a8fa1",
             "parentId": "27deb8df4545e701fde3be7f",
             "slotId": "mod_mount_003"
-        },
-        {
+        }, {
             "_id": "27deb8df4545e701fde3be7f",
             "_tpl": "6281209662cba23f6c4d7a19",
             "parentId": "cc67e8677fcd1eebcaa1b4e7",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "84ad035a6094cdf7efd34dce",
             "_tpl": "6281212a09427b40ab14e770",
             "parentId": "cc67e8677fcd1eebcaa1b4e7",
             "slotId": "mod_foregrip"
-        },
-        {
+        }, {
             "_id": "c865989edf78b4cecc4f5d0d",
             "_tpl": "628120621d5df4475f46a335",
             "parentId": "da4bd6bcd6aeefbfa5d1ba3d",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "da4bd6bcd6aeefbfa5d1ba3d",
             "_tpl": "62812081d23f207deb0ab216",
             "parentId": "70bcfe7afedd8fefb8add4ca",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "70bcfe7afedd8fefb8add4ca",
             "_tpl": "628121434fa03b6b6c35dc6a",
             "parentId": "dbd0cfcfc47ae321cba15ef0",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "dbd0cfcfc47ae321cba15ef0",
             "_tpl": "62811fbf09427b40ab14e767",
             "parentId": "cc67e8677fcd1eebcaa1b4e7",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "cc67e8677fcd1eebcaa1b4e7",
             "_tpl": "6281204f308cb521f87a8f9b",
             "parentId": "cb66d8e84e0053e6dd8d52cd",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "cb66d8e84e0053e6dd8d52cd",
             "_tpl": "62811e2510e26c1f344e6554",
             "parentId": "0a6c89c0beff4a99a1218348",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "67a178932abd35e54c29ceae",
             "_tpl": "62811cd7308cb521f87a8f99",
             "parentId": "0a6c89c0beff4a99a1218348",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "fe7eb0f3e1ee7dbd49dbed3a",
             "_tpl": "644674a13d52156624001fbc",
             "parentId": "hideout",
@@ -5359,44 +4696,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "31cef3ec0e08041968ffe3c4",
             "_tpl": "6450ec2e7da7133e5a09ca96",
             "parentId": "fe7eb0f3e1ee7dbd49dbed3a",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "ed7fb5e1ca0523f1c594e06b",
             "_tpl": "6450f21a3d52156624001fcf",
             "parentId": "fe7eb0f3e1ee7dbd49dbed3a",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "01ee02d9aadff33d8f2cccf8",
             "_tpl": "6451167ad4928d46d30be3fd",
             "parentId": "fe7eb0f3e1ee7dbd49dbed3a",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "ed3aea1a0ca8cbccd2483e5c",
             "_tpl": "645122f6d4928d46d30be3ff",
             "parentId": "fe7eb0f3e1ee7dbd49dbed3a",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "9d9fef5fbb2f12db1a66601f",
             "_tpl": "644675573d52156624001fc9",
             "parentId": "ed3aea1a0ca8cbccd2483e5c",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "63e92ce1881af0bfd60ddb2c",
             "_tpl": "64527a263d52156624001fd7",
             "parentId": "ed3aea1a0ca8cbccd2483e5c",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "2464cf8a8e8a1fbfd0f9eba0",
             "_tpl": "645e0c6b3b381ede770e1cc9",
             "parentId": "hideout",
@@ -5407,38 +4737,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "0ada1b25fe758bdc54b9fdef",
             "_tpl": "6450ec2e7da7133e5a09ca96",
             "parentId": "2464cf8a8e8a1fbfd0f9eba0",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "acab91acd8f3a26dc696ef8d",
             "_tpl": "6452519e3d52156624001fd5",
             "parentId": "2464cf8a8e8a1fbfd0f9eba0",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "ed6fedaf9bd29e0cef1a725a",
             "_tpl": "645123013d52156624001fd1",
             "parentId": "2464cf8a8e8a1fbfd0f9eba0",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "2ceccc6ad3dbfeff71eecac6",
             "_tpl": "6448f2f6d4928d46d30be3f6",
             "parentId": "ed6fedaf9bd29e0cef1a725a",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "d50d091c6f5b6b31bf15a0be",
             "_tpl": "64527a263d52156624001fd7",
             "parentId": "ed6fedaf9bd29e0cef1a725a",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "003c2c9db2b8dde27cc21c7c",
             "_tpl": "6410733d5dd49d77bd07847e",
             "parentId": "hideout",
@@ -5449,50 +4773,42 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "5df6a6baefe2ea293edcc801",
             "_tpl": "6410745d5dd49d77bd078485",
             "parentId": "003c2c9db2b8dde27cc21c7c",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "d88050bbafb7315caa0dee0a",
             "_tpl": "6410758c857473525b08bb77",
             "parentId": "003c2c9db2b8dde27cc21c7c",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "c3a45ac9effb8e7ee45ec8fe",
             "_tpl": "64119d90dcf48d656f0aa275",
             "parentId": "d88050bbafb7315caa0dee0a",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "e8109c294c702cbbedbf4e24",
             "_tpl": "64119d1f2c6d6f921a0929f8",
             "parentId": "d88050bbafb7315caa0dee0a",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "60d0528bdbaa58ec70e1d8bd",
             "_tpl": "64119d672c6d6f921a0929fb",
             "parentId": "e8109c294c702cbbedbf4e24",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "698b35e7073c979ea26ee11c",
             "_tpl": "64119cdbdcf48d656f0aa272",
             "parentId": "003c2c9db2b8dde27cc21c7c",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "c6804b1bdd1e5dafb41b6919",
             "_tpl": "641074a07fd350b98c0b3f96",
             "parentId": "003c2c9db2b8dde27cc21c7c",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "f02daaee0df5d4e6bb4cfafd",
             "_tpl": "627e14b21713922ded6f2c15",
             "parentId": "hideout",
@@ -5503,98 +4819,82 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "de49cadbaedbae2d26c61eee",
             "_tpl": "628120fd5631d45211793c9f",
             "parentId": "f02daaee0df5d4e6bb4cfafd",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "f1afcfc1c19e44d1dac700ad",
             "_tpl": "62811f828193841aca4a45c3",
             "parentId": "1bcf0a88750fe0a1a19f6dba",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "cfad20fbb4e217dacc85a3d4",
             "_tpl": "628120c21d5df4475f46a337",
             "parentId": "5aec2a8ffe40cf1bb94b7efe",
             "slotId": "mod_mount_000"
-        },
-        {
+        }, {
             "_id": "115fb977a2cbb321b178cda9",
             "_tpl": "628120d309427b40ab14e76d",
             "parentId": "5aec2a8ffe40cf1bb94b7efe",
             "slotId": "mod_mount_001"
-        },
-        {
+        }, {
             "_id": "159a35d18d0bedcea2ebccb2",
             "_tpl": "628120d309427b40ab14e76d",
             "parentId": "5aec2a8ffe40cf1bb94b7efe",
             "slotId": "mod_mount_002"
-        },
-        {
+        }, {
             "_id": "6b899bad7dcce22cb653efff",
             "_tpl": "628120dd308cb521f87a8fa1",
             "parentId": "5aec2a8ffe40cf1bb94b7efe",
             "slotId": "mod_mount_003"
-        },
-        {
+        }, {
             "_id": "5aec2a8ffe40cf1bb94b7efe",
             "_tpl": "6281209662cba23f6c4d7a19",
             "parentId": "a0a3995b5addbef0ecbaffba",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "5e5e342add89308e8f7dde56",
             "_tpl": "6281212a09427b40ab14e770",
             "parentId": "a0a3995b5addbef0ecbaffba",
             "slotId": "mod_foregrip"
-        },
-        {
+        }, {
             "_id": "c95ab98bc272a47ea4cc7fac",
             "_tpl": "628120621d5df4475f46a335",
             "parentId": "b68dbe59abfa96d46b7d4bed",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "b68dbe59abfa96d46b7d4bed",
             "_tpl": "62812081d23f207deb0ab216",
             "parentId": "dba43d5ba99e8adcd8066f5e",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "dba43d5ba99e8adcd8066f5e",
             "_tpl": "628121434fa03b6b6c35dc6a",
             "parentId": "9ffc165e4ddeb74acee4d6ff",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "9ffc165e4ddeb74acee4d6ff",
             "_tpl": "62811fbf09427b40ab14e767",
             "parentId": "a0a3995b5addbef0ecbaffba",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "a0a3995b5addbef0ecbaffba",
             "_tpl": "6281204f308cb521f87a8f9b",
             "parentId": "1bcf0a88750fe0a1a19f6dba",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "1bcf0a88750fe0a1a19f6dba",
             "_tpl": "62811e2510e26c1f344e6554",
             "parentId": "f02daaee0df5d4e6bb4cfafd",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "f09a11ce5d904a8abadf2afc",
             "_tpl": "62811cd7308cb521f87a8f99",
             "parentId": "f02daaee0df5d4e6bb4cfafd",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "40bcd1980b5274f896bbecb7",
             "_tpl": "628120fd5631d45211793c9f",
             "parentId": "hideout",
@@ -5605,8 +4905,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "0e3e5dcab535dab6f281dc5c",
             "_tpl": "641074a07fd350b98c0b3f96",
             "parentId": "hideout",
@@ -5617,8 +4916,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "5b1c1f7b7d3ea76eb4f868ae",
             "_tpl": "6422e1ea3c0f06190302161a",
             "parentId": "hideout",
@@ -5629,8 +4927,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "8a624d589119c4d2a24de9b5",
             "_tpl": "6450ec2e7da7133e5a09ca96",
             "parentId": "hideout",
@@ -5641,8 +4938,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "79b74f9a54adcd8671d3eda0",
             "_tpl": "5c5970672e221602b21d7855",
             "parentId": "hideout",
@@ -5653,8 +4949,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f42ab266eb5d079fef2f8ffc",
             "_tpl": "587df583245977373c4f1129",
             "parentId": "hideout",
@@ -5665,8 +4960,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a331bf1a7c88cdcbe0d7a957",
             "_tpl": "5bfea7ad0db834001c38f1ee",
             "parentId": "hideout",
@@ -5677,8 +4971,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "eaaa847ac7c8cebfb5b1a59b",
             "_tpl": "5bfeaa0f0db834001b734927",
             "parentId": "hideout",

--- a/db/traders/6765fbd20fdc7eb79b00000c/assort.json
+++ b/db/traders/6765fbd20fdc7eb79b00000c/assort.json
@@ -1,1789 +1,2048 @@
 {
     "barter_scheme": {
         "f7afeb9dcd44e5c2df0fdebe": [
-            [{
+            [
+                {
                     "_tpl": "590a3d9c86f774385926e510",
                     "count": 10
-                }, {
+                },
+                {
                     "_tpl": "590c645c86f77412b01304d9",
                     "count": 5
                 }
             ]
         ],
         "51a485bf649f505b4ce23cbc": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60000
                 }
             ]
         ],
         "eee701afcd64ac958917f38b": [
-            [{
+            [
+                {
                     "_tpl": "57513f9324597720a7128161",
                     "count": 2
                 }
             ]
         ],
         "ff2be5592cff0c39dc6ce2f4": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2800
                 }
             ]
         ],
         "09e0f2ebb6ddec747acfa310": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 6000
                 }
             ]
         ],
         "acfeabef6feadb2bcdff8b6f": [
-            [{
+            [
+                {
                     "_tpl": "5c0d5ae286f7741e46554302",
                     "count": 3
                 }
             ]
         ],
         "befaa9e78a9be7dc3dbaddd7": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 165
                 }
             ]
         ],
         "bec8baa49d915d21f3cf3946": [
-            [{
+            [
+                {
                     "_tpl": "59e6906286f7746c9f75e847",
                     "count": 6
                 }
             ]
         ],
         "1c23fd6f997fea6aab4092df": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 660
                 }
             ]
         ],
         "1825ca0ed5fbdab1b5cc7bba": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 17000
                 }
             ]
         ],
         "da7ed5414ccfc4564efaabd6": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1500
                 }
             ]
         ],
         "0bdbccfd208aeea0ddc47cce": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 30000
                 }
             ]
         ],
         "b7b0dde96e10bde42d78a1da": [
-            [{
+            [
+                {
                     "_tpl": "5d1b39a386f774252339976f",
                     "count": 5
                 }
             ]
         ],
         "9c5ef2be33cc074cc80fd688": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3300
                 }
             ]
         ],
         "97d8e98fdedbb04209ba6ea3": [
-            [{
+            [
+                {
                     "_tpl": "59e4d24686f7741776641ac7",
                     "count": 3
                 }
             ]
         ],
         "03b2fb63acf4bfe6fe0e72f5": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 225
                 }
             ]
         ],
         "51300aa813b4dae28bdca525": [
-            [{
+            [
+                {
                     "_tpl": "56dff2ced2720bb4668b4567",
                     "count": 6
                 }
             ]
         ],
         "c6c5b6bbf2c02eafe2a409af": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 590
                 }
             ]
         ],
         "45dd1a0dd42cb8b7613ffed6": [
-            [{
+            [
+                {
                     "_tpl": "61962b617c6c7b169525f168",
                     "count": 3
                 }
             ]
         ],
         "5b0af0012b6eafbc8ad2719e": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 740
                 }
             ]
         ],
         "d1fd1ed131adc6edf787facd": [
-            [{
+            [
+                {
                     "_tpl": "56dfef82d2720bbd668b4567",
                     "count": 2
                 }
             ]
         ],
         "cdd1ac8a6ff37aa0d0a075fd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 500
                 }
             ]
         ],
         "d8be427c92cebf3fbadfffba": [
-            [{
+            [
+                {
                     "_tpl": "56dff4ecd2720b5f5a8b4568",
                     "count": 2
                 }
             ]
         ],
         "a8f5f4b32432094bf88584fa": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 90
                 }
             ]
         ],
         "caf1de383b3581f1bffc6030": [
-            [{
+            [
+                {
                     "_tpl": "56dff421d2720b5f5a8b4567",
                     "count": 4
                 }
             ]
         ],
         "fe19a2dcbac6ce46f4ebbb02": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 45
                 }
             ]
         ],
         "cedad22a07a58bcb25e5013b": [
-            [{
+            [
+                {
                     "_tpl": "56dff3afd2720bba668b4567",
                     "count": 2
                 }
             ]
         ],
         "a5fac979afb4bdfeddda0eb9": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 205
                 }
             ]
         ],
         "dffb5680abbcfbc31faec6b6": [
-            [{
+            [
+                {
                     "_tpl": "56dff216d2720bbd668b4568",
                     "count": 2
                 }
             ]
         ],
         "5cab97f1b7972fba8773ac4d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 54
                 }
             ]
         ],
         "b85ebc4dee217a25b8a3cc32": [
-            [{
+            [
+                {
                     "_tpl": "56dff4a2d2720bbd668b456a",
                     "count": 3
                 }
             ]
         ],
         "5ae1d9ecacebd3325d720dbe": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 130
                 }
             ]
         ],
         "3cae97dbd4c5d296fd1aecde": [
-            [{
+            [
+                {
                     "_tpl": "573719762459775a626ccbc1",
                     "count": 3
                 }
             ]
         ],
         "7be0adcab6acc382e17becd2": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 63
                 }
             ]
         ],
         "addc13cb33a8fb54eb3237da": [
-            [{
+            [
+                {
                     "_tpl": "56dff0bed2720bb0668b4567",
                     "count": 2
                 }
             ]
         ],
         "bbf7baeca1b654c5c9f0bcfb": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 82
                 }
             ]
         ],
         "dd396513b7f0d941a4e7bdc4": [
-            [{
+            [
+                {
                     "_tpl": "56dff338d2720bbd668b4569",
                     "count": 2
                 }
             ]
         ],
         "14ea806be1d4475cf9fbce2d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 82
                 }
             ]
         ],
         "36b47feeadeeface1d34eecf": [
-            [{
+            [
+                {
                     "_tpl": "5d0375ff86f774186372f685",
                     "count": 1
                 }
             ]
         ],
         "caf3d9bf3d2bf4efd49ece0b": [
-            [{
+            [
+                {
                     "_tpl": "59e361e886f774176c10a2a5",
                     "count": 4
                 }
             ]
         ],
         "267823eb62a2f7acf8cfceb5": [
-            [{
+            [
+                {
                     "_tpl": "5d4041f086f7743cac3f22a7",
                     "count": 2
                 }
             ]
         ],
         "75fe098ddbb4f58bbe3c17cc": [
-            [{
+            [
+                {
                     "_tpl": "5d03784a86f774203e7e0c4d",
                     "count": 2
                 }
             ]
         ],
         "edbdebc5a978f4f73afeedea": [
-            [{
+            [
+                {
                     "_tpl": "5e2aee0a86f774755a234b62",
                     "count": 2
                 }
             ]
         ],
         "c70681b0caba7a7c4a9551dd": [
-            [{
+            [
+                {
                     "_tpl": "5d1b32c186f774252167a530",
                     "count": 1
                 }
             ]
         ],
         "6ffbead04e4e9bf14db45e9c": [
-            [{
+            [
+                {
                     "_tpl": "5d1b304286f774253763a528",
                     "count": 1
                 }
             ]
         ],
         "57932e2b7dce3ebb31ba4a08": [
-            [{
+            [
+                {
                     "_tpl": "5d1b392c86f77425243e98fe",
                     "count": 4
                 }
             ]
         ],
         "ad6bb74e267087fc01c9fd1e": [
-            [{
+            [
+                {
                     "_tpl": "5751496424597720a27126da",
                     "count": 2
                 }
             ]
         ],
         "7e3872a04bef1b68da53ddaf": [
-            [{
+            [
+                {
                     "_tpl": "57514643245977207f2c2d09",
                     "count": 3
                 }
             ]
         ],
         "3bd165f6627ba5d97bdabaa5": [
-            [{
+            [
+                {
                     "_tpl": "59e358a886f7741776641ac3",
                     "count": 2
                 }
             ]
         ],
         "acd38f7af0feacccbce1ce3c": [
-            [{
+            [
+                {
                     "_tpl": "57347d5f245977448b40fa81",
                     "count": 1
                 }
             ]
         ],
         "ccde5ef196dcf7d4f7c0ad84": [
-            [{
+            [
+                {
                     "_tpl": "5e2af2bc86f7746d3f3c33fc",
                     "count": 2
                 }
             ]
         ],
         "507bfdceec87dbcbe7a28081": [
-            [{
+            [
+                {
                     "_tpl": "5bc9c29cd4351e003562b8a3",
                     "count": 1
                 }
             ]
         ],
         "851dafd2930c1452d223755b": [
-            [{
+            [
+                {
                     "_tpl": "5672cb304bdc2dc2088b456a",
                     "count": 1
                 }
             ]
         ],
         "f55e3c9de4a7abd5afe4c2df": [
-            [{
+            [
+                {
                     "_tpl": "57347d90245977448f7b7f65",
                     "count": 2
                 }
             ]
         ],
         "73b0fc2dd4c9c1f3543cd9c1": [
-            [{
+            [
+                {
                     "_tpl": "590a386e86f77429692b27ab",
                     "count": 2
                 }
             ]
         ],
         "ad5ec232ca5bbeae937bb5ad": [
-            [{
+            [
+                {
                     "_tpl": "5751435d24597720a27126d1",
                     "count": 1
                 }
             ]
         ],
         "bbadda2559edb2baf09d5dc1": [
-            [{
+            [
+                {
                     "_tpl": "5734779624597737e04bf329",
                     "count": 2
                 }
             ]
         ],
         "ac71f96dbe4b231cadcee132": [
-            [{
+            [
+                {
                     "_tpl": "59e35abd86f7741778269d82",
                     "count": 1
                 }
             ]
         ],
         "3eecf5deccce8335fccaffd1": [
-            [{
+            [
+                {
                     "_tpl": "575062b524597720a31c09a1",
                     "count": 1
                 }
             ]
         ],
         "ebcdcc2b7eb9c20ab06acaf5": [
-            [{
+            [
+                {
                     "_tpl": "5c13cd2486f774072c757944",
                     "count": 2
                 }
             ]
         ],
         "fdfcedae16be8feddc0ea7ee": [
-            [{
+            [
+                {
                     "_tpl": "57347d8724597744596b4e76",
                     "count": 2
                 }
             ]
         ],
         "cabdb4c1495b6815b4ba9f51": [
-            [{
+            [
+                {
                     "_tpl": "544fb6cc4bdc2d34748b456e",
                     "count": 1
                 }
             ]
         ],
         "7ddc89ffbe95aaac2e3e4ac3": [
-            [{
+            [
+                {
                     "_tpl": "5448ff904bdc2d6f028b456e",
                     "count": 1
                 }
             ]
         ],
         "53d1c415aeddbb8fbeceb0ef": [
-            [{
+            [
+                {
                     "_tpl": "544fb62a4bdc2dfb738b4568",
                     "count": 1
                 }
             ]
         ],
         "4ec114a9eb0dfafdb5facafe": [
-            [{
+            [
+                {
                     "_tpl": "57513fcc24597720a31c09a6",
                     "count": 1
                 }
             ]
         ],
         "2ff88da5b0a91bd0feaacac7": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5600
                 }
             ]
         ],
         "44dbab6cee357ded1e3b729f": [
-            [{
+            [
+                {
                     "_tpl": "5e023cf8186a883be655e54f",
                     "count": 2
                 }
             ]
         ],
         "a6debb8e4c29f589c5d9c3db": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 205
                 }
             ]
         ],
         "d3934fcbf9db76cffbf0e971": [
-            [{
+            [
+                {
                     "_tpl": "57a0dfb82459774d3078b56c",
                     "count": 4
                 }
             ]
         ],
         "bac7a48f8a8eba54a6abd1ac": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 880
                 }
             ]
         ],
         "e506bfbaddaf6cf680f4d3a7": [
-            [{
+            [
+                {
                     "_tpl": "59e36c6f86f774176c10a2a7",
                     "count": 3
                 }
             ]
         ],
         "0751b54d74e5bccbcbdaf625": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 21000
                 }
             ]
         ],
         "243a72c0ecab68e63ef4ba65": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 26000
                 }
             ]
         ],
         "b6d8749a9b609e46eb910dca": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60000
                 }
             ]
         ],
         "aba8dd2f419d3f90e42aabcf": [
-            [{
+            [
+                {
                     "_tpl": "5e023e88277cce2b522ff2b1",
                     "count": 3
                 }
             ]
         ],
         "e3b3d99c6be49f6ca07560a1": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 390
                 }
             ]
         ],
         "ae3d89a1f2366cddefdbf3f6": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 14500
                 }
             ]
         ],
         "f63d3e4ae77e8abdfe36d7af": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 37500
                 }
             ]
         ],
         "0e6da835c1a9f1edda83df89": [
-            [{
+            [
+                {
                     "_tpl": "5656d7c34bdc2d9d198b4587",
                     "count": 5
                 }
             ]
         ],
         "2cdea03f665c4ce65c7d1f1e": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1050
                 }
             ]
         ],
         "6aa3acbe6be11ce5ed522ce1": [
-            [{
+            [
+                {
                     "_tpl": "5a38ebd9c4a282000d722a5b",
                     "count": 4
                 }
             ]
         ],
         "cf7f0cf0b168de8bad9dbada": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 185
                 }
             ]
         ],
         "fe2aa27f123fc25e462af7b6": [
-            [{
+            [
+                {
                     "_tpl": "59e4d3d286f774176a36250a",
                     "count": 3
                 }
             ]
         ],
         "e523a8d2d5ab18ddcbbbb827": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 150
                 }
             ]
         ],
         "6921eaa048c0405619f2948d": [
-            [{
+            [
+                {
                     "_tpl": "59e4cf5286f7741778269d8a",
                     "count": 4
                 }
             ]
         ],
         "690ba255e7d8ed06ec14f87d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 65
                 }
             ]
         ],
         "b2ef9af5e4aa25efee78a9ec": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 930
                 }
             ]
         ],
         "3daccfae304d967f54cef4bb": [
-            [{
+            [
+                {
                     "_tpl": "5734781f24597737e04bf32a",
                     "count": 3
                 }
             ]
         ],
         "cd706d2bc5c4e45dfeb87b57": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 26250
                 }
             ]
         ],
         "38beda0d56a9c7636acfcd1f": [
-            [{
+            [
+                {
                     "_tpl": "590a386e86f77429692b27ab",
                     "count": 4
                 }
             ]
         ],
         "cba9defaede775b699fafea7": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 29000
                 }
             ]
         ],
         "d4dbec374aeddbcaab371ffd": [
-            [{
+            [
+                {
                     "_tpl": "60194943740c5d77f6705eea",
                     "count": 4
                 }
             ]
         ],
         "afd727ab3a4cc49c59f4ba4e": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 95
                 }
             ]
         ],
         "4eaaaffcabc67c45bed2e97e": [
-            [{
+            [
+                {
                     "_tpl": "59e68f6f86f7746c9f75e846",
                     "count": 2
                 }
             ]
         ],
         "9a707c8ebfb1d1d14d05c867": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 400
                 }
             ]
         ],
         "bfbfac0770bde5ab59d90fbc": [
-            [{
+            [
+                {
                     "_tpl": "54527ac44bdc2d36668b4567",
                     "count": 2
                 }
             ]
         ],
         "5cc11aa5f5afd1befeb8aa3b": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1200
                 }
             ]
         ],
         "c392f5cafebb09f0d2cbacce": [
-            [{
+            [
+                {
                     "_tpl": "59e6927d86f77411da468256",
                     "count": 3
                 }
             ]
         ],
         "e27cc9d11b5fe4dda9c8a16e": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 80
                 }
             ]
         ],
         "af5833ffb06b7b103bd80bdb": [
-            [{
+            [
+                {
                     "_tpl": "59e6918f86f7746c9f75e849",
                     "count": 3
                 }
             ]
         ],
         "73cbff75d4bbdd6bbf76362d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 120
                 }
             ]
         ],
         "0aa1e4932e90c16b2c7ddbee": [
-            [{
+            [
+                {
                     "_tpl": "58820d1224597753c90aeb13",
                     "count": 2
                 }
             ]
         ],
         "cd106018ca64ceacb8ff2f9c": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 45
                 }
             ]
         ],
         "6ea1ffe9eee54b1cf36376cf": [
-            [{
+            [
+                {
                     "_tpl": "573477e124597737dd42e191",
                     "count": 1
-                }, {
+                },
+                {
                     "_tpl": "5bc9c29cd4351e003562b8a3",
                     "count": 2
                 }
             ]
         ],
         "ec82a5f1dfb49c7c191ef8bd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 36600
                 }
             ]
         ],
         "9fedefc8bf5bbf109deee2eb": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 42000
                 }
             ]
         ],
         "4147f4c1ccaef366bfccec6b": [
-            [{
+            [
+                {
                     "_tpl": "5a608bf24f39f98ffc77720e",
                     "count": 2
                 }
             ]
         ],
         "d4cd7de283faedfbbe72abd1": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1100
                 }
             ]
         ],
         "7e5f4bd20de1cc072b1bd1ac": [
-            [{
+            [
+                {
                     "_tpl": "58dd3ad986f77403051cba8f",
                     "count": 6
                 }
             ]
         ],
         "379aa33c1fbf1afbfeba5f8d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 550
                 }
             ]
         ],
         "0b59f7cfdee039c2b1ef60cd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 18600
                 }
             ]
         ],
         "769bf3edae3ccccefdabaecf": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1860
                 }
             ]
         ],
         "b9b6184222b2a9f7a8a1381e": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 33000
                 }
             ]
         ],
         "25d9cdc19f953ca2b7e2e19d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 37000
                 }
             ]
         ],
         "60c72fc9bbd53cbeec2a0867": [
-            [{
+            [
+                {
                     "_tpl": "5d1b39a386f774252339976f",
                     "count": 2
-                }, {
+                },
+                {
                     "_tpl": "57347c1124597737fb1379e3",
                     "count": 3
                 }
             ]
         ],
         "bafde5fee8bf01e574dffdfd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 33300
                 }
             ]
         ],
         "b0e4c1aadbd05c70bb4bae11": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1700
                 }
             ]
         ],
         "9dd2c749743a53c9efa92df6": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 42000
                 }
             ]
         ],
         "d55017fe6e6cf9e0bfeb4dcd": [
-            [{
+            [
+                {
                     "_tpl": "590c645c86f77412b01304d9",
                     "count": 3
                 }
             ]
         ],
         "268df6124c7584f8acd980ed": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 57000
                 }
             ]
         ],
         "eb9e0f0277f7b85f2c513e55": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 45000
                 }
             ]
         ],
         "bbeaaaedce2a9bf8fd1a8251": [
-            [{
+            [
+                {
                     "_tpl": "5d403f9186f7743cac3f229b",
                     "count": 2
-                }, {
+                },
+                {
                     "_tpl": "5bc9c377d4351e3bac12251b",
                     "count": 2
                 }
             ]
         ],
         "bc3eee4fb6caeaef28b91a85": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 46000
                 }
             ]
         ],
         "5bf4e8e362ffdfdb08c8ddee": [
-            [{
+            [
+                {
                     "_tpl": "5af0548586f7743a532b7e99",
                     "count": 2
                 }
             ]
         ],
         "e6a9ac9a2a6d58d04642b3b2": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 37500
                 }
             ]
         ],
         "7cbf7a98ba8c769aa75c04fa": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5400
                 }
             ]
         ],
         "24f5d14dd6a1d2f4d5dedaab": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 18000
                 }
             ]
         ],
         "b1c647f0b20aa881ba8fd022": [
-            [{
+            [
+                {
                     "_tpl": "590a373286f774287540368b",
                     "count": 5
                 }
             ]
         ],
         "cf3bc468503c7cfec45ebada": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 95000
                 }
             ]
         ],
         "9b1f0add467fc69d1bc4ccb4": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3300
                 }
             ]
         ],
         "f5fbec96e2bde57b45bceacd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24500
                 }
             ]
         ],
         "1ffe68bf509adbcc118b7ece": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2800
                 }
             ]
         ],
         "dcab6a885f5298acfab2ebfd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 4400
                 }
             ]
         ],
         "009d6cecd1806d108ca1f87d": [
-            [{
+            [
+                {
                     "_tpl": "5c07df7f0db834001b73588a",
                     "count": 5
                 }
             ]
         ],
         "f7253aa7fdb140fe0e3fb6d2": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 77500
                 }
             ]
         ],
         "ef57451fccdd2dab9877e7c9": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2550
                 }
             ]
         ],
         "f5dc47ad4ca0c2eecb6dbdbc": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 30000
                 }
             ]
         ],
         "ead9d3a507d7d92f2e24b9a0": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 31000
                 }
             ]
         ],
         "b076af4f8db6d01773b6ec8d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2250
                 }
             ]
         ],
         "df6171d1caf99a2a2731aeea": [
-            [{
+            [
+                {
                     "_tpl": "5d1b2ffd86f77425243e8d17",
                     "count": 1
                 }
             ]
         ],
         "ed1d018635ec71b82a0fdf69": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 36600
                 }
             ]
         ],
         "bbc9ffadaceab18bcfbd9ec2": [
-            [{
+            [
+                {
                     "_tpl": "59e6920f86f77411d82aa167",
                     "count": 3
                 }
             ]
         ],
         "feaec87b5a2fdd40ffa3fe4f": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 120
                 }
             ]
         ],
         "eafae65d6aad97aceca88ac7": [
-            [{
+            [
+                {
                     "_tpl": "56dff026d2720bb8668b4567",
                     "count": 2
                 }
             ]
         ],
         "28bfa3ec60199dc7bde5edfd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1200
                 }
             ]
         ],
         "4d2ff8d2c0ccadf9b93c90d0": [
-            [{
+            [
+                {
                     "_tpl": "61962d879bb3d20b0946d385",
                     "count": 2
                 }
             ]
         ],
         "5ef33313f8f51144ae07f65f": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 420
                 }
             ]
         ],
         "b8284dc99eed2dac03e047a4": [
-            [{
+            [
+                {
                     "_tpl": "5c0d668f86f7747ccb7f13b2",
                     "count": 3
                 }
             ]
         ],
         "be0bad95ab0da15c1ab12214": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1200
                 }
             ]
         ],
         "afeb2a8f9c2808713f59aacf": [
-            [{
+            [
+                {
                     "_tpl": "5448fee04bdc2dbc018b4567",
                     "count": 1
                 }
             ]
         ],
         "ee3fde0c8c92e698bd9bd19f": [
-            [{
+            [
+                {
                     "_tpl": "590a3d9c86f774385926e510",
                     "count": 1
                 }
             ]
         ],
         "aab4525ecf51da1f42fcd762": [
-            [{
+            [
+                {
                     "_tpl": "590c31c586f774245e3141b2",
                     "count": 2
                 }
             ]
         ],
         "1754f6dbbfa616d96eb70fcc": [
-            [{
+            [
+                {
                     "_tpl": "5d1b2fa286f77425227d1674",
                     "count": 1
                 }
             ]
         ],
         "8a099caacbfbf8b1dcdaf63b": [
-            [{
+            [
+                {
                     "_tpl": "5b4335ba86f7744d2837a264",
                     "count": 7
                 }
             ]
         ],
         "2c2953acc3228daceef9f38d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 94000
                 }
             ]
         ],
         "ea9ac15897f831abaf7b1211": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3600
                 }
             ]
         ],
         "3252770cddbeb28272aa70c7": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 38000
                 }
             ]
         ],
         "068d2acdaeeebbdbced8cb9f": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 34000
                 }
             ]
         ],
         "7e9679dec77bb78d6efba17b": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3400
                 }
             ]
         ],
         "60a6fef0eea83306ecc3c048": [
-            [{
+            [
+                {
                     "_tpl": "5cadf6e5ae921500113bb973",
                     "count": 5
                 }
             ]
         ],
         "c10f9da0a3cdc89fd50df6ff": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 340
                 }
             ]
         ],
         "09c7ad74c8d8f4f3f5e7ffdd": [
-            [{
+            [
+                {
                     "_tpl": "560d5e524bdc2d25448b4571",
                     "count": 10
                 }
             ]
         ],
         "7c5baaacf488e2abad22f2d1": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 210
                 }
             ]
         ],
         "8cc0e55afbbbeb4155258a4d": [
-            [{
+            [
+                {
                     "_tpl": "5cadf6ddae9215051e1c23b2",
                     "count": 3
                 }
             ]
         ],
         "22cfd4ea7fcbff22238357c1": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 840
                 }
             ]
         ],
         "b88ad5eb1bdebda76f6aff1f": [
-            [{
+            [
+                {
                     "_tpl": "590c392f86f77444754deb29",
                     "count": 4
                 }
             ]
         ],
         "19a87af0baebfa18bbecbfeb": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 106000
                 }
             ]
         ],
         "c7f609cf854ed2d2a2d2a49a": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 6000
                 }
             ]
         ],
         "0dead76e1dc5cdb01db6abc1": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 15500
                 }
             ]
         ],
         "acd6e280bed6cd2af5c9cb1e": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1900
                 }
             ]
         ],
         "a11cffe3dad659dced532fed": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 27000
                 }
             ]
         ],
         "5db2bc2d1aa10e5dcc26d799": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5700
                 }
             ]
         ],
         "f0eaf4f5a4a65d9ef3f9478f": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24600
                 }
             ]
         ],
         "525e9188f021e8b2acff23be": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5700
                 }
             ]
         ],
         "b6ff87ecb676eef0a7d0c5ea": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3600
                 }
             ]
         ],
         "dedfbfbeace1d679e4da8bdd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5200
                 }
             ]
         ],
         "f4061aa0190c0c542fa5eadf": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 4600
                 }
             ]
         ],
         "d3f4fad38fbd5a9c885ffb7b": [
-            [{
+            [
+                {
                     "_tpl": "59e3577886f774176a362503",
                     "count": 8
                 }
             ]
         ],
         "dab7c8f57398c5eba1a7a9cd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 183000
                 }
             ]
         ],
         "ccfd666d9cbcaa0da2bbffcf": [
-            [{
+            [
+                {
                     "_tpl": "590c651286f7741e566b6461",
                     "count": 6
                 }
             ]
         ],
         "fa7a7b8c6abdad1f8a9d1eaa": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 123000
                 }
             ]
         ],
         "80a3e7b7fc957d25ceefa219": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2250
                 }
             ]
         ],
         "edefb4eeb3d4e7ef61fd351c": [
-            [{
+            [
+                {
                     "_tpl": "58864a4f2459770fcc257101",
                     "count": 2
                 }
             ]
         ],
         "08032bf34904cddba9dc7c94": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 225
                 }
             ]
         ],
         "3a153a2ade193cc210e32712": [
-            [{
+            [
+                {
                     "_tpl": "5e023e53d4353e3302577c4c",
                     "count": 3
                 }
             ]
         ],
         "dca9ffdfd90ff5fd4d6cc9d0": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 160
                 }
             ]
         ],
         "ef8d6189a0ac59db6f9aafcf": [
-            [{
+            [
+                {
                     "_tpl": "5e023e6e34d52a55c3304f71",
                     "count": 5
                 }
             ]
         ],
         "39e1acb06dbcfbe6d4640dba": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 98
                 }
             ]
         ],
         "fc44da03ac88feee8bde7fbd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 4800
                 }
             ]
         ],
         "a39ac3e862cce0de1eff0cca": [
-            [{
+            [
+                {
                     "_tpl": "5a6086ea4f39f99cd479502f",
                     "count": 3
                 }
             ]
         ],
         "1e0942ffd38bae1b29f8ee34": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1500
                 }
             ]
         ],
         "9ce25be3e360b9a02c34bfeb": [
-            [{
+            [
+                {
                     "_tpl": "573478bc24597738002c6175",
                     "count": 5
                 }
             ]
         ],
         "8ecb75b20c8fefdc113e9bf2": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 76000
                 }
             ]
         ],
         "a4df4950e5655243d23e00ff": [
-            [{
+            [
+                {
                     "_tpl": "54527a984bdc2d4e668b4567",
                     "count": 4
                 }
             ]
         ],
         "a37ee9bde17850b919eaf0ba": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 270
                 }
             ]
         ],
         "acd2a2d83adfb4bfd7d1b04d": [
-            [{
+            [
+                {
                     "_tpl": "59e690b686f7746c9f75e848",
                     "count": 3
                 }
             ]
         ],
         "744cefdce2142d0ddbcb7fff": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1400
                 }
             ]
         ],
         "779deae5707a54522bdaa6ca": [
-            [{
+            [
+                {
                     "_tpl": "59e0d99486f7744a32234762",
                     "count": 4
                 }
             ]
         ],
         "e0f97cb7b2afb81efbee3d05": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1200
                 }
             ]
         ],
         "afd34f681f6efeaa0321bb84": [
-            [{
+            [
+                {
                     "_tpl": "5d1b317c86f7742523398392",
                     "count": 1
-                }, {
+                },
+                {
                     "_tpl": "5d63d33b86f7746ea9275524",
                     "count": 5
                 }
             ]
         ],
         "ddacd746b270532e7c761c07": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 98000
                 }
             ]
         ],
         "ab2dc3ce4e83c14fa8d7ec23": [
-            [{
+            [
+                {
                     "_tpl": "61bf7b6302b3924be92fa8c3",
                     "count": 6
-                }, {
+                },
+                {
                     "_tpl": "619cbfeb6b8a1b37a54eebfa",
                     "count": 2
                 }
             ]
         ],
         "16426ac6c6fede5eeb28e114": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 110000
                 }
             ]
         ],
         "721924cb66db16bffacd4d06": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 22500
                 }
             ]
         ],
         "61bac5b8c3a2c58b10e35ad6": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3100
                 }
             ]
         ],
         "66ca525ad612fc82421fbaa3": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3700
                 }
             ]
         ],
         "d7aa8ebca8cacbc741cafd9a": [
-            [{
+            [
+                {
                     "_tpl": "619cbfccbedcde2f5b3f7bdd",
                     "count": 2
                 }
             ]
         ],
         "ddcdced49ce92c83f133a8b8": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 85000
                 }
             ]
         ],
         "1e53fcc5df55cc4baeb7a9ac": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1900
                 }
             ]
         ],
         "de85b4dc3eaa6fbe1aaade6c": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 78000
                 }
             ]
         ],
         "aac07961f94d3ec2d9600f5d": [
-            [{
+            [
+                {
                     "_tpl": "56dff061d2720bb5668b4567",
                     "count": 4
                 }
             ]
         ],
         "cbe2c68fda18333b59afadd0": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 750
                 }
             ]
         ],
         "e2da3ebbadea1fe55aa25c99": [
-            [{
+            [
+                {
                     "_tpl": "57a0e5022459774d1673f889",
                     "count": 2
                 }
             ]
         ],
         "02ceeeaeb7ffcab7df0e7fde": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 580
                 }
             ]
         ],
         "dccbe2319a8d86bdafa1a8cc": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "96ce24efde7f7fdb74b7cd72": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 660
                 }
             ]
         ],
         "7d33ea8e2eaaad24ada9a92c": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "997dd0e96ce2ea6ffbb2bfae": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 120
                 }
             ]
         ],
         "f714e6fac3aa8ac5ab5e8b0b": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "2acaff8c0e4dbaf8e84f5c4d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 85
                 }
             ]
         ],
         "a9d7eabebf51477f7d615d66": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "1d966fc3c05c0cfbfb6db0bb": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 950
                 }
             ]
         ],
         "bda2ff902bc93909425bf53f": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "c7e1f40ffae087ecc96ceaaf": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 450
                 }
             ]
         ],
         "d2ee8d41b52c9cdbc83cfd74": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "0ffccaa6b7cead2daeea355b": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 120
                 }
             ]
         ],
         "1ab4be0cf384fb2a35a00fdd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3100
                 }
             ]
         ],
         "d8542abf28bfc3e8358503bb": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 4500
                 }
             ]
         ],
         "0e9daeadadafdced379c78fc": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "dd2dda5ed65fa75cd9b5e0d4": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 110000
                 }
             ]
         ],
         "2a2fcf4b17f8905fcbd18c02": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "12e2cbbcd0fc1a2f9eef88d6": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 63000
                 }
             ]
         ],
         "1eebaa8b0df8b85864bd9dd1": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "accce84b4fbbec3a50c3f0b9": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 90000
                 }
             ]
         ],
         "e06d1d5bd0bafc5daa43beab": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "19d9df7a326dbb28a8d4c0ee": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 66000
                 }
             ]
         ],
         "3bb7bf8716b6edd9cfeb7c01": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "1a5e752edad847aa77c3e4ad": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 75000
                 }
             ]
         ],
         "debdcc752ca60d8087a6df4d": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "ac0c9fbb17a1afe29a70903d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 57000
                 }
             ]
         ],
         "bdfefe4ecb28f112e49eabdd": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "ad8a5ee6aea053d6ba1e9949": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 64000
                 }
             ]
         ],
         "a2f6071ed03fa6bba2d0d151": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "e7a17a4ff2bcd5f406f03da7": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 66000
                 }
             ]
         ],
         "aaf6d69efa9cacf60adc7f8e": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "13950de5b6675e5c3a833dde": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 190000
                 }
             ]
         ],
         "d98ab051c5da92d456bcdc1f": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2100
                 }
             ]
         ],
         "ae52b4abba99e7fd158401bd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1400
                 }
             ]
         ],
         "eacecba5bed5b258dddf2eaf": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3000
                 }
             ]
         ],
         "edf9df344ec677aacbb52f9f": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 7500
                 }
             ]
         ],
         "e6a60edaacc44e043b69aad4": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3600
                 }
             ]
         ],
         "667b4b8efce0ac366aed9eb7": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1700
                 }
             ]
         ]
     },
-    "items": [{
+    "items": [
+        {
             "_id": "09c7ad74c8d8f4f3f5e7ffdd",
             "_tpl": "5cadf6e5ae921500113bb973",
             "parentId": "hideout",
@@ -1794,7 +2053,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "60a6fef0eea83306ecc3c048",
             "_tpl": "5cadf6ddae9215051e1c23b2",
             "parentId": "hideout",
@@ -1805,7 +2065,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "0dead76e1dc5cdb01db6abc1",
             "_tpl": "5caf1109ae9215753c44119f",
             "parentId": "hideout",
@@ -1816,7 +2077,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "8cc0e55afbbbeb4155258a4d",
             "_tpl": "5cadf6eeae921500134b2799",
             "parentId": "hideout",
@@ -1827,7 +2089,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7c5baaacf488e2abad22f2d1",
             "_tpl": "5cadf6e5ae921500113bb973",
             "parentId": "hideout",
@@ -1838,7 +2101,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c10f9da0a3cdc89fd50df6ff",
             "_tpl": "5cadf6ddae9215051e1c23b2",
             "parentId": "hideout",
@@ -1849,7 +2113,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "22cfd4ea7fcbff22238357c1",
             "_tpl": "5cadf6eeae921500134b2799",
             "parentId": "hideout",
@@ -1860,7 +2125,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "3cae97dbd4c5d296fd1aecde",
             "_tpl": "56dff421d2720b5f5a8b4567",
             "parentId": "hideout",
@@ -1871,7 +2137,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "4ec114a9eb0dfafdb5facafe",
             "_tpl": "573733c72459776b0b7b51b0",
             "parentId": "hideout",
@@ -1882,7 +2149,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d05fa7bd2725e7fda3fed110",
             "_tpl": "56dff421d2720b5f5a8b4567",
             "parentId": "4ec114a9eb0dfafdb5facafe",
@@ -1891,7 +2159,8 @@
             "upd": {
                 "StackObjectsCount": 30
             }
-        }, {
+        },
+        {
             "_id": "caf1de383b3581f1bffc6030",
             "_tpl": "56dff216d2720bbd668b4568",
             "parentId": "hideout",
@@ -1902,7 +2171,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "53d1c415aeddbb8fbeceb0ef",
             "_tpl": "5737339e2459776af261abeb",
             "parentId": "hideout",
@@ -1913,7 +2183,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a373a1aaf894bcabb62bc805",
             "_tpl": "56dff216d2720bbd668b4568",
             "parentId": "53d1c415aeddbb8fbeceb0ef",
@@ -1922,7 +2193,8 @@
             "upd": {
                 "StackObjectsCount": 30
             }
-        }, {
+        },
+        {
             "_id": "dffb5680abbcfbc31faec6b6",
             "_tpl": "56dff338d2720bbd668b4569",
             "parentId": "hideout",
@@ -1933,7 +2205,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "851dafd2930c1452d223755b",
             "_tpl": "57372e4a24597768553071c2",
             "parentId": "hideout",
@@ -1944,7 +2217,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "cba9db87d2e9eecf455896bf",
             "_tpl": "56dff338d2720bbd668b4569",
             "parentId": "851dafd2930c1452d223755b",
@@ -1953,7 +2227,8 @@
             "upd": {
                 "StackObjectsCount": 30
             }
-        }, {
+        },
+        {
             "_id": "507bfdceec87dbcbe7a28081",
             "_tpl": "57372e1924597768553071c1",
             "parentId": "hideout",
@@ -1964,7 +2239,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7dd74a4c68ba7698a2b58ba5",
             "_tpl": "56dff338d2720bbd668b4569",
             "parentId": "507bfdceec87dbcbe7a28081",
@@ -1973,7 +2249,8 @@
             "upd": {
                 "StackObjectsCount": 120
             }
-        }, {
+        },
+        {
             "_id": "ccde5ef196dcf7d4f7c0ad84",
             "_tpl": "57372deb245977685d4159b3",
             "parentId": "hideout",
@@ -1984,7 +2261,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f9dd1f9622fd3beac2a5c98e",
             "_tpl": "56dff338d2720bbd668b4569",
             "parentId": "ccde5ef196dcf7d4f7c0ad84",
@@ -1993,7 +2271,8 @@
             "upd": {
                 "StackObjectsCount": 120
             }
-        }, {
+        },
+        {
             "_id": "dd396513b7f0d941a4e7bdc4",
             "_tpl": "56dff4ecd2720b5f5a8b4568",
             "parentId": "hideout",
@@ -2004,7 +2283,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "cabdb4c1495b6815b4ba9f51",
             "_tpl": "5737300424597769942d5a01",
             "parentId": "hideout",
@@ -2015,7 +2295,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "9a5ddde0ed95037cff6254fa",
             "_tpl": "56dff4ecd2720b5f5a8b4568",
             "parentId": "cabdb4c1495b6815b4ba9f51",
@@ -2024,7 +2305,8 @@
             "upd": {
                 "StackObjectsCount": 30
             }
-        }, {
+        },
+        {
             "_id": "fdfcedae16be8feddc0ea7ee",
             "_tpl": "57372fc52459776998772ca1",
             "parentId": "hideout",
@@ -2035,7 +2317,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "cfadd751f5ff6edae16a36d8",
             "_tpl": "56dff4ecd2720b5f5a8b4568",
             "parentId": "fdfcedae16be8feddc0ea7ee",
@@ -2044,7 +2327,8 @@
             "upd": {
                 "StackObjectsCount": 120
             }
-        }, {
+        },
+        {
             "_id": "ebcdcc2b7eb9c20ab06acaf5",
             "_tpl": "57372f7d245977699b53e301",
             "parentId": "hideout",
@@ -2055,7 +2339,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f8d11adad37752aae24bc63f",
             "_tpl": "56dff4ecd2720b5f5a8b4568",
             "parentId": "ebcdcc2b7eb9c20ab06acaf5",
@@ -2064,7 +2349,8 @@
             "upd": {
                 "StackObjectsCount": 120
             }
-        }, {
+        },
+        {
             "_id": "d8be427c92cebf3fbadfffba",
             "_tpl": "56dff0bed2720bb0668b4567",
             "parentId": "hideout",
@@ -2075,7 +2361,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7ddc89ffbe95aaac2e3e4ac3",
             "_tpl": "5737330a2459776af32363a1",
             "parentId": "hideout",
@@ -2086,7 +2373,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "dbb06caa9ca450adbbf1d2c1",
             "_tpl": "56dff0bed2720bb0668b4567",
             "parentId": "7ddc89ffbe95aaac2e3e4ac3",
@@ -2095,7 +2383,8 @@
             "upd": {
                 "StackObjectsCount": 30
             }
-        }, {
+        },
+        {
             "_id": "addc13cb33a8fb54eb3237da",
             "_tpl": "56dff4a2d2720bbd668b456a",
             "parentId": "hideout",
@@ -2106,7 +2395,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "3eecf5deccce8335fccaffd1",
             "_tpl": "57372f5c24597769917c0131",
             "parentId": "hideout",
@@ -2117,7 +2407,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "edaf0fb48dce55dd1d84bdef",
             "_tpl": "56dff4a2d2720bbd668b456a",
             "parentId": "3eecf5deccce8335fccaffd1",
@@ -2126,7 +2417,8 @@
             "upd": {
                 "StackObjectsCount": 30
             }
-        }, {
+        },
+        {
             "_id": "ac71f96dbe4b231cadcee132",
             "_tpl": "57372f2824597769a270a191",
             "parentId": "hideout",
@@ -2137,7 +2429,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ff0ffece639fdad59863cd00",
             "_tpl": "56dff4a2d2720bbd668b456a",
             "parentId": "ac71f96dbe4b231cadcee132",
@@ -2146,7 +2439,8 @@
             "upd": {
                 "StackObjectsCount": 120
             }
-        }, {
+        },
+        {
             "_id": "bbadda2559edb2baf09d5dc1",
             "_tpl": "57372ee1245977685d4159b5",
             "parentId": "hideout",
@@ -2157,7 +2451,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b4f966b4d67e2bbb10eae2d8",
             "_tpl": "56dff4a2d2720bbd668b456a",
             "parentId": "bbadda2559edb2baf09d5dc1",
@@ -2166,7 +2461,8 @@
             "upd": {
                 "StackObjectsCount": 120
             }
-        }, {
+        },
+        {
             "_id": "b85ebc4dee217a25b8a3cc32",
             "_tpl": "56dff3afd2720bba668b4567",
             "parentId": "hideout",
@@ -2177,7 +2473,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ad5ec232ca5bbeae937bb5ad",
             "_tpl": "57372ebf2459776862260582",
             "parentId": "hideout",
@@ -2188,7 +2485,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "1b4dc0b0ee3cd37375ce9aba",
             "_tpl": "56dff3afd2720bba668b4567",
             "parentId": "ad5ec232ca5bbeae937bb5ad",
@@ -2197,7 +2495,8 @@
             "upd": {
                 "StackObjectsCount": 30
             }
-        }, {
+        },
+        {
             "_id": "73b0fc2dd4c9c1f3543cd9c1",
             "_tpl": "57372e94245977685648d3e1",
             "parentId": "hideout",
@@ -2208,7 +2507,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "416b89bbfc5135eaea387492",
             "_tpl": "56dff3afd2720bba668b4567",
             "parentId": "73b0fc2dd4c9c1f3543cd9c1",
@@ -2217,7 +2517,8 @@
             "upd": {
                 "StackObjectsCount": 120
             }
-        }, {
+        },
+        {
             "_id": "f55e3c9de4a7abd5afe4c2df",
             "_tpl": "57372e73245977685d4159b4",
             "parentId": "hideout",
@@ -2228,7 +2529,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b8eaab2aade4e9accc75b2a3",
             "_tpl": "56dff3afd2720bba668b4567",
             "parentId": "f55e3c9de4a7abd5afe4c2df",
@@ -2237,7 +2539,8 @@
             "upd": {
                 "StackObjectsCount": 120
             }
-        }, {
+        },
+        {
             "_id": "ef57451fccdd2dab9877e7c9",
             "_tpl": "5bed61680db834001d2c45ab",
             "parentId": "hideout",
@@ -2248,7 +2551,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "cedad22a07a58bcb25e5013b",
             "_tpl": "56dff2ced2720bb4668b4567",
             "parentId": "hideout",
@@ -2259,7 +2563,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "acd38f7af0feacccbce1ce3c",
             "_tpl": "57372db0245977685d4159b2",
             "parentId": "hideout",
@@ -2270,7 +2575,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "62f790f5dd75a5dd7b9ea9af",
             "_tpl": "56dff2ced2720bb4668b4567",
             "parentId": "acd38f7af0feacccbce1ce3c",
@@ -2279,7 +2585,8 @@
             "upd": {
                 "StackObjectsCount": 30
             }
-        }, {
+        },
+        {
             "_id": "3bd165f6627ba5d97bdabaa5",
             "_tpl": "57372d4c245977685a3da2a1",
             "parentId": "hideout",
@@ -2290,7 +2597,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "94de91c587dbe8ddadf0edc7",
             "_tpl": "56dff2ced2720bb4668b4567",
             "parentId": "3bd165f6627ba5d97bdabaa5",
@@ -2299,7 +2607,8 @@
             "upd": {
                 "StackObjectsCount": 120
             }
-        }, {
+        },
+        {
             "_id": "7e3872a04bef1b68da53ddaf",
             "_tpl": "57372d1b2459776862260581",
             "parentId": "hideout",
@@ -2310,7 +2619,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "8edf6a6a2be7bded04410ddc",
             "_tpl": "56dff2ced2720bb4668b4567",
             "parentId": "7e3872a04bef1b68da53ddaf",
@@ -2319,7 +2629,8 @@
             "upd": {
                 "StackObjectsCount": 120
             }
-        }, {
+        },
+        {
             "_id": "51300aa813b4dae28bdca525",
             "_tpl": "56dfef82d2720bbd668b4567",
             "parentId": "hideout",
@@ -2330,7 +2641,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "267823eb62a2f7acf8cfceb5",
             "_tpl": "57372ac324597767001bc261",
             "parentId": "hideout",
@@ -2341,7 +2653,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e9e2b0761b5c84bd06b599ab",
             "_tpl": "56dfef82d2720bbd668b4567",
             "parentId": "267823eb62a2f7acf8cfceb5",
@@ -2350,7 +2663,8 @@
             "upd": {
                 "StackObjectsCount": 30
             }
-        }, {
+        },
+        {
             "_id": "caf3d9bf3d2bf4efd49ece0b",
             "_tpl": "57372a7f24597766fe0de0c1",
             "parentId": "hideout",
@@ -2361,7 +2675,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d9d7cea43bf483805bb852cc",
             "_tpl": "56dfef82d2720bbd668b4567",
             "parentId": "caf3d9bf3d2bf4efd49ece0b",
@@ -2370,7 +2685,8 @@
             "upd": {
                 "StackObjectsCount": 120
             }
-        }, {
+        },
+        {
             "_id": "36b47feeadeeface1d34eecf",
             "_tpl": "5737292724597765e5728562",
             "parentId": "hideout",
@@ -2381,7 +2697,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "19fb7ecaf0cabd1edbe52fff",
             "_tpl": "56dfef82d2720bbd668b4567",
             "parentId": "36b47feeadeeface1d34eecf",
@@ -2390,7 +2707,8 @@
             "upd": {
                 "StackObjectsCount": 120
             }
-        }, {
+        },
+        {
             "_id": "d1fd1ed131adc6edf787facd",
             "_tpl": "56dff061d2720bb5668b4567",
             "parentId": "hideout",
@@ -2401,7 +2719,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ad6bb74e267087fc01c9fd1e",
             "_tpl": "57372c89245977685d4159b1",
             "parentId": "hideout",
@@ -2412,7 +2731,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fefedc5221d73fe8bae09cb6",
             "_tpl": "56dff061d2720bb5668b4567",
             "parentId": "ad6bb74e267087fc01c9fd1e",
@@ -2421,7 +2741,8 @@
             "upd": {
                 "StackObjectsCount": 30
             }
-        }, {
+        },
+        {
             "_id": "57932e2b7dce3ebb31ba4a08",
             "_tpl": "57372c56245977685e584582",
             "parentId": "hideout",
@@ -2432,7 +2753,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a80867bd9d721d8c9f7f4eae",
             "_tpl": "56dff061d2720bb5668b4567",
             "parentId": "57932e2b7dce3ebb31ba4a08",
@@ -2441,7 +2763,8 @@
             "upd": {
                 "StackObjectsCount": 120
             }
-        }, {
+        },
+        {
             "_id": "6ffbead04e4e9bf14db45e9c",
             "_tpl": "57372c21245977670937c6c2",
             "parentId": "hideout",
@@ -2452,7 +2775,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bacdcb132add30efa0aa0efa",
             "_tpl": "56dff061d2720bb5668b4567",
             "parentId": "6ffbead04e4e9bf14db45e9c",
@@ -2461,7 +2785,8 @@
             "upd": {
                 "StackObjectsCount": 120
             }
-        }, {
+        },
+        {
             "_id": "aac07961f94d3ec2d9600f5d",
             "_tpl": "61962b617c6c7b169525f168",
             "parentId": "hideout",
@@ -2472,7 +2797,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "45dd1a0dd42cb8b7613ffed6",
             "_tpl": "56dff026d2720bb8668b4567",
             "parentId": "hideout",
@@ -2483,7 +2809,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c70681b0caba7a7c4a9551dd",
             "_tpl": "57372bd3245977670b7cd243",
             "parentId": "hideout",
@@ -2494,7 +2821,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "cb39bdf126dadb0c67cc6a20",
             "_tpl": "56dff026d2720bb8668b4567",
             "parentId": "c70681b0caba7a7c4a9551dd",
@@ -2503,7 +2831,8 @@
             "upd": {
                 "StackObjectsCount": 30
             }
-        }, {
+        },
+        {
             "_id": "edbdebc5a978f4f73afeedea",
             "_tpl": "57372bad245977670b7cd242",
             "parentId": "hideout",
@@ -2514,7 +2843,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "1d2e3b679fcb269c125ccb71",
             "_tpl": "56dff026d2720bb8668b4567",
             "parentId": "edbdebc5a978f4f73afeedea",
@@ -2523,7 +2853,8 @@
             "upd": {
                 "StackObjectsCount": 120
             }
-        }, {
+        },
+        {
             "_id": "75fe098ddbb4f58bbe3c17cc",
             "_tpl": "57372b832459776701014e41",
             "parentId": "hideout",
@@ -2534,7 +2865,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "677e8966dd164a4cc34b65c8",
             "_tpl": "56dff026d2720bb8668b4567",
             "parentId": "75fe098ddbb4f58bbe3c17cc",
@@ -2543,7 +2875,8 @@
             "upd": {
                 "StackObjectsCount": 120
             }
-        }, {
+        },
+        {
             "_id": "eafae65d6aad97aceca88ac7",
             "_tpl": "5c0d5e4486f77478390952fe",
             "parentId": "hideout",
@@ -2554,7 +2887,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "1754f6dbbfa616d96eb70fcc",
             "_tpl": "5c1262a286f7743f8a69aab2",
             "parentId": "hideout",
@@ -2565,7 +2899,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7c4b42ec00bcf001296684dc",
             "_tpl": "5c0d5e4486f77478390952fe",
             "parentId": "1754f6dbbfa616d96eb70fcc",
@@ -2574,7 +2909,8 @@
             "upd": {
                 "StackObjectsCount": 30
             }
-        }, {
+        },
+        {
             "_id": "1825ca0ed5fbdab1b5cc7bba",
             "_tpl": "55d482194bdc2d1d4e8b456b",
             "parentId": "hideout",
@@ -2585,7 +2921,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7be0adcab6acc382e17becd2",
             "_tpl": "56dff421d2720b5f5a8b4567",
             "parentId": "hideout",
@@ -2596,7 +2933,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fe19a2dcbac6ce46f4ebbb02",
             "_tpl": "56dff216d2720bbd668b4568",
             "parentId": "hideout",
@@ -2607,7 +2945,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "5cab97f1b7972fba8773ac4d",
             "_tpl": "56dff338d2720bbd668b4569",
             "parentId": "hideout",
@@ -2618,7 +2957,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "14ea806be1d4475cf9fbce2d",
             "_tpl": "56dff4ecd2720b5f5a8b4568",
             "parentId": "hideout",
@@ -2629,7 +2969,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a8f5f4b32432094bf88584fa",
             "_tpl": "56dff0bed2720bb0668b4567",
             "parentId": "hideout",
@@ -2640,7 +2981,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bbf7baeca1b654c5c9f0bcfb",
             "_tpl": "56dff4a2d2720bbd668b456a",
             "parentId": "hideout",
@@ -2651,7 +2993,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "5ae1d9ecacebd3325d720dbe",
             "_tpl": "56dff3afd2720bba668b4567",
             "parentId": "hideout",
@@ -2662,7 +3005,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a5fac979afb4bdfeddda0eb9",
             "_tpl": "56dff2ced2720bb4668b4567",
             "parentId": "hideout",
@@ -2673,7 +3017,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c6c5b6bbf2c02eafe2a409af",
             "_tpl": "56dfef82d2720bbd668b4567",
             "parentId": "hideout",
@@ -2684,7 +3029,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "cdd1ac8a6ff37aa0d0a075fd",
             "_tpl": "56dff061d2720bb5668b4567",
             "parentId": "hideout",
@@ -2695,7 +3041,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "cbe2c68fda18333b59afadd0",
             "_tpl": "61962b617c6c7b169525f168",
             "parentId": "hideout",
@@ -2706,7 +3053,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "5b0af0012b6eafbc8ad2719e",
             "_tpl": "56dff026d2720bb8668b4567",
             "parentId": "hideout",
@@ -2717,7 +3065,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "28bfa3ec60199dc7bde5edfd",
             "_tpl": "5c0d5e4486f77478390952fe",
             "parentId": "hideout",
@@ -2728,7 +3077,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "0aa1e4932e90c16b2c7ddbee",
             "_tpl": "59e6927d86f77411da468256",
             "parentId": "hideout",
@@ -2739,7 +3089,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c392f5cafebb09f0d2cbacce",
             "_tpl": "59e6918f86f7746c9f75e849",
             "parentId": "hideout",
@@ -2750,7 +3101,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "af5833ffb06b7b103bd80bdb",
             "_tpl": "59e6920f86f77411d82aa167",
             "parentId": "hideout",
@@ -2761,7 +3113,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bbc9ffadaceab18bcfbd9ec2",
             "_tpl": "5c0d5ae286f7741e46554302",
             "parentId": "hideout",
@@ -2772,7 +3125,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "afeb2a8f9c2808713f59aacf",
             "_tpl": "5c11279ad174af029d64592b",
             "parentId": "hideout",
@@ -2783,7 +3137,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f43d5abbfdf50eb24daee0c3",
             "_tpl": "5c0d5ae286f7741e46554302",
             "parentId": "afeb2a8f9c2808713f59aacf",
@@ -2792,7 +3147,8 @@
             "upd": {
                 "StackObjectsCount": 20
             }
-        }, {
+        },
+        {
             "_id": "b6ff87ecb676eef0a7d0c5ea",
             "_tpl": "5d1340cad7ad1a0b0b249869",
             "parentId": "hideout",
@@ -2803,7 +3159,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "acfeabef6feadb2bcdff8b6f",
             "_tpl": "54527a984bdc2d4e668b4567",
             "parentId": "hideout",
@@ -2814,7 +3171,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "eee701afcd64ac958917f38b",
             "_tpl": "5447ac644bdc2d6c208b4567",
             "parentId": "hideout",
@@ -2825,7 +3183,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "14c30ec07e6815ad6b21eb5c",
             "_tpl": "54527a984bdc2d4e668b4567",
             "parentId": "eee701afcd64ac958917f38b",
@@ -2834,7 +3193,8 @@
             "upd": {
                 "StackObjectsCount": 50
             }
-        }, {
+        },
+        {
             "_id": "a4df4950e5655243d23e00ff",
             "_tpl": "60194943740c5d77f6705eea",
             "parentId": "hideout",
@@ -2845,7 +3205,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d4dbec374aeddbcaab371ffd",
             "_tpl": "59e68f6f86f7746c9f75e846",
             "parentId": "hideout",
@@ -2856,7 +3217,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b076af4f8db6d01773b6ec8d",
             "_tpl": "5c0548ae0db834001966a3c2",
             "parentId": "hideout",
@@ -2867,7 +3229,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7e9679dec77bb78d6efba17b",
             "_tpl": "5c6d42cb2e2216000e69d7d1",
             "parentId": "hideout",
@@ -2878,7 +3241,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "4eaaaffcabc67c45bed2e97e",
             "_tpl": "59e6906286f7746c9f75e847",
             "parentId": "hideout",
@@ -2889,7 +3253,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bec8baa49d915d21f3cf3946",
             "_tpl": "54527ac44bdc2d36668b4567",
             "parentId": "hideout",
@@ -2900,7 +3265,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bfbfac0770bde5ab59d90fbc",
             "_tpl": "59e690b686f7746c9f75e848",
             "parentId": "hideout",
@@ -2911,7 +3277,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "acd2a2d83adfb4bfd7d1b04d",
             "_tpl": "601949593ae8f707c4608daa",
             "parentId": "hideout",
@@ -2922,7 +3289,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ae3d89a1f2366cddefdbf3f6",
             "_tpl": "59c1383d86f774290a37e0ca",
             "parentId": "hideout",
@@ -2933,7 +3301,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "cd106018ca64ceacb8ff2f9c",
             "_tpl": "59e6927d86f77411da468256",
             "parentId": "hideout",
@@ -2944,7 +3313,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e27cc9d11b5fe4dda9c8a16e",
             "_tpl": "59e6918f86f7746c9f75e849",
             "parentId": "hideout",
@@ -2955,7 +3325,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "73cbff75d4bbdd6bbf76362d",
             "_tpl": "59e6920f86f77411d82aa167",
             "parentId": "hideout",
@@ -2966,7 +3337,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "feaec87b5a2fdd40ffa3fe4f",
             "_tpl": "5c0d5ae286f7741e46554302",
             "parentId": "hideout",
@@ -2977,7 +3349,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "befaa9e78a9be7dc3dbaddd7",
             "_tpl": "54527a984bdc2d4e668b4567",
             "parentId": "hideout",
@@ -2988,7 +3361,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a37ee9bde17850b919eaf0ba",
             "_tpl": "60194943740c5d77f6705eea",
             "parentId": "hideout",
@@ -2999,7 +3373,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "afd727ab3a4cc49c59f4ba4e",
             "_tpl": "59e68f6f86f7746c9f75e846",
             "parentId": "hideout",
@@ -3010,7 +3385,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "9a707c8ebfb1d1d14d05c867",
             "_tpl": "59e6906286f7746c9f75e847",
             "parentId": "hideout",
@@ -3021,7 +3397,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "1c23fd6f997fea6aab4092df",
             "_tpl": "54527ac44bdc2d36668b4567",
             "parentId": "hideout",
@@ -3032,7 +3409,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "5cc11aa5f5afd1befeb8aa3b",
             "_tpl": "59e690b686f7746c9f75e848",
             "parentId": "hideout",
@@ -3043,7 +3421,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "744cefdce2142d0ddbcb7fff",
             "_tpl": "601949593ae8f707c4608daa",
             "parentId": "hideout",
@@ -3054,7 +3433,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "6aa3acbe6be11ce5ed522ce1",
             "_tpl": "59e4cf5286f7741778269d8a",
             "parentId": "hideout",
@@ -3065,7 +3445,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "6921eaa048c0405619f2948d",
             "_tpl": "59e4d3d286f774176a36250a",
             "parentId": "hideout",
@@ -3076,7 +3457,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fe2aa27f123fc25e462af7b6",
             "_tpl": "59e4d24686f7741776641ac7",
             "parentId": "hideout",
@@ -3087,7 +3469,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a11cffe3dad659dced532fed",
             "_tpl": "5cbdc23eae9215001136a407",
             "parentId": "hideout",
@@ -3098,7 +3481,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "97d8e98fdedbb04209ba6ea3",
             "_tpl": "5656d7c34bdc2d9d198b4587",
             "parentId": "hideout",
@@ -3109,7 +3493,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b7b0dde96e10bde42d78a1da",
             "_tpl": "5649ed104bdc2d3d1c8b458b",
             "parentId": "hideout",
@@ -3120,7 +3505,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "049c9c978ad53edbd5f1dcce",
             "_tpl": "5656d7c34bdc2d9d198b4587",
             "parentId": "b7b0dde96e10bde42d78a1da",
@@ -3129,7 +3515,8 @@
             "upd": {
                 "StackObjectsCount": 20
             }
-        }, {
+        },
+        {
             "_id": "0e6da835c1a9f1edda83df89",
             "_tpl": "59e0d99486f7744a32234762",
             "parentId": "hideout",
@@ -3140,7 +3527,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "779deae5707a54522bdaa6ca",
             "_tpl": "601aa3d2b2bcb34913271e6d",
             "parentId": "hideout",
@@ -3151,7 +3539,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f0eaf4f5a4a65d9ef3f9478f",
             "_tpl": "5cfe8010d7ad1a59283b14c6",
             "parentId": "hideout",
@@ -3162,7 +3551,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "721924cb66db16bffacd4d06",
             "_tpl": "61695095d92c473c7702147a",
             "parentId": "hideout",
@@ -3173,7 +3563,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "cf7f0cf0b168de8bad9dbada",
             "_tpl": "59e4cf5286f7741778269d8a",
             "parentId": "hideout",
@@ -3184,7 +3575,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "690ba255e7d8ed06ec14f87d",
             "_tpl": "59e4d3d286f774176a36250a",
             "parentId": "hideout",
@@ -3195,7 +3587,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e523a8d2d5ab18ddcbbbb827",
             "_tpl": "59e4d24686f7741776641ac7",
             "parentId": "hideout",
@@ -3206,7 +3599,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "03b2fb63acf4bfe6fe0e72f5",
             "_tpl": "5656d7c34bdc2d9d198b4587",
             "parentId": "hideout",
@@ -3217,7 +3611,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "2cdea03f665c4ce65c7d1f1e",
             "_tpl": "59e0d99486f7744a32234762",
             "parentId": "hideout",
@@ -3228,7 +3623,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e0f97cb7b2afb81efbee3d05",
             "_tpl": "601aa3d2b2bcb34913271e6d",
             "parentId": "hideout",
@@ -3239,7 +3635,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "edefb4eeb3d4e7ef61fd351c",
             "_tpl": "5e023e53d4353e3302577c4c",
             "parentId": "hideout",
@@ -3250,7 +3647,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "3a153a2ade193cc210e32712",
             "_tpl": "5e023e6e34d52a55c3304f71",
             "parentId": "hideout",
@@ -3261,7 +3659,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f4061aa0190c0c542fa5eadf",
             "_tpl": "5d25a7b88abbc3054f3e60bc",
             "parentId": "hideout",
@@ -3272,7 +3671,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ef8d6189a0ac59db6f9aafcf",
             "_tpl": "5e023e88277cce2b522ff2b1",
             "parentId": "hideout",
@@ -3283,7 +3683,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7cbf7a98ba8c769aa75c04fa",
             "_tpl": "5addcce35acfc4001a5fc635",
             "parentId": "hideout",
@@ -3294,7 +3695,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "1e53fcc5df55cc4baeb7a9ac",
             "_tpl": "61840bedd92c473c77021635",
             "parentId": "hideout",
@@ -3305,7 +3707,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "aba8dd2f419d3f90e42aabcf",
             "_tpl": "58dd3ad986f77403051cba8f",
             "parentId": "hideout",
@@ -3316,7 +3719,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ea9ac15897f831abaf7b1211",
             "_tpl": "5c503ad32e2216398b5aada2",
             "parentId": "hideout",
@@ -3327,7 +3731,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "dedfbfbeace1d679e4da8bdd",
             "_tpl": "5d25a6a48abbc306c62e6310",
             "parentId": "hideout",
@@ -3338,7 +3743,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7e5f4bd20de1cc072b1bd1ac",
             "_tpl": "5a608bf24f39f98ffc77720e",
             "parentId": "hideout",
@@ -3349,7 +3755,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "dcab6a885f5298acfab2ebfd",
             "_tpl": "5b7d37845acfc400170e2f87",
             "parentId": "hideout",
@@ -3360,7 +3767,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "61bac5b8c3a2c58b10e35ad6",
             "_tpl": "617131a4568c120fdd29482d",
             "parentId": "hideout",
@@ -3371,7 +3779,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "4147f4c1ccaef366bfccec6b",
             "_tpl": "5a6086ea4f39f99cd479502f",
             "parentId": "hideout",
@@ -3382,7 +3791,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "5db2bc2d1aa10e5dcc26d799",
             "_tpl": "5cf12a15d7f00c05464b293f",
             "parentId": "hideout",
@@ -3393,7 +3803,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "24f5d14dd6a1d2f4d5dedaab",
             "_tpl": "5addccf45acfc400185c2989",
             "parentId": "hideout",
@@ -3404,7 +3815,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a39ac3e862cce0de1eff0cca",
             "_tpl": "5efb0c1bd79ff02a1f5e68d9",
             "parentId": "hideout",
@@ -3415,7 +3827,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f5fbec96e2bde57b45bceacd",
             "_tpl": "5b7bef9c5acfc43d102852ec",
             "parentId": "hideout",
@@ -3426,7 +3839,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "08032bf34904cddba9dc7c94",
             "_tpl": "5e023e53d4353e3302577c4c",
             "parentId": "hideout",
@@ -3437,7 +3851,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "dca9ffdfd90ff5fd4d6cc9d0",
             "_tpl": "5e023e6e34d52a55c3304f71",
             "parentId": "hideout",
@@ -3448,7 +3863,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "39e1acb06dbcfbe6d4640dba",
             "_tpl": "5e023e88277cce2b522ff2b1",
             "parentId": "hideout",
@@ -3459,7 +3875,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e3b3d99c6be49f6ca07560a1",
             "_tpl": "58dd3ad986f77403051cba8f",
             "parentId": "hideout",
@@ -3470,7 +3887,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "379aa33c1fbf1afbfeba5f8d",
             "_tpl": "5a608bf24f39f98ffc77720e",
             "parentId": "hideout",
@@ -3481,7 +3899,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d4cd7de283faedfbbe72abd1",
             "_tpl": "5a6086ea4f39f99cd479502f",
             "parentId": "hideout",
@@ -3492,7 +3911,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "1e0942ffd38bae1b29f8ee34",
             "_tpl": "5efb0c1bd79ff02a1f5e68d9",
             "parentId": "hideout",
@@ -3503,7 +3923,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "44dbab6cee357ded1e3b729f",
             "_tpl": "57a0dfb82459774d3078b56c",
             "parentId": "hideout",
@@ -3514,7 +3935,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d3934fcbf9db76cffbf0e971",
             "_tpl": "57a0e5022459774d1673f889",
             "parentId": "hideout",
@@ -3525,7 +3947,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "2ff88da5b0a91bd0feaacac7",
             "_tpl": "57838f9f2459774a150289a0",
             "parentId": "hideout",
@@ -3536,7 +3959,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e2da3ebbadea1fe55aa25c99",
             "_tpl": "61962d879bb3d20b0946d385",
             "parentId": "hideout",
@@ -3547,7 +3971,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "4d2ff8d2c0ccadf9b93c90d0",
             "_tpl": "5c0d668f86f7747ccb7f13b2",
             "parentId": "hideout",
@@ -3558,7 +3983,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "aab4525ecf51da1f42fcd762",
             "_tpl": "5c12619186f7743f871c8a32",
             "parentId": "hideout",
@@ -3569,7 +3995,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7dbaafadefb7ff7bd64d059a",
             "_tpl": "5c0d668f86f7747ccb7f13b2",
             "parentId": "aab4525ecf51da1f42fcd762",
@@ -3578,7 +4005,8 @@
             "upd": {
                 "StackObjectsCount": 8
             }
-        }, {
+        },
+        {
             "_id": "b8284dc99eed2dac03e047a4",
             "_tpl": "5c0d688c86f77413ae3407b2",
             "parentId": "hideout",
@@ -3589,7 +4017,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ee3fde0c8c92e698bd9bd19f",
             "_tpl": "5c1260dc86f7746b106e8748",
             "parentId": "hideout",
@@ -3600,7 +4029,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bcdc5ba23dc583d7012ff2b5",
             "_tpl": "5c0d688c86f77413ae3407b2",
             "parentId": "ee3fde0c8c92e698bd9bd19f",
@@ -3609,7 +4039,8 @@
             "upd": {
                 "StackObjectsCount": 8
             }
-        }, {
+        },
+        {
             "_id": "0b59f7cfdee039c2b1ef60cd",
             "_tpl": "5a9e81fba2750c00164f6b11",
             "parentId": "hideout",
@@ -3620,7 +4051,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a6debb8e4c29f589c5d9c3db",
             "_tpl": "57a0dfb82459774d3078b56c",
             "parentId": "hideout",
@@ -3631,7 +4063,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bac7a48f8a8eba54a6abd1ac",
             "_tpl": "57a0e5022459774d1673f889",
             "parentId": "hideout",
@@ -3642,7 +4075,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "02ceeeaeb7ffcab7df0e7fde",
             "_tpl": "61962d879bb3d20b0946d385",
             "parentId": "hideout",
@@ -3653,7 +4087,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "5ef33313f8f51144ae07f65f",
             "_tpl": "5c0d668f86f7747ccb7f13b2",
             "parentId": "hideout",
@@ -3664,7 +4099,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "be0bad95ab0da15c1ab12214",
             "_tpl": "5c0d688c86f77413ae3407b2",
             "parentId": "hideout",
@@ -3675,7 +4111,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "38beda0d56a9c7636acfcd1f",
             "_tpl": "59e6687d86f77411d949b251",
             "parentId": "hideout",
@@ -3686,47 +4123,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "dce9af3db4ca20a4e02c6afe",
             "_tpl": "59e649f986f77411d949b246",
             "parentId": "38beda0d56a9c7636acfcd1f",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "8fcc8f0a6bf1e3cbae9a43e8",
             "_tpl": "59e898ee86f77427614bd225",
             "parentId": "dce9af3db4ca20a4e02c6afe",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "fac624b8a9ad4dd29e6c3956",
             "_tpl": "59e8a00d86f7742ad93b569c",
             "parentId": "38beda0d56a9c7636acfcd1f",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "adffd82f6fababef4ae6e2dc",
             "_tpl": "59e6318286f77444dd62c4cc",
             "parentId": "38beda0d56a9c7636acfcd1f",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "28feccabc9efaa1de8abec56",
             "_tpl": "59e6449086f7746c9f75e822",
             "parentId": "38beda0d56a9c7636acfcd1f",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "f393dd26a5edbbee9e670e3d",
             "_tpl": "59e8977386f77415a553c453",
             "parentId": "38beda0d56a9c7636acfcd1f",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "ffec80acbfb452e77aeff2ad",
             "_tpl": "59e89d0986f77427600d226e",
             "parentId": "38beda0d56a9c7636acfcd1f",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "afdf8794674a1d3426779ecd",
             "_tpl": "59d625f086f774661516605d",
             "parentId": "38beda0d56a9c7636acfcd1f",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "3daccfae304d967f54cef4bb",
             "_tpl": "59e6152586f77473dc057aa1",
             "parentId": "hideout",
@@ -3737,47 +4183,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "3aecda730aa19f90d72465fb",
             "_tpl": "59e649f986f77411d949b246",
             "parentId": "3daccfae304d967f54cef4bb",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "aeffa95668faeadabbcd360e",
             "_tpl": "59e6284f86f77440d569536f",
             "parentId": "3aecda730aa19f90d72465fb",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "af1dd17fcc8deceb4220fff3",
             "_tpl": "59e61eb386f77440d64f5daf",
             "parentId": "3daccfae304d967f54cef4bb",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "ca510ecabbca250fb13abd4b",
             "_tpl": "59e6318286f77444dd62c4cc",
             "parentId": "3daccfae304d967f54cef4bb",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "0a6babef55e6f508ebc9f7c6",
             "_tpl": "59e6449086f7746c9f75e822",
             "parentId": "3daccfae304d967f54cef4bb",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "cc66f740a228bb0b7a11b76f",
             "_tpl": "59d650cf86f7741b846413a4",
             "parentId": "3daccfae304d967f54cef4bb",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "2a6a2b25a192560ba197047b",
             "_tpl": "59e6227d86f77440d64f5dc2",
             "parentId": "3daccfae304d967f54cef4bb",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "82adbbea37bcfc433f4f4e9c",
             "_tpl": "59d625f086f774661516605d",
             "parentId": "3daccfae304d967f54cef4bb",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "df6171d1caf99a2a2731aeea",
             "_tpl": "5c07c60e0db834002330051f",
             "parentId": "hideout",
@@ -3788,52 +4243,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "afafa951ba6f08ee1c18b5ec",
             "_tpl": "5c0e2ff6d174af02a1659d4a",
             "parentId": "df6171d1caf99a2a2731aeea",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "eeaf1ff2d11bfe6ae5eb1a78",
             "_tpl": "5aaa5e60e5b5b000140293d6",
             "parentId": "df6171d1caf99a2a2731aeea",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "ed5b52da70ec28f441f0f7ea",
             "_tpl": "5c0e2f26d174af02a9625114",
             "parentId": "df6171d1caf99a2a2731aeea",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "9ed41d2e78f4074ca76ea8fe",
             "_tpl": "5c0e2f94d174af029f650d56",
             "parentId": "ed5b52da70ec28f441f0f7ea",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "1d05eaac2c8f7a8da6ae2e84",
             "_tpl": "5c0fafb6d174af02a96260ba",
             "parentId": "9ed41d2e78f4074ca76ea8fe",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "adec9d6e1f3b3d68f8d1efcd",
             "_tpl": "5ae30e795acfc408fb139a0b",
             "parentId": "9ed41d2e78f4074ca76ea8fe",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "ded5e42abaa32658bfea7674",
             "_tpl": "5c0e2f5cd174af02a012cfc9",
             "parentId": "ed5b52da70ec28f441f0f7ea",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "afece77afc0a8d0acbc85ed1",
             "_tpl": "5c0faeddd174af02a962601f",
             "parentId": "df6171d1caf99a2a2731aeea",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "a2f56dbebbff77ed09fe81a7",
             "_tpl": "5c0faf68d174af02a96260b8",
             "parentId": "df6171d1caf99a2a2731aeea",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "e506bfbaddaf6cf680f4d3a7",
             "_tpl": "57dc2fa62459775949412633",
             "parentId": "hideout",
@@ -3844,42 +4309,50 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e5b346201ebfea0dccb39d46",
             "_tpl": "57e3dba62459770f0c32322b",
             "parentId": "e506bfbaddaf6cf680f4d3a7",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "8df9df2eefbf16c2c946e6f3",
             "_tpl": "57dc347d245977596754e7a1",
             "parentId": "e506bfbaddaf6cf680f4d3a7",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "4ef099324beac67aaca7b53d",
             "_tpl": "564ca99c4bdc2d16268b4589",
             "parentId": "e506bfbaddaf6cf680f4d3a7",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "0b7aadd2bd11c1adfdb5f5f3",
             "_tpl": "57dc324a24597759501edc20",
             "parentId": "e506bfbaddaf6cf680f4d3a7",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "9f0676a581fe701299ccb7dc",
             "_tpl": "57dc334d245977597164366f",
             "parentId": "e506bfbaddaf6cf680f4d3a7",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "33f7bd40065b3f38776e6afb",
             "_tpl": "59d36a0086f7747e673f3946",
             "parentId": "e506bfbaddaf6cf680f4d3a7",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "e27c17bef9e27e805e2dff3e",
             "_tpl": "57dc32dc245977596d4ef3d3",
             "parentId": "33f7bd40065b3f38776e6afb",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "da7ed5414ccfc4564efaabd6",
             "_tpl": "55d4837c4bdc2d1d4e8b456c",
             "parentId": "hideout",
@@ -3890,7 +4363,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "769bf3edae3ccccefdabaecf",
             "_tpl": "5aaa5e60e5b5b000140293d6",
             "parentId": "hideout",
@@ -3901,7 +4375,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b2ef9af5e4aa25efee78a9ec",
             "_tpl": "59e5d83b86f7745aed03d262",
             "parentId": "hideout",
@@ -3912,7 +4387,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "60c72fc9bbd53cbeec2a0867",
             "_tpl": "5ac4cd105acfc40016339859",
             "parentId": "hideout",
@@ -3923,47 +4399,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "0e83ddf7fa260e7d1382d204",
             "_tpl": "59c6633186f7740cf0493bb9",
             "parentId": "60c72fc9bbd53cbeec2a0867",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "4a0e27c1b830e6fb2cae0d9c",
             "_tpl": "5648b1504bdc2d9d488b4584",
             "parentId": "0e83ddf7fa260e7d1382d204",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "efa1c8c03c0da2bc2805fe5a",
             "_tpl": "5ac7655e5acfc40016339a19",
             "parentId": "60c72fc9bbd53cbeec2a0867",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "ee47cfcd9e9890647e0a5d7b",
             "_tpl": "5649ade84bdc2d1b2b8b4587",
             "parentId": "60c72fc9bbd53cbeec2a0867",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "52e6e18eb4d2e4de20e339eb",
             "_tpl": "5ac50da15acfc4001718d287",
             "parentId": "60c72fc9bbd53cbeec2a0867",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "ac6961d60b7beeef7ebb778f",
             "_tpl": "5ac72e475acfc400180ae6fe",
             "parentId": "60c72fc9bbd53cbeec2a0867",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "305723dcbd4e4beaefa2ca6a",
             "_tpl": "5ac50c185acfc400163398d4",
             "parentId": "60c72fc9bbd53cbeec2a0867",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "2aab492a9246fcaddf8dc5d6",
             "_tpl": "55d480c04bdc2d1d4e8b456a",
             "parentId": "60c72fc9bbd53cbeec2a0867",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "d55017fe6e6cf9e0bfeb4dcd",
             "_tpl": "5ac66d015acfc400180ae6e4",
             "parentId": "hideout",
@@ -3974,47 +4459,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "3ebdd01ba2a9f3a1c1d7afcb",
             "_tpl": "59c6633186f7740cf0493bb9",
             "parentId": "d55017fe6e6cf9e0bfeb4dcd",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "556daca1abf04bdc832a0c4b",
             "_tpl": "5648b1504bdc2d9d488b4584",
             "parentId": "3ebdd01ba2a9f3a1c1d7afcb",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "c1841bb66fbdbb0eabae721d",
             "_tpl": "5ac72e725acfc400180ae701",
             "parentId": "d55017fe6e6cf9e0bfeb4dcd",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "4bdcfeeaad12cd6cf5ca39bf",
             "_tpl": "5649ade84bdc2d1b2b8b4587",
             "parentId": "d55017fe6e6cf9e0bfeb4dcd",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "d9d993080284d08affed8b4c",
             "_tpl": "5ac50da15acfc4001718d287",
             "parentId": "d55017fe6e6cf9e0bfeb4dcd",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "763525b805c2221aa03d205a",
             "_tpl": "5ac733a45acfc400192630e2",
             "parentId": "d55017fe6e6cf9e0bfeb4dcd",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "590cfd31924caafa12f12cc2",
             "_tpl": "5ac50c185acfc400163398d4",
             "parentId": "d55017fe6e6cf9e0bfeb4dcd",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "fcccef810aaad08bd0cab9ab",
             "_tpl": "5ac66c5d5acfc4001718d314",
             "parentId": "d55017fe6e6cf9e0bfeb4dcd",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "f7afeb9dcd44e5c2df0fdebe",
             "_tpl": "5447a9cd4bdc2dbd208b4567",
             "parentId": "hideout",
@@ -4025,67 +4519,80 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "13aba59ca0b2d67d756b9dea",
             "_tpl": "55d4b9964bdc2d1d4e8b456e",
             "parentId": "f7afeb9dcd44e5c2df0fdebe",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "a95eaeec95a024bad83c2d82",
             "_tpl": "55d4887d4bdc2d962f8b4570",
             "parentId": "f7afeb9dcd44e5c2df0fdebe",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "82d935bd73c95d5017a03ffe",
             "_tpl": "544a38634bdc2d58388b4568",
             "parentId": "25d01e8e3bc0dbeffca9c59b",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "f1e9c3cabacc7efe8aaebc1a",
             "_tpl": "5ae30e795acfc408fb139a0b",
             "parentId": "25d01e8e3bc0dbeffca9c59b",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "25d01e8e3bc0dbeffca9c59b",
             "_tpl": "55d3632e4bdc2d972f8b4569",
             "parentId": "06a61c974ade41bed2d81545",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "3bea6f87c61fe27e44cb30be",
             "_tpl": "637f57a68d137b27f70c4968",
             "parentId": "9b938df8628c6dfb9aedc2be",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "9b938df8628c6dfb9aedc2be",
             "_tpl": "5ae30db85acfc408fb139a05",
             "parentId": "06a61c974ade41bed2d81545",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "1f90b1bdc2107e8f56ac8ffb",
             "_tpl": "5ae30bad5acfc400185c2dc4",
             "parentId": "06a61c974ade41bed2d81545",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "06a61c974ade41bed2d81545",
             "_tpl": "55d355e64bdc2d962f8b4569",
             "parentId": "f7afeb9dcd44e5c2df0fdebe",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "3fcdbbecf7b4bd0bad2ad482",
             "_tpl": "55d4ae6c4bdc2d8b2f8b456e",
             "parentId": "bb079fffcf5c314023947fd9",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "bb079fffcf5c314023947fd9",
             "_tpl": "5649be884bdc2d79388b4577",
             "parentId": "f7afeb9dcd44e5c2df0fdebe",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "895baec8ce75eda10c36c3fb",
             "_tpl": "55d44fd14bdc2d962f8b456e",
             "parentId": "f7afeb9dcd44e5c2df0fdebe",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "9ce25be3e360b9a02c34bfeb",
             "_tpl": "5fbcc1d9016cce60e8341ab3",
             "parentId": "hideout",
@@ -4096,67 +4603,80 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f72fb2a5b7ddedc7c91e4a6a",
             "_tpl": "5fbcbd6c187fea44d52eda14",
             "parentId": "9ce25be3e360b9a02c34bfeb",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "cafe8fbcab4eed8e1d3d16dd",
             "_tpl": "55d4887d4bdc2d962f8b4570",
             "parentId": "9ce25be3e360b9a02c34bfeb",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "bbf88da0a1357ebadda6b51d",
             "_tpl": "5fbcc3e4d6fa9c00c571bb58",
             "parentId": "9ce25be3e360b9a02c34bfeb",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "b3a132ffae4d8fa98d9cfdfa",
             "_tpl": "5fbbfacda56d053a3543f799",
             "parentId": "bbf88da0a1357ebadda6b51d",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "531effb0ca6deb5cd1f6c8a7",
             "_tpl": "5fbc22ccf24b94483f726483",
             "parentId": "b3a132ffae4d8fa98d9cfdfa",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "7bbebae2dccc59173ad16c74",
             "_tpl": "5fbcbd10ab884124df0cd563",
             "parentId": "531effb0ca6deb5cd1f6c8a7",
             "slotId": "mod_muzzle_000"
-        }, {
+        },
+        {
             "_id": "4fac6f3475f12ec25c90cade",
             "_tpl": "5fbc210bf24b94483f726481",
             "parentId": "b3a132ffae4d8fa98d9cfdfa",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "dcef94e2c5a49d35ade47ec1",
             "_tpl": "5fbc226eca32ed67276c155d",
             "parentId": "bbf88da0a1357ebadda6b51d",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "4f6be6a28c8f60cd7bfc9a48",
             "_tpl": "5fc0fa362770a0045c59c677",
             "parentId": "dcef94e2c5a49d35ade47ec1",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "cfdafcdcd3cf7ed2a7dbaab1",
             "_tpl": "5fc0fa957283c4046c58147e",
             "parentId": "bbf88da0a1357ebadda6b51d",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "c8aa4c78fbaccf75112e57ba",
             "_tpl": "5fbcc437d724d907e2077d5c",
             "parentId": "9ce25be3e360b9a02c34bfeb",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "445d0a7d88cfbf9becffc2ac",
             "_tpl": "5fbcc640016cce60e8341acc",
             "parentId": "9ce25be3e360b9a02c34bfeb",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "6ea1ffe9eee54b1cf36376cf",
             "_tpl": "59ff346386f77477562ff5e2",
             "parentId": "hideout",
@@ -4167,57 +4687,68 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b5bbeef5bf667dd19eeb5724",
             "_tpl": "59d64ec286f774171d1e0a42",
             "parentId": "6ea1ffe9eee54b1cf36376cf",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "25cdd661ddd2f0be21527b83",
             "_tpl": "59d64f2f86f77417193ef8b3",
             "parentId": "b5bbeef5bf667dd19eeb5724",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "2fe1a7aa746cf5e3bfd3da92",
             "_tpl": "59d64fc686f774171b243fe2",
             "parentId": "6ea1ffe9eee54b1cf36376cf",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "df4882e7bc7f796ea8f3c4bd",
             "_tpl": "5a0071d486f77404e23a12b2",
             "parentId": "6ea1ffe9eee54b1cf36376cf",
             "slotId": "mod_pistol_grip_akms"
-        }, {
+        },
+        {
             "_id": "6fcc0e5329fdba91cc6cef1a",
             "_tpl": "59d6507c86f7741b846413a2",
             "parentId": "6ea1ffe9eee54b1cf36376cf",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "fcdb1081a3f9ffad42e4a655",
             "_tpl": "59d650cf86f7741b846413a4",
             "parentId": "6ea1ffe9eee54b1cf36376cf",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "458bb96d37e3127bd4f2e0ad",
             "_tpl": "5a0ed824fcdbcb0176308b0d",
             "parentId": "fcdb1081a3f9ffad42e4a655",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "bbcdc23440953f7b9ceffe3e",
             "_tpl": "59ff3b6a86f77477562ff5ed",
             "parentId": "6ea1ffe9eee54b1cf36376cf",
             "slotId": "mod_stock_akms"
-        }, {
+        },
+        {
             "_id": "68e6fc29a72bd3fe9bc387d1",
             "_tpl": "5a0060fc86f7745793204432",
             "parentId": "6ea1ffe9eee54b1cf36376cf",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "8edaf1cd40dcdc10eceeeecc",
             "_tpl": "5a0f096dfcdbcb0176308b15",
             "parentId": "6ea1ffe9eee54b1cf36376cf",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "acd6e280bed6cd2af5c9cb1e",
             "_tpl": "5cbdaf89ae9215000e5b9c94",
             "parentId": "hideout",
@@ -4228,7 +4759,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b0e4c1aadbd05c70bb4bae11",
             "_tpl": "5ac66c5d5acfc4001718d314",
             "parentId": "hideout",
@@ -4239,7 +4771,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ff2be5592cff0c39dc6ce2f4",
             "_tpl": "5448c1d04bdc2dff2f8b4569",
             "parentId": "hideout",
@@ -4250,7 +4783,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fc44da03ac88feee8bde7fbd",
             "_tpl": "5e21a3c67e40bd02257a008a",
             "parentId": "hideout",
@@ -4261,7 +4795,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "5bf4e8e362ffdfdb08c8ddee",
             "_tpl": "5ac66d9b5acfc4001633997a",
             "parentId": "hideout",
@@ -4272,47 +4807,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "1ad42621d9eeae6619212f9c",
             "_tpl": "59c6633186f7740cf0493bb9",
             "parentId": "5bf4e8e362ffdfdb08c8ddee",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "85dbdcbec0dbefbb6157a572",
             "_tpl": "5648b1504bdc2d9d488b4584",
             "parentId": "1ad42621d9eeae6619212f9c",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "cc5daf3e75cb0be0a9d126cf",
             "_tpl": "5ac72e945acfc43f3b691116",
             "parentId": "5bf4e8e362ffdfdb08c8ddee",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "14ccbebf9fa5fdae4110bbde",
             "_tpl": "5649ade84bdc2d1b2b8b4587",
             "parentId": "5bf4e8e362ffdfdb08c8ddee",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "0ffed87271fc3e8c9d8a6a7d",
             "_tpl": "5ac50da15acfc4001718d287",
             "parentId": "5bf4e8e362ffdfdb08c8ddee",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "bdfdc1efbbaedafaf20faedb",
             "_tpl": "5ac733a45acfc400192630e2",
             "parentId": "5bf4e8e362ffdfdb08c8ddee",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "da8b048af6eab745a3427bac",
             "_tpl": "5ac50c185acfc400163398d4",
             "parentId": "5bf4e8e362ffdfdb08c8ddee",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "de493c5952ffcd84ca00bff8",
             "_tpl": "55d480c04bdc2d1d4e8b456a",
             "parentId": "5bf4e8e362ffdfdb08c8ddee",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "d7aa8ebca8cacbc741cafd9a",
             "_tpl": "6184055050224f204c1da540",
             "parentId": "hideout",
@@ -4323,77 +4867,92 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "db90d52b89fb7bc9b7fecb5c",
             "_tpl": "55d4b9964bdc2d1d4e8b456e",
             "parentId": "d7aa8ebca8cacbc741cafd9a",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "8dfc76e2eaec2e41f2e7eaef",
             "_tpl": "61840bedd92c473c77021635",
             "parentId": "d7aa8ebca8cacbc741cafd9a",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "d76f9bef4c7eaed6acc4db98",
             "_tpl": "618405198004cc50514c3594",
             "parentId": "d7aa8ebca8cacbc741cafd9a",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "ad5f2bba4abb68eb1987f1d0",
             "_tpl": "6183fd9e8004cc50514c358f",
             "parentId": "d76f9bef4c7eaed6acc4db98",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "6c2c08eb407f8a5bff93cc5c",
             "_tpl": "618407a850224f204c1da549",
             "parentId": "ad5f2bba4abb68eb1987f1d0",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "6a7faf83c66cba7f49cbaf6a",
             "_tpl": "61816fcad92c473c770215cc",
             "parentId": "ad5f2bba4abb68eb1987f1d0",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "dbcbc4faa7087875dc3be4bc",
             "_tpl": "61817865d3a39d50044c13a4",
             "parentId": "d76f9bef4c7eaed6acc4db98",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "64e9aa5d7d000ea7adecc7bd",
             "_tpl": "61816df1d3a39d50044c139e",
             "parentId": "d76f9bef4c7eaed6acc4db98",
             "slotId": "mod_mount_000"
-        }, {
+        },
+        {
             "_id": "f2a62d5edadaf23af6a691c1",
             "_tpl": "61816dfa6ef05c2ce828f1ad",
             "parentId": "d76f9bef4c7eaed6acc4db98",
             "slotId": "mod_mount_001"
-        }, {
+        },
+        {
             "_id": "11dcf8c6eb15c46dbfaa8cf8",
             "_tpl": "61816734d8e3106d9806c1f3",
             "parentId": "d7aa8ebca8cacbc741cafd9a",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "a21d39aeab2cceee868bebdf",
             "_tpl": "618167528004cc50514c34f9",
             "parentId": "11dcf8c6eb15c46dbfaa8cf8",
             "slotId": "mod_stock_001"
-        }, {
+        },
+        {
             "_id": "36ff63e4fdeff885cfcbbddd",
             "_tpl": "618167616ef05c2ce828f1a8",
             "parentId": "a21d39aeab2cceee868bebdf",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "b8afc4b29d061d2ba2dbccdd",
             "_tpl": "618167441cb55961fa0fdc71",
             "parentId": "11dcf8c6eb15c46dbfaa8cf8",
             "slotId": "mod_stock_002"
-        }, {
+        },
+        {
             "_id": "c804783caeff93f3e2edc4a2",
             "_tpl": "6181688c6c780c1e710c9b04",
             "parentId": "d7aa8ebca8cacbc741cafd9a",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "009d6cecd1806d108ca1f87d",
             "_tpl": "5bb2475ed4351e00853264e3",
             "parentId": "hideout",
@@ -4404,62 +4963,74 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "0ebfb6c22be78adaa1fa01d8",
             "_tpl": "5bb20e0ed4351e3bac1212dc",
             "parentId": "009d6cecd1806d108ca1f87d",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "029ddb77f1d45c074bc98ef6",
             "_tpl": "5c05413a0db834001c390617",
             "parentId": "009d6cecd1806d108ca1f87d",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "c08cd00e41533f9fd65e8c1b",
             "_tpl": "5bb20d53d4351e4502010a69",
             "parentId": "009d6cecd1806d108ca1f87d",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "d7aa11adea3f755f7ca6d0ca",
             "_tpl": "5bb20d9cd4351e00334c9d8a",
             "parentId": "c08cd00e41533f9fd65e8c1b",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "4f8e7fc9bbb6ff6fba11bccb",
             "_tpl": "544a38634bdc2d58388b4568",
             "parentId": "d7aa11adea3f755f7ca6d0ca",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "4d3e5f5f0cf13e0aef008e1b",
             "_tpl": "5bb20dcad4351e3bac1212da",
             "parentId": "d7aa11adea3f755f7ca6d0ca",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "c7bdecbabaaedce201aa0c07",
             "_tpl": "5bb20de5d4351e0035629e59",
             "parentId": "c08cd00e41533f9fd65e8c1b",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "bced98d0ad6c0dc5fc8c48c5",
             "_tpl": "5bb20e49d4351e3bac1212de",
             "parentId": "c08cd00e41533f9fd65e8c1b",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "139b4327386ad3e466a4d4ce",
             "_tpl": "5bb20e58d4351e00320205d7",
             "parentId": "009d6cecd1806d108ca1f87d",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "fec2dc53bed4b9a9c7bb844f",
             "_tpl": "5bb20e70d4351e0035629f8f",
             "parentId": "139b4327386ad3e466a4d4ce",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "cfbe1a6cf30aefbfdacadf2a",
             "_tpl": "5bb20dbcd4351e44f824c04e",
             "parentId": "009d6cecd1806d108ca1f87d",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "d3f4fad38fbd5a9c885ffb7b",
             "_tpl": "5d43021ca4b9362eab4b5e25",
             "parentId": "hideout",
@@ -4470,72 +5041,86 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "42eb9869c4bbe9ab9f4df7ff",
             "_tpl": "55802f5d4bdc2dac148b458f",
             "parentId": "d3f4fad38fbd5a9c885ffb7b",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "e7e2c083e2201cea431bcfac",
             "_tpl": "5aaa5dfee5b5b000140293d3",
             "parentId": "d3f4fad38fbd5a9c885ffb7b",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "2ffd6054dfbfdb180ebd9d37",
             "_tpl": "5d4405aaa4b9361e6a4e6bd3",
             "parentId": "d3f4fad38fbd5a9c885ffb7b",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "b9f401f05cdac0cdfacf37ae",
             "_tpl": "5d440b93a4b9364276578d4b",
             "parentId": "2ffd6054dfbfdb180ebd9d37",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "ca1e04034ac2a0fbb0584b09",
             "_tpl": "5d440625a4b9361eec4ae6c5",
             "parentId": "b9f401f05cdac0cdfacf37ae",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "f58a9f7ddb509e362daa2a4a",
             "_tpl": "5d44064fa4b9361e4f6eb8b5",
             "parentId": "ca1e04034ac2a0fbb0584b09",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "cc5304c6b1c66e0e9fa07906",
             "_tpl": "56eabcd4d2720b66698b4574",
             "parentId": "b9f401f05cdac0cdfacf37ae",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "2cc467768896cbe4d7ddcbc2",
             "_tpl": "5d4405f0a4b9361e6a4e6bd9",
             "parentId": "2ffd6054dfbfdb180ebd9d37",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "31db8af5462663b31a6acbf7",
             "_tpl": "5b7be47f5acfc400170e2dd2",
             "parentId": "2cc467768896cbe4d7ddcbc2",
             "slotId": "mod_mount_004"
-        }, {
+        },
+        {
             "_id": "1f0c74eb6bb6ebd9ecc0d5b1",
             "_tpl": "5b7be4895acfc400170e2dd5",
             "parentId": "2cc467768896cbe4d7ddcbc2",
             "slotId": "mod_foregrip"
-        }, {
+        },
+        {
             "_id": "bf407c87abb3ee3a7efdfaa2",
             "_tpl": "5649be884bdc2d79388b4577",
             "parentId": "d3f4fad38fbd5a9c885ffb7b",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "8c46fba1aec27a63fe89bafd",
             "_tpl": "5d4406a8a4b9361e4f6eb8b7",
             "parentId": "bf407c87abb3ee3a7efdfaa2",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "5d00c1969dfdccd6642dad94",
             "_tpl": "5d44334ba4b9362b346d1948",
             "parentId": "d3f4fad38fbd5a9c885ffb7b",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "bbeaaaedce2a9bf8fd1a8251",
             "_tpl": "5ac66d725acfc43b321d4b60",
             "parentId": "hideout",
@@ -4546,47 +5131,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "17c2bad9b6d8cccbda7ed4fd",
             "_tpl": "5648b1504bdc2d9d488b4584",
             "parentId": "ae3bb6bce5a15febdf4807b7",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "ae3bb6bce5a15febdf4807b7",
             "_tpl": "59c6633186f7740cf0493bb9",
             "parentId": "bbeaaaedce2a9bf8fd1a8251",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "4f0be201f0b0a4ddfa6f88d4",
             "_tpl": "5ac72e895acfc43b321d4bd5",
             "parentId": "bbeaaaedce2a9bf8fd1a8251",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "e77e3ecdf5917dde68fceb05",
             "_tpl": "5649ade84bdc2d1b2b8b4587",
             "parentId": "bbeaaaedce2a9bf8fd1a8251",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "67dfacf57c2c4aec53be83b5",
             "_tpl": "5ac50da15acfc4001718d287",
             "parentId": "bbeaaaedce2a9bf8fd1a8251",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "dc8ebbd1c76bcaae2bd2b750",
             "_tpl": "5ac733a45acfc400192630e2",
             "parentId": "bbeaaaedce2a9bf8fd1a8251",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "ac2ee5dedae9ede66b0c5bdc",
             "_tpl": "5ac50c185acfc400163398d4",
             "parentId": "bbeaaaedce2a9bf8fd1a8251",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "15b8cb1a6db7cd36fce2571f",
             "_tpl": "5ac66bea5acfc43b321d4aec",
             "parentId": "bbeaaaedce2a9bf8fd1a8251",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "9c5ef2be33cc074cc80fd688",
             "_tpl": "564ca9df4bdc2d35148b4569",
             "parentId": "hideout",
@@ -4597,7 +5191,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "09e0f2ebb6ddec747acfa310",
             "_tpl": "544a378f4bdc2d30388b4567",
             "parentId": "hideout",
@@ -4608,7 +5203,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "525e9188f021e8b2acff23be",
             "_tpl": "5d1340bdd7ad1a0e8d245aab",
             "parentId": "hideout",
@@ -4619,7 +5215,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "9b1f0add467fc69d1bc4ccb4",
             "_tpl": "5b1fb3e15acfc4001637f068",
             "parentId": "hideout",
@@ -4630,7 +5227,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "afd34f681f6efeaa0321bb84",
             "_tpl": "606587252535c57a13424cfd",
             "parentId": "hideout",
@@ -4641,67 +5239,80 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "63cdcde3b79dba649d1ef1b1",
             "_tpl": "55802f5d4bdc2dac148b458f",
             "parentId": "afd34f681f6efeaa0321bb84",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "dfaafc6ad69ea1deebac9cae",
             "_tpl": "59d6272486f77466146386ff",
             "parentId": "afd34f681f6efeaa0321bb84",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "c229ec04febbe6f88f2beb90",
             "_tpl": "606587a88900dc2d9a55b659",
             "parentId": "afd34f681f6efeaa0321bb84",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "8ea098cdaae040fee1371a62",
             "_tpl": "60658776f2cb2e02a42ace2b",
             "parentId": "c229ec04febbe6f88f2beb90",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "d7f5f9b5ffc9bf7dcdc4770f",
             "_tpl": "6065c6e7132d4d12c81fd8e1",
             "parentId": "8ea098cdaae040fee1371a62",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "d1ae3a1ded58d04c89ffe14e",
             "_tpl": "6065dc8a132d4d12c81fd8e3",
             "parentId": "8ea098cdaae040fee1371a62",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "4d049b61e3bdccdcb22f392c",
             "_tpl": "6065880c132d4d12c81fd8da",
             "parentId": "c229ec04febbe6f88f2beb90",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "b3e0be61acdfbd6a452eddae",
             "_tpl": "5bc09a30d4351e00367fb7c8",
             "parentId": "4d049b61e3bdccdcb22f392c",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "3cea6dbf68c2dbcdbc6083d9",
             "_tpl": "5bc09a18d4351e003562b68e",
             "parentId": "c229ec04febbe6f88f2beb90",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "db13cef5a5de88b3d8e1abff",
             "_tpl": "606587e18900dc2d9a55b65f",
             "parentId": "afd34f681f6efeaa0321bb84",
             "slotId": "mod_stock_001"
-        }, {
+        },
+        {
             "_id": "dcbafbad8beef891b74a13de",
             "_tpl": "606587d11246154cad35d635",
             "parentId": "db13cef5a5de88b3d8e1abff",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "b1e8cfc65e81e1bae6b39bb4",
             "_tpl": "606587bd6d0bd7580617bacc",
             "parentId": "afd34f681f6efeaa0321bb84",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "8a099caacbfbf8b1dcdaf63b",
             "_tpl": "5c488a752e221602b412af63",
             "parentId": "hideout",
@@ -4712,32 +5323,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "98ff93ffde463cf85aec63a2",
             "_tpl": "5c48a2c22e221602b313fb6c",
             "parentId": "8a099caacbfbf8b1dcdaf63b",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "ae5af0cfeb295faaaafe64f6",
             "_tpl": "55802d5f4bdc2dac148b458e",
             "parentId": "8a099caacbfbf8b1dcdaf63b",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "6bf9a033109de0d0d54a6aac",
             "_tpl": "5c48a14f2e2216152006edd7",
             "parentId": "8a099caacbfbf8b1dcdaf63b",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "0915f0dd1ed16ecbc3ca16c8",
             "_tpl": "5c48a2852e221602b21d5923",
             "parentId": "8a099caacbfbf8b1dcdaf63b",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "5d597ff21abb99c7ea7de0ea",
             "_tpl": "5c48a2a42e221602b66d1e07",
             "parentId": "0915f0dd1ed16ecbc3ca16c8",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "b1c647f0b20aa881ba8fd022",
             "_tpl": "5b0bbe4e5acfc40dc528a72d",
             "parentId": "hideout",
@@ -4748,62 +5365,74 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "80cfca0f5eda6a4f97bb6fad",
             "_tpl": "5b099b965acfc400186331e6",
             "parentId": "b1c647f0b20aa881ba8fd022",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "95a7028a70ce8b6f540b48f7",
             "_tpl": "5b099ac65acfc400186331e1",
             "parentId": "b1c647f0b20aa881ba8fd022",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "27f2ecb3e503c4f57ef7796a",
             "_tpl": "5b099a9d5acfc47a8607efe7",
             "parentId": "b1c647f0b20aa881ba8fd022",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "ced53204fac6a7b5ae1f4b9b",
             "_tpl": "5b099b7d5acfc400186331e4",
             "parentId": "410ae6ceeb2fd89151aab4bd",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "410ae6ceeb2fd89151aab4bd",
             "_tpl": "5b099a765acfc47a8607efe3",
             "parentId": "b1c647f0b20aa881ba8fd022",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "215223de7cd828cb10e6ddad",
             "_tpl": "5b0bc22d5acfc47a8607f085",
             "parentId": "b1c647f0b20aa881ba8fd022",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "e2afc14ac68ddcea0f078395",
             "_tpl": "5b099bb25acfc400186331e8",
             "parentId": "b1c647f0b20aa881ba8fd022",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "c3ccaaa97ca0008b0f7cebc5",
             "_tpl": "58d2912286f7744e27117493",
             "parentId": "1e091e6d3597b937aae760b6",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "1e091e6d3597b937aae760b6",
             "_tpl": "56eabf3bd2720b75698b4569",
             "parentId": "0af38bfaa1970f5614af80fd",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "0af38bfaa1970f5614af80fd",
             "_tpl": "5649be884bdc2d79388b4577",
             "parentId": "a5ddfda4b104c23b77a9bff1",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "a5ddfda4b104c23b77a9bff1",
             "_tpl": "5b099bf25acfc4001637e683",
             "parentId": "b1c647f0b20aa881ba8fd022",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "ab2dc3ce4e83c14fa8d7ec23",
             "_tpl": "6165ac306ef05c2ce828ef74",
             "parentId": "hideout",
@@ -4814,77 +5443,92 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "3c1ddabec4b2a61fd138a2d2",
             "_tpl": "571659bb2459771fb2755a12",
             "parentId": "ab2dc3ce4e83c14fa8d7ec23",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "f3beca9efaf9f5ee64c8eca2",
             "_tpl": "6183d53f1cb55961fa0fdcda",
             "parentId": "ab2dc3ce4e83c14fa8d7ec23",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "d62c8edb1b5cdca015a3d47f",
             "_tpl": "618178aa1cb55961fa0fdc80",
             "parentId": "8bac77df6b2efe3de8c2d4d5",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "5aaf374e5cf4bd8ee1e4d98c",
             "_tpl": "61816fcad92c473c770215cc",
             "parentId": "8bac77df6b2efe3de8c2d4d5",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "8bac77df6b2efe3de8c2d4d5",
             "_tpl": "6183b0711cb55961fa0fdcad",
             "parentId": "b41ef74c3aa93adbe2c7cf71",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "adbb07dd6ee8da098c88d12f",
             "_tpl": "61817865d3a39d50044c13a4",
             "parentId": "b41ef74c3aa93adbe2c7cf71",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "e77f4f4f39adebc1e4d5ae3f",
             "_tpl": "61816df1d3a39d50044c139e",
             "parentId": "b41ef74c3aa93adbe2c7cf71",
             "slotId": "mod_mount_000"
-        }, {
+        },
+        {
             "_id": "aaa27b00c73cecaabfa4c87f",
             "_tpl": "61816dfa6ef05c2ce828f1ad",
             "parentId": "b41ef74c3aa93adbe2c7cf71",
             "slotId": "mod_mount_001"
-        }, {
+        },
+        {
             "_id": "b41ef74c3aa93adbe2c7cf71",
             "_tpl": "6165aeedfaa1272e431521e3",
             "parentId": "ab2dc3ce4e83c14fa8d7ec23",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "b5b336a22cfaa10d9bee8f1c",
             "_tpl": "618167616ef05c2ce828f1a8",
             "parentId": "c4d427dccb3defec461ccf5f",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "c4d427dccb3defec461ccf5f",
             "_tpl": "61825d136ef05c2ce828f1cc",
             "parentId": "deeeae2278a5bafccbdde3ca",
             "slotId": "mod_stock_001"
-        }, {
+        },
+        {
             "_id": "370aea4ca4b1a3b10926087a",
             "_tpl": "61825d24d3a39d50044c13af",
             "parentId": "deeeae2278a5bafccbdde3ca",
             "slotId": "mod_stock_002"
-        }, {
+        },
+        {
             "_id": "deeeae2278a5bafccbdde3ca",
             "_tpl": "61825d06d92c473c770215de",
             "parentId": "ab2dc3ce4e83c14fa8d7ec23",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "c8f7dc63cf8ae3c05cde1dfb",
             "_tpl": "6181688c6c780c1e710c9b04",
             "parentId": "ab2dc3ce4e83c14fa8d7ec23",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "ccfd666d9cbcaa0da2bbffcf",
             "_tpl": "5dcbd56fdbd3d91b3e5468d5",
             "parentId": "hideout",
@@ -4895,32 +5539,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c1a02c2f1253e0edbde1cddf",
             "_tpl": "5dcbd6dddbd3d91b3e5468de",
             "parentId": "ccfd666d9cbcaa0da2bbffcf",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "f5f1c33d1b1576789fdd95b7",
             "_tpl": "5a3501acc4a282000d72293a",
             "parentId": "ccfd666d9cbcaa0da2bbffcf",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "6703184bbbc920e77759bef0",
             "_tpl": "5dcbd6b46ec07c0c4347a564",
             "parentId": "ccfd666d9cbcaa0da2bbffcf",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "df3efd356bc2f2d7faf9b702",
             "_tpl": "5dcbe9431e1f4616d354987e",
             "parentId": "ccfd666d9cbcaa0da2bbffcf",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "7dedb9fdd14deaab7bbf7ceb",
             "_tpl": "5dcbe965e4ed22586443a79d",
             "parentId": "df3efd356bc2f2d7faf9b702",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "b88ad5eb1bdebda76f6aff1f",
             "_tpl": "5cadfbf7ae92152ac412eeef",
             "parentId": "hideout",
@@ -4931,37 +5581,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "1722caec8acb7bcabf9cefb3",
             "_tpl": "5caf17c9ae92150b30006be1",
             "parentId": "b88ad5eb1bdebda76f6aff1f",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "c2243f141ed80ff96da63e65",
             "_tpl": "5caf1041ae92157c28402e3f",
             "parentId": "b88ad5eb1bdebda76f6aff1f",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "33d949838bab210faee021ca",
             "_tpl": "5caf16a2ae92152ac412efbc",
             "parentId": "b88ad5eb1bdebda76f6aff1f",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "97eeebc2eb1d6cfa9ac55fcb",
             "_tpl": "5cdaa99dd7f00c002412d0b2",
             "parentId": "b88ad5eb1bdebda76f6aff1f",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "ce3eecabaaefb4c451a7ecae",
             "_tpl": "5cda9bcfd7f00c0c0b53e900",
             "parentId": "97eeebc2eb1d6cfa9ac55fcb",
             "slotId": "mod_foregrip"
-        }, {
+        },
+        {
             "_id": "8a9a05ea3c4eaf4fcbb67d12",
             "_tpl": "5caf1691ae92152ac412efb9",
             "parentId": "b88ad5eb1bdebda76f6aff1f",
             "slotId": "mod_scope"
-        }, {
+        },
+        {
             "_id": "c7f609cf854ed2d2a2d2a49a",
             "_tpl": "5caf1041ae92157c28402e3f",
             "parentId": "hideout",
@@ -4972,7 +5629,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "068d2acdaeeebbdbced8cb9f",
             "_tpl": "5c6592372e221600133e47d7",
             "parentId": "hideout",
@@ -4983,7 +5641,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "3252770cddbeb28272aa70c7",
             "_tpl": "5c6175362e221600133e3b94",
             "parentId": "hideout",
@@ -4994,7 +5653,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "80a3e7b7fc957d25ceefa219",
             "_tpl": "5df8f541c41b2312ea3335e3",
             "parentId": "hideout",
@@ -5005,7 +5665,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "1ffe68bf509adbcc118b7ece",
             "_tpl": "5b7c2d1d5acfc43d1028532a",
             "parentId": "hideout",
@@ -5016,7 +5677,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "66ca525ad612fc82421fbaa3",
             "_tpl": "618168dc8004cc50514c34fc",
             "parentId": "hideout",
@@ -5027,7 +5689,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "cba9defaede775b699fafea7",
             "_tpl": "59e6687d86f77411d949b251",
             "parentId": "hideout",
@@ -5038,47 +5701,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bb2efa7f3eb6be8a53ae49b3",
             "_tpl": "59e649f986f77411d949b246",
             "parentId": "cba9defaede775b699fafea7",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "c49256dc4a5ecd3d76e9a3a8",
             "_tpl": "59e898ee86f77427614bd225",
             "parentId": "bb2efa7f3eb6be8a53ae49b3",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "c6eae474a7de6bbf4bac0aca",
             "_tpl": "59e8a00d86f7742ad93b569c",
             "parentId": "cba9defaede775b699fafea7",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "a2b4db4fbcaae62cacff3dd9",
             "_tpl": "59e6318286f77444dd62c4cc",
             "parentId": "cba9defaede775b699fafea7",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "a433161adaaac69ac46405fa",
             "_tpl": "59e6449086f7746c9f75e822",
             "parentId": "cba9defaede775b699fafea7",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "eaeb36b8eb5e6cb51fa6b3f9",
             "_tpl": "59e8977386f77415a553c453",
             "parentId": "cba9defaede775b699fafea7",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "0ad93af908b994e9e73eaeba",
             "_tpl": "59e89d0986f77427600d226e",
             "parentId": "cba9defaede775b699fafea7",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "bf65f2d8effba561abaa5efb",
             "_tpl": "59d625f086f774661516605d",
             "parentId": "cba9defaede775b699fafea7",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "cd706d2bc5c4e45dfeb87b57",
             "_tpl": "59e6152586f77473dc057aa1",
             "parentId": "hideout",
@@ -5089,47 +5761,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7e22bedfaea53cf09baea054",
             "_tpl": "59e649f986f77411d949b246",
             "parentId": "cd706d2bc5c4e45dfeb87b57",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "cbfac4aa77c5eb00de9a8cac",
             "_tpl": "59e6284f86f77440d569536f",
             "parentId": "7e22bedfaea53cf09baea054",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "2bd9e686b3f13b5d33aed7d5",
             "_tpl": "59e61eb386f77440d64f5daf",
             "parentId": "cd706d2bc5c4e45dfeb87b57",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "76daafb3bfa52ad0262bb3c2",
             "_tpl": "59e6318286f77444dd62c4cc",
             "parentId": "cd706d2bc5c4e45dfeb87b57",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "ad5fdaa76d2c56f4fc6dceb4",
             "_tpl": "59e6449086f7746c9f75e822",
             "parentId": "cd706d2bc5c4e45dfeb87b57",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "8dedcbfb7d99fe25d4ef13fa",
             "_tpl": "59d650cf86f7741b846413a4",
             "parentId": "cd706d2bc5c4e45dfeb87b57",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "ed8a35505afce2db26d30a71",
             "_tpl": "59e6227d86f77440d64f5dc2",
             "parentId": "cd706d2bc5c4e45dfeb87b57",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "e3e1bfdeb367d8583fc76b09",
             "_tpl": "59d625f086f774661516605d",
             "parentId": "cd706d2bc5c4e45dfeb87b57",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "ed1d018635ec71b82a0fdf69",
             "_tpl": "5c07c60e0db834002330051f",
             "parentId": "hideout",
@@ -5140,52 +5821,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "6ebcb5e02d5ec2db1cb048cc",
             "_tpl": "5c0e2ff6d174af02a1659d4a",
             "parentId": "ed1d018635ec71b82a0fdf69",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "27caed6d4fc37dd40abf064a",
             "_tpl": "5aaa5e60e5b5b000140293d6",
             "parentId": "ed1d018635ec71b82a0fdf69",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "ee6c9cf5e813afcdfd30b1ba",
             "_tpl": "5c0e2f26d174af02a9625114",
             "parentId": "ed1d018635ec71b82a0fdf69",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "bca8861d9dc82ff0a27a38e1",
             "_tpl": "5c0e2f94d174af029f650d56",
             "parentId": "ee6c9cf5e813afcdfd30b1ba",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "cc499d2c61cdda014ee70547",
             "_tpl": "5c0fafb6d174af02a96260ba",
             "parentId": "bca8861d9dc82ff0a27a38e1",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "68caa0fbb6b26a090bdcbca7",
             "_tpl": "5ae30e795acfc408fb139a0b",
             "parentId": "bca8861d9dc82ff0a27a38e1",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "3f0eb0f2d7894dacb6bbd16c",
             "_tpl": "5c0e2f5cd174af02a012cfc9",
             "parentId": "ee6c9cf5e813afcdfd30b1ba",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "a10e4e5b9f3bedeab54dbf92",
             "_tpl": "5c0faeddd174af02a962601f",
             "parentId": "ed1d018635ec71b82a0fdf69",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "ce9c34bc374e6ccdbf62cfdf",
             "_tpl": "5c0faf68d174af02a96260b8",
             "parentId": "ed1d018635ec71b82a0fdf69",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "0751b54d74e5bccbcbdaf625",
             "_tpl": "57dc2fa62459775949412633",
             "parentId": "hideout",
@@ -5196,42 +5887,50 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d045f1ffd7dd0ab2bdbf4ddc",
             "_tpl": "57e3dba62459770f0c32322b",
             "parentId": "0751b54d74e5bccbcbdaf625",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "9dcabfbf9b502551e422b0ff",
             "_tpl": "57dc347d245977596754e7a1",
             "parentId": "0751b54d74e5bccbcbdaf625",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "07bd2f9aae2b5cd83dad7dbd",
             "_tpl": "564ca99c4bdc2d16268b4589",
             "parentId": "0751b54d74e5bccbcbdaf625",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "b9e49a6c3d069f9eb4bac76c",
             "_tpl": "57dc324a24597759501edc20",
             "parentId": "0751b54d74e5bccbcbdaf625",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "2ae4f515dd418cedcb7bc291",
             "_tpl": "57dc334d245977597164366f",
             "parentId": "0751b54d74e5bccbcbdaf625",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "0e7c4ebbcdf8bbde1e1ddcea",
             "_tpl": "59d36a0086f7747e673f3946",
             "parentId": "0751b54d74e5bccbcbdaf625",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "b1caff7cbd2bd0bd5a72ccae",
             "_tpl": "57dc32dc245977596d4ef3d3",
             "parentId": "0e7c4ebbcdf8bbde1e1ddcea",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "243a72c0ecab68e63ef4ba65",
             "_tpl": "583990e32459771419544dd2",
             "parentId": "hideout",
@@ -5242,42 +5941,50 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "11808cb6ab744bf0ba3c430a",
             "_tpl": "5649ad3f4bdc2df8348b4585",
             "parentId": "243a72c0ecab68e63ef4ba65",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "6a68203f9bb27fc6a93c7f0b",
             "_tpl": "57dc347d245977596754e7a1",
             "parentId": "243a72c0ecab68e63ef4ba65",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "bf2cafca018df0777dbbfce3",
             "_tpl": "564ca99c4bdc2d16268b4589",
             "parentId": "243a72c0ecab68e63ef4ba65",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "eafce170a7edc43106f2eee4",
             "_tpl": "57dc324a24597759501edc20",
             "parentId": "243a72c0ecab68e63ef4ba65",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "6e2e54a3aac5de6a790e3e68",
             "_tpl": "57dc334d245977597164366f",
             "parentId": "243a72c0ecab68e63ef4ba65",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "8fdeefcfcfbc66cf8e11db16",
             "_tpl": "57dc32dc245977596d4ef3d3",
             "parentId": "0a7eac3b6ce89ddc97bb1158",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "0a7eac3b6ce89ddc97bb1158",
             "_tpl": "59d36a0086f7747e673f3946",
             "parentId": "243a72c0ecab68e63ef4ba65",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "b6d8749a9b609e46eb910dca",
             "_tpl": "5839a40f24597726f856b511",
             "parentId": "hideout",
@@ -5288,42 +5995,50 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b4c3537e3e1f4f873eb0faf6",
             "_tpl": "5649ad3f4bdc2df8348b4585",
             "parentId": "b6d8749a9b609e46eb910dca",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "40e9e49d3adfdef25ca8eada",
             "_tpl": "57dc347d245977596754e7a1",
             "parentId": "b6d8749a9b609e46eb910dca",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "3bcba5b8efacec70fad8a534",
             "_tpl": "564ca99c4bdc2d16268b4589",
             "parentId": "b6d8749a9b609e46eb910dca",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "afba03c0eabc769e2957b407",
             "_tpl": "57ffb0e42459777d047111c5",
             "parentId": "b6d8749a9b609e46eb910dca",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "dcaf6853bcd9e7bb016dc72e",
             "_tpl": "5839a7742459773cf9693481",
             "parentId": "b6d8749a9b609e46eb910dca",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "c3ca7ce0ddf049388217a12f",
             "_tpl": "59d36a0086f7747e673f3946",
             "parentId": "b6d8749a9b609e46eb910dca",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "78ba09e25976ec90b5abcba3",
             "_tpl": "57dc32dc245977596d4ef3d3",
             "parentId": "c3ca7ce0ddf049388217a12f",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "bafde5fee8bf01e574dffdfd",
             "_tpl": "5ac4cd105acfc40016339859",
             "parentId": "hideout",
@@ -5334,47 +6049,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ebcc1d36c1edc5edebbe4366",
             "_tpl": "59c6633186f7740cf0493bb9",
             "parentId": "bafde5fee8bf01e574dffdfd",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "b7a20c6db4ef0c53414c0e4c",
             "_tpl": "5648b1504bdc2d9d488b4584",
             "parentId": "ebcc1d36c1edc5edebbe4366",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "fabe8981421e2ae4eb5fd0b0",
             "_tpl": "5ac7655e5acfc40016339a19",
             "parentId": "bafde5fee8bf01e574dffdfd",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "db316bf0553d8ff6fbd7cbae",
             "_tpl": "5649ade84bdc2d1b2b8b4587",
             "parentId": "bafde5fee8bf01e574dffdfd",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "b8c62d01cc7d6d35fadc1a9e",
             "_tpl": "5ac50da15acfc4001718d287",
             "parentId": "bafde5fee8bf01e574dffdfd",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "08a9178e7dcaac5ce4261ef9",
             "_tpl": "5ac72e475acfc400180ae6fe",
             "parentId": "bafde5fee8bf01e574dffdfd",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "95ffc100f5eacffdb4b21f7c",
             "_tpl": "5ac50c185acfc400163398d4",
             "parentId": "bafde5fee8bf01e574dffdfd",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "bbfbdeccdfda2cefccddaccf",
             "_tpl": "55d480c04bdc2d1d4e8b456a",
             "parentId": "bafde5fee8bf01e574dffdfd",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "ead9d3a507d7d92f2e24b9a0",
             "_tpl": "5bf3e0490db83400196199af",
             "parentId": "hideout",
@@ -5385,47 +6109,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "0698b285c82aecebe907ad9a",
             "_tpl": "59c6633186f7740cf0493bb9",
             "parentId": "ead9d3a507d7d92f2e24b9a0",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "1f1aff1645dac7fdbffb7dc9",
             "_tpl": "5648b0744bdc2d363b8b4578",
             "parentId": "0698b285c82aecebe907ad9a",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "53dfffc0eaa595b9d3ffce8c",
             "_tpl": "5649aa744bdc2ded0b8b457e",
             "parentId": "ead9d3a507d7d92f2e24b9a0",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "a34e730e5b22dd92dd5e31a1",
             "_tpl": "57e3dba62459770f0c32322b",
             "parentId": "ead9d3a507d7d92f2e24b9a0",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "13ccbcdb59f4f6809f079b3b",
             "_tpl": "5649af094bdc2df8348b4586",
             "parentId": "ead9d3a507d7d92f2e24b9a0",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "54bfaead7b6f4dcba3e2619f",
             "_tpl": "5649b0544bdc2d1b2b8b458a",
             "parentId": "ead9d3a507d7d92f2e24b9a0",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "bbbc7afbd67cbfdee95bfd01",
             "_tpl": "5ab626e4d8ce87272e4c6e43",
             "parentId": "ead9d3a507d7d92f2e24b9a0",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "ab9ca24bef18b433beda5cfc",
             "_tpl": "564ca99c4bdc2d16268b4589",
             "parentId": "ead9d3a507d7d92f2e24b9a0",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "f5dc47ad4ca0c2eecb6dbdbc",
             "_tpl": "5bf3e03b0db834001d2c4a9c",
             "parentId": "hideout",
@@ -5436,47 +6169,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "4e2d6dedd9226c10eabe3efd",
             "_tpl": "59c6633186f7740cf0493bb9",
             "parentId": "f5dc47ad4ca0c2eecb6dbdbc",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "cdba0cfbebf4a48e7cba8bc3",
             "_tpl": "5648b0744bdc2d363b8b4578",
             "parentId": "4e2d6dedd9226c10eabe3efd",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "de7cdceb1eaeee71b5122622",
             "_tpl": "5649aa744bdc2ded0b8b457e",
             "parentId": "f5dc47ad4ca0c2eecb6dbdbc",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "9efc9e427c42a626e49e7ab0",
             "_tpl": "57e3dba62459770f0c32322b",
             "parentId": "f5dc47ad4ca0c2eecb6dbdbc",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "0016a46ac17d5e365eefaed6",
             "_tpl": "5649af094bdc2df8348b4586",
             "parentId": "f5dc47ad4ca0c2eecb6dbdbc",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "ca6bfbe36aa1ff0da9d3d195",
             "_tpl": "5649b0544bdc2d1b2b8b458a",
             "parentId": "f5dc47ad4ca0c2eecb6dbdbc",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "afee84d60bdb1b4fdc0c89a8",
             "_tpl": "5649b1c04bdc2d16268b457c",
             "parentId": "f5dc47ad4ca0c2eecb6dbdbc",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "96c9672eefbeec070bce5e1a",
             "_tpl": "564ca99c4bdc2d16268b4589",
             "parentId": "f5dc47ad4ca0c2eecb6dbdbc",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "0bdbccfd208aeea0ddc47cce",
             "_tpl": "5644bd2b4bdc2d3b4c8b4572",
             "parentId": "hideout",
@@ -5487,47 +6229,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e3f44cfee308eb569a344f59",
             "_tpl": "5648b0744bdc2d363b8b4578",
             "parentId": "a23fae1e7c448d32b2c106ca",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "a23fae1e7c448d32b2c106ca",
             "_tpl": "59c6633186f7740cf0493bb9",
             "parentId": "0bdbccfd208aeea0ddc47cce",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "1ff1fcc16558ab9b45a9b136",
             "_tpl": "5649aa744bdc2ded0b8b457e",
             "parentId": "0bdbccfd208aeea0ddc47cce",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "92a0eccdbca0e144ca57f49c",
             "_tpl": "5649ad3f4bdc2df8348b4585",
             "parentId": "0bdbccfd208aeea0ddc47cce",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "deb7be56eaeb6d36cdeb6c76",
             "_tpl": "5649af094bdc2df8348b4586",
             "parentId": "0bdbccfd208aeea0ddc47cce",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "e9d455d82d1abd050a98d44a",
             "_tpl": "5649b0544bdc2d1b2b8b458a",
             "parentId": "0bdbccfd208aeea0ddc47cce",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "1cfc9db40b2ffcff3be9b95f",
             "_tpl": "5649b1c04bdc2d16268b457c",
             "parentId": "0bdbccfd208aeea0ddc47cce",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "152d254cfc6ca2cc15612c7c",
             "_tpl": "564ca99c4bdc2d16268b4589",
             "parentId": "0bdbccfd208aeea0ddc47cce",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "b9b6184222b2a9f7a8a1381e",
             "_tpl": "5ab8e9fcd8ce870019439434",
             "parentId": "hideout",
@@ -5538,47 +6289,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f23994fa80a4ca7bc37e3e3a",
             "_tpl": "59c6633186f7740cf0493bb9",
             "parentId": "b9b6184222b2a9f7a8a1381e",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "ad9d71f5bcccfca84a5f0a67",
             "_tpl": "5648b0744bdc2d363b8b4578",
             "parentId": "f23994fa80a4ca7bc37e3e3a",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "bf1afa8a8f4079db5c2cfcec",
             "_tpl": "5649aa744bdc2ded0b8b457e",
             "parentId": "b9b6184222b2a9f7a8a1381e",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "fe8b6ffe0ff45ad9b19db3d7",
             "_tpl": "57e3dba62459770f0c32322b",
             "parentId": "b9b6184222b2a9f7a8a1381e",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "36ead7aa77bf2cc8ad4535c5",
             "_tpl": "5649af094bdc2df8348b4586",
             "parentId": "b9b6184222b2a9f7a8a1381e",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "92a7ac88e78390ffbbcc51d5",
             "_tpl": "5649b0544bdc2d1b2b8b458a",
             "parentId": "b9b6184222b2a9f7a8a1381e",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "b0ee508dd4dd8afaa20bdbd9",
             "_tpl": "5ab626e4d8ce87272e4c6e43",
             "parentId": "b9b6184222b2a9f7a8a1381e",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "eb1e88c6edbeaa760c1c5ab0",
             "_tpl": "564ca99c4bdc2d16268b4589",
             "parentId": "b9b6184222b2a9f7a8a1381e",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "268df6124c7584f8acd980ed",
             "_tpl": "5ac66d015acfc400180ae6e4",
             "parentId": "hideout",
@@ -5589,47 +6349,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "cbfe467b40fcb70d5cab923c",
             "_tpl": "59c6633186f7740cf0493bb9",
             "parentId": "268df6124c7584f8acd980ed",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "e6a7f016e7daaaeaa3d08d44",
             "_tpl": "5648b1504bdc2d9d488b4584",
             "parentId": "cbfe467b40fcb70d5cab923c",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "12ecf8f6352bca25dd6a32e6",
             "_tpl": "5ac72e725acfc400180ae701",
             "parentId": "268df6124c7584f8acd980ed",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "b40f4fd049edff1b88fb7aea",
             "_tpl": "5649ade84bdc2d1b2b8b4587",
             "parentId": "268df6124c7584f8acd980ed",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "a86cd9eef68bcbaeae3d0d98",
             "_tpl": "5ac50da15acfc4001718d287",
             "parentId": "268df6124c7584f8acd980ed",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "2daf2083dbef4bb6bddb5da0",
             "_tpl": "5ac733a45acfc400192630e2",
             "parentId": "268df6124c7584f8acd980ed",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "aadf6cddbf3dabbcefb27eaa",
             "_tpl": "5ac50c185acfc400163398d4",
             "parentId": "268df6124c7584f8acd980ed",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "daedc215e5cca911ac26f17f",
             "_tpl": "5ac66c5d5acfc4001718d314",
             "parentId": "268df6124c7584f8acd980ed",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "9dd2c749743a53c9efa92df6",
             "_tpl": "5ac66cb05acfc40198510a10",
             "parentId": "hideout",
@@ -5640,47 +6409,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b25e27fec16ee28e5bb552c6",
             "_tpl": "59c6633186f7740cf0493bb9",
             "parentId": "9dd2c749743a53c9efa92df6",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "0eda86230bf5e67f4d5fdaf6",
             "_tpl": "5648b1504bdc2d9d488b4584",
             "parentId": "b25e27fec16ee28e5bb552c6",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "b8aafda67b9cbc168f06ef64",
             "_tpl": "5ac72e615acfc43f67248aa0",
             "parentId": "9dd2c749743a53c9efa92df6",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "eecbe29ccbcfcddeee9b7a10",
             "_tpl": "5649ade84bdc2d1b2b8b4587",
             "parentId": "9dd2c749743a53c9efa92df6",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "dea23ceed6947607b9fdd47a",
             "_tpl": "5ac50da15acfc4001718d287",
             "parentId": "9dd2c749743a53c9efa92df6",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "fb593e2aefbaa3637ff37bfc",
             "_tpl": "5ac72e475acfc400180ae6fe",
             "parentId": "9dd2c749743a53c9efa92df6",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "adbdd82d349cfafceb813f9c",
             "_tpl": "5ac50c185acfc400163398d4",
             "parentId": "9dd2c749743a53c9efa92df6",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "cc0a74b4ada6c42aa42dd6df",
             "_tpl": "5ac66c5d5acfc4001718d314",
             "parentId": "9dd2c749743a53c9efa92df6",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "51a485bf649f505b4ce23cbc",
             "_tpl": "5447a9cd4bdc2dbd208b4567",
             "parentId": "hideout",
@@ -5691,67 +6469,80 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "05b0430ccc611a1a222cd57d",
             "_tpl": "55d4b9964bdc2d1d4e8b456e",
             "parentId": "51a485bf649f505b4ce23cbc",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "bbaeba2d41be3fbfa3998e5f",
             "_tpl": "55d4887d4bdc2d962f8b4570",
             "parentId": "51a485bf649f505b4ce23cbc",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "bba58e81f0ddc05fcc7de629",
             "_tpl": "544a38634bdc2d58388b4568",
             "parentId": "d7facbe19de72bed5dce5e80",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "05c9996cbbdaf7ac2adf8f67",
             "_tpl": "5ae30e795acfc408fb139a0b",
             "parentId": "d7facbe19de72bed5dce5e80",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "d7facbe19de72bed5dce5e80",
             "_tpl": "55d3632e4bdc2d972f8b4569",
             "parentId": "fc2b86ff54ce0aed7802b31c",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "ebfc0464cd0cbcea79d1ffb2",
             "_tpl": "637f57a68d137b27f70c4968",
             "parentId": "f8f7b2bc4aa6d307d92eff6e",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "f8f7b2bc4aa6d307d92eff6e",
             "_tpl": "5ae30db85acfc408fb139a05",
             "parentId": "fc2b86ff54ce0aed7802b31c",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "7ff3a3ee9fff75e0bc8d4eff",
             "_tpl": "5ae30bad5acfc400185c2dc4",
             "parentId": "fc2b86ff54ce0aed7802b31c",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "fc2b86ff54ce0aed7802b31c",
             "_tpl": "55d355e64bdc2d962f8b4569",
             "parentId": "51a485bf649f505b4ce23cbc",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "f8a368a4eb9ad93b3303af49",
             "_tpl": "55d4ae6c4bdc2d8b2f8b456e",
             "parentId": "51710dec4caf7c46c0af1d38",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "51710dec4caf7c46c0af1d38",
             "_tpl": "5649be884bdc2d79388b4577",
             "parentId": "51a485bf649f505b4ce23cbc",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "f60bf2ed0afd2ae134c0048c",
             "_tpl": "55d44fd14bdc2d962f8b456e",
             "parentId": "51a485bf649f505b4ce23cbc",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "8ecb75b20c8fefdc113e9bf2",
             "_tpl": "5fbcc1d9016cce60e8341ab3",
             "parentId": "hideout",
@@ -5762,67 +6553,80 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f23abcda787b7bd2705a9bce",
             "_tpl": "5fbcbd6c187fea44d52eda14",
             "parentId": "8ecb75b20c8fefdc113e9bf2",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "e3ebf7e4e07bf7c3f017d2ba",
             "_tpl": "55d4887d4bdc2d962f8b4570",
             "parentId": "8ecb75b20c8fefdc113e9bf2",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "43bc14df0a69423a9ecd8fb8",
             "_tpl": "5fbcc3e4d6fa9c00c571bb58",
             "parentId": "8ecb75b20c8fefdc113e9bf2",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "ed1b7bf882017f43f96dee90",
             "_tpl": "5fbbfacda56d053a3543f799",
             "parentId": "43bc14df0a69423a9ecd8fb8",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "9b40d4cba0304f15f4c6b483",
             "_tpl": "5fbc22ccf24b94483f726483",
             "parentId": "ed1b7bf882017f43f96dee90",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "ce46a731cc547fceaa2bfcc9",
             "_tpl": "5fbcbd10ab884124df0cd563",
             "parentId": "9b40d4cba0304f15f4c6b483",
             "slotId": "mod_muzzle_000"
-        }, {
+        },
+        {
             "_id": "da9cae1d6fe78e86fd7a8afc",
             "_tpl": "5fbc210bf24b94483f726481",
             "parentId": "ed1b7bf882017f43f96dee90",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "b25e1d8daaf1cf3c2bd5c9f9",
             "_tpl": "5fbc226eca32ed67276c155d",
             "parentId": "43bc14df0a69423a9ecd8fb8",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "fbe35ac554f28fed26ae9a67",
             "_tpl": "5fc0fa362770a0045c59c677",
             "parentId": "b25e1d8daaf1cf3c2bd5c9f9",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "b34496d4da4453ce83410f4a",
             "_tpl": "5fc0fa957283c4046c58147e",
             "parentId": "43bc14df0a69423a9ecd8fb8",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "a4a84bcedfb76b7afb08b97d",
             "_tpl": "5fbcc437d724d907e2077d5c",
             "parentId": "8ecb75b20c8fefdc113e9bf2",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "4df4b9bef11ccc4fdc1060b7",
             "_tpl": "5fbcc640016cce60e8341acc",
             "parentId": "8ecb75b20c8fefdc113e9bf2",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "ec82a5f1dfb49c7c191ef8bd",
             "_tpl": "59ff346386f77477562ff5e2",
             "parentId": "hideout",
@@ -5833,57 +6637,68 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "9ad66a9dafcef1659ad0ecdc",
             "_tpl": "59d64ec286f774171d1e0a42",
             "parentId": "ec82a5f1dfb49c7c191ef8bd",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "05a651b8bfdfd7abd811b13d",
             "_tpl": "59d64f2f86f77417193ef8b3",
             "parentId": "9ad66a9dafcef1659ad0ecdc",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "a4b4ecd3075c9c7bd6f0aaee",
             "_tpl": "59d64fc686f774171b243fe2",
             "parentId": "ec82a5f1dfb49c7c191ef8bd",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "acc69ed0530414fc4d10c0ec",
             "_tpl": "5a0071d486f77404e23a12b2",
             "parentId": "ec82a5f1dfb49c7c191ef8bd",
             "slotId": "mod_pistol_grip_akms"
-        }, {
+        },
+        {
             "_id": "da3e4cace90a53e4acbd46ac",
             "_tpl": "59d6507c86f7741b846413a2",
             "parentId": "ec82a5f1dfb49c7c191ef8bd",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "277227a60b6af2e03b72f6d8",
             "_tpl": "59d650cf86f7741b846413a4",
             "parentId": "ec82a5f1dfb49c7c191ef8bd",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "7a9cb865edf9b0bc25693c29",
             "_tpl": "5a0ed824fcdbcb0176308b0d",
             "parentId": "277227a60b6af2e03b72f6d8",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "4d749ea867b665b9be9c794d",
             "_tpl": "59ff3b6a86f77477562ff5ed",
             "parentId": "ec82a5f1dfb49c7c191ef8bd",
             "slotId": "mod_stock_akms"
-        }, {
+        },
+        {
             "_id": "7e2bfbd6ff16cd59225e18e2",
             "_tpl": "5a0060fc86f7745793204432",
             "parentId": "ec82a5f1dfb49c7c191ef8bd",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "ac0c9b1680cbdcfce7afa698",
             "_tpl": "5a0f096dfcdbcb0176308b15",
             "parentId": "ec82a5f1dfb49c7c191ef8bd",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "25d9cdc19f953ca2b7e2e19d",
             "_tpl": "5abcbc27d8ce8700182eceeb",
             "parentId": "hideout",
@@ -5894,47 +6709,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e3a5bd1f38b04ae3cdf2662b",
             "_tpl": "59d64f2f86f77417193ef8b3",
             "parentId": "fc3ebbb75f6fec2df5af8822",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "fc3ebbb75f6fec2df5af8822",
             "_tpl": "59d64ec286f774171d1e0a42",
             "parentId": "25d9cdc19f953ca2b7e2e19d",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "c1cfa89b78bdbf8fdba05ecf",
             "_tpl": "59e61eb386f77440d64f5daf",
             "parentId": "25d9cdc19f953ca2b7e2e19d",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "cffcddffcb3e42f65dffdfd9",
             "_tpl": "5a0071d486f77404e23a12b2",
             "parentId": "25d9cdc19f953ca2b7e2e19d",
             "slotId": "mod_pistol_grip_akms"
-        }, {
+        },
+        {
             "_id": "e454b7ab19dc3ff745aceafd",
             "_tpl": "59d6507c86f7741b846413a2",
             "parentId": "25d9cdc19f953ca2b7e2e19d",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "e4055ebe228423ad8baf138c",
             "_tpl": "59d650cf86f7741b846413a4",
             "parentId": "25d9cdc19f953ca2b7e2e19d",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "d80536b25ec3a21def43ae4f",
             "_tpl": "5abcd472d8ce8700166032ae",
             "parentId": "25d9cdc19f953ca2b7e2e19d",
             "slotId": "mod_stock_akms"
-        }, {
+        },
+        {
             "_id": "a99f46aed1df7a85cc731633",
             "_tpl": "5a0060fc86f7745793204432",
             "parentId": "25d9cdc19f953ca2b7e2e19d",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "f63d3e4ae77e8abdfe36d7af",
             "_tpl": "59d6088586f774275f37482f",
             "parentId": "hideout",
@@ -5945,57 +6769,68 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "6fc23e1fb2f1f0486c2d2ac3",
             "_tpl": "59d64ec286f774171d1e0a42",
             "parentId": "f63d3e4ae77e8abdfe36d7af",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "ce64bbafab0fb1da8e0ab99e",
             "_tpl": "59d64f2f86f77417193ef8b3",
             "parentId": "6fc23e1fb2f1f0486c2d2ac3",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "3b8d5b6db7ea40ac5bbcea45",
             "_tpl": "59d64fc686f774171b243fe2",
             "parentId": "f63d3e4ae77e8abdfe36d7af",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "5cf55df4d2cbf143a7afbaa5",
             "_tpl": "59e62cc886f77440d40b52a1",
             "parentId": "f63d3e4ae77e8abdfe36d7af",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "fec9527aa8be6a23cdfcca34",
             "_tpl": "59d6507c86f7741b846413a2",
             "parentId": "f63d3e4ae77e8abdfe36d7af",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "5d89123facdcbded86eb1c7f",
             "_tpl": "59d650cf86f7741b846413a4",
             "parentId": "f63d3e4ae77e8abdfe36d7af",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "7e5a820fe9f7ba89b6b8e67f",
             "_tpl": "5a0ed824fcdbcb0176308b0d",
             "parentId": "5d89123facdcbded86eb1c7f",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "82f9acaaff3ccbbd337f4e09",
             "_tpl": "59d6514b86f774171a068a08",
             "parentId": "f63d3e4ae77e8abdfe36d7af",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "20409428d34ff9b9b4ee71fa",
             "_tpl": "59d625f086f774661516605d",
             "parentId": "f63d3e4ae77e8abdfe36d7af",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "1f81bebe7df8f929ba6e5fcd",
             "_tpl": "5a0f096dfcdbcb0176308b15",
             "parentId": "f63d3e4ae77e8abdfe36d7af",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "9fedefc8bf5bbf109deee2eb",
             "_tpl": "5a0ec13bfcdbcb00165aa685",
             "parentId": "hideout",
@@ -6006,47 +6841,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "5df56b4a11eb4df6e4efe2dd",
             "_tpl": "59d64f2f86f77417193ef8b3",
             "parentId": "7fb2b3fbadcf875e9edac17b",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "7fb2b3fbadcf875e9edac17b",
             "_tpl": "59d64ec286f774171d1e0a42",
             "parentId": "9fedefc8bf5bbf109deee2eb",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "04f4c2dfb5d36abfdb3d83bd",
             "_tpl": "59d64fc686f774171b243fe2",
             "parentId": "9fedefc8bf5bbf109deee2eb",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "6eaec9d20c5f3f3c9b5e2f9c",
             "_tpl": "59e62cc886f77440d40b52a1",
             "parentId": "9fedefc8bf5bbf109deee2eb",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "7326ed6eb49ce5acada80abd",
             "_tpl": "59d6507c86f7741b846413a2",
             "parentId": "9fedefc8bf5bbf109deee2eb",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "f30696bc3eebe1f82ebc9a6e",
             "_tpl": "59d650cf86f7741b846413a4",
             "parentId": "9fedefc8bf5bbf109deee2eb",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "a5e6ccebeb3921ddac8ba6f8",
             "_tpl": "59d6514b86f774171a068a08",
             "parentId": "9fedefc8bf5bbf109deee2eb",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "2f5d5ac4deac3ff2ffc77c2a",
             "_tpl": "5a01c29586f77474660c694c",
             "parentId": "9fedefc8bf5bbf109deee2eb",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "e6a9ac9a2a6d58d04642b3b2",
             "_tpl": "5ac66d9b5acfc4001633997a",
             "parentId": "hideout",
@@ -6057,47 +6901,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "dce7ebc9dad20ccc1facac45",
             "_tpl": "59c6633186f7740cf0493bb9",
             "parentId": "e6a9ac9a2a6d58d04642b3b2",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "bac1c5b6ba92b0eaffcb11ae",
             "_tpl": "5648b1504bdc2d9d488b4584",
             "parentId": "dce7ebc9dad20ccc1facac45",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "ddbb45d5432ceaf1fc30fe3d",
             "_tpl": "5ac72e945acfc43f3b691116",
             "parentId": "e6a9ac9a2a6d58d04642b3b2",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "6f12f1fc8ad59c7fdeef4e9e",
             "_tpl": "5649ade84bdc2d1b2b8b4587",
             "parentId": "e6a9ac9a2a6d58d04642b3b2",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "b3b92b31c3bcfccc69a375b4",
             "_tpl": "5ac50da15acfc4001718d287",
             "parentId": "e6a9ac9a2a6d58d04642b3b2",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "0bcd95becaa5d7589ccbb10d",
             "_tpl": "5ac733a45acfc400192630e2",
             "parentId": "e6a9ac9a2a6d58d04642b3b2",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "f2afc01b501cded821b24d9c",
             "_tpl": "5ac50c185acfc400163398d4",
             "parentId": "e6a9ac9a2a6d58d04642b3b2",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "ba1bedbad2cccad557aa6aae",
             "_tpl": "55d480c04bdc2d1d4e8b456a",
             "parentId": "e6a9ac9a2a6d58d04642b3b2",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "ddcdced49ce92c83f133a8b8",
             "_tpl": "6184055050224f204c1da540",
             "parentId": "hideout",
@@ -6108,77 +6961,92 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "aadf48efcdda991dafbf5a1b",
             "_tpl": "55d4b9964bdc2d1d4e8b456e",
             "parentId": "ddcdced49ce92c83f133a8b8",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "0fadfbbaf3be47a45fb73ffb",
             "_tpl": "61840bedd92c473c77021635",
             "parentId": "ddcdced49ce92c83f133a8b8",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "b2b5f9a097fe1c1c474f0e5e",
             "_tpl": "618405198004cc50514c3594",
             "parentId": "ddcdced49ce92c83f133a8b8",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "eb9d56a613582c728b6d8abb",
             "_tpl": "6183fd9e8004cc50514c358f",
             "parentId": "b2b5f9a097fe1c1c474f0e5e",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "6b91b2adb1f06aaf1aaf4947",
             "_tpl": "618407a850224f204c1da549",
             "parentId": "eb9d56a613582c728b6d8abb",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "76e3f4e8caa1d1ebbca2a5cf",
             "_tpl": "61816fcad92c473c770215cc",
             "parentId": "eb9d56a613582c728b6d8abb",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "284f48e2de3a260bda7c5eae",
             "_tpl": "61817865d3a39d50044c13a4",
             "parentId": "b2b5f9a097fe1c1c474f0e5e",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "67d3da27cccdedf39eacee95",
             "_tpl": "61816df1d3a39d50044c139e",
             "parentId": "b2b5f9a097fe1c1c474f0e5e",
             "slotId": "mod_mount_000"
-        }, {
+        },
+        {
             "_id": "8f06bbddc26e79b08bbe23a8",
             "_tpl": "61816dfa6ef05c2ce828f1ad",
             "parentId": "b2b5f9a097fe1c1c474f0e5e",
             "slotId": "mod_mount_001"
-        }, {
+        },
+        {
             "_id": "2e92d8e2abcaa69f0aaac17e",
             "_tpl": "61816734d8e3106d9806c1f3",
             "parentId": "ddcdced49ce92c83f133a8b8",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "201decbfd1df6515bd55045c",
             "_tpl": "618167528004cc50514c34f9",
             "parentId": "2e92d8e2abcaa69f0aaac17e",
             "slotId": "mod_stock_001"
-        }, {
+        },
+        {
             "_id": "dbcddf10ef9154c6ec06fee8",
             "_tpl": "618167616ef05c2ce828f1a8",
             "parentId": "201decbfd1df6515bd55045c",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "bec407a92363e4b5d2f68082",
             "_tpl": "618167441cb55961fa0fdc71",
             "parentId": "2e92d8e2abcaa69f0aaac17e",
             "slotId": "mod_stock_002"
-        }, {
+        },
+        {
             "_id": "93cd8602bc0c5f32c3f088d2",
             "_tpl": "6181688c6c780c1e710c9b04",
             "parentId": "ddcdced49ce92c83f133a8b8",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "de85b4dc3eaa6fbe1aaade6c",
             "_tpl": "618428466ef05c2ce828f218",
             "parentId": "hideout",
@@ -6189,77 +7057,92 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "17ced69c083bc7fb207eb5a0",
             "_tpl": "571659bb2459771fb2755a12",
             "parentId": "de85b4dc3eaa6fbe1aaade6c",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "ec2acd8e95fafc7e01e6dcd4",
             "_tpl": "61840d85568c120fdd2962a5",
             "parentId": "de85b4dc3eaa6fbe1aaade6c",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "e072bb3a04facd8ab643cdfb",
             "_tpl": "618407a850224f204c1da549",
             "parentId": "a6378eafeb55a51091dec65c",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "6dfd3249b234de5a1dd3b0f2",
             "_tpl": "61816fcad92c473c770215cc",
             "parentId": "a6378eafeb55a51091dec65c",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "a6378eafeb55a51091dec65c",
             "_tpl": "6183fd911cb55961fa0fdce9",
             "parentId": "b06b537fb3c2daec0b3093bc",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "5dceb7efcaedd4fbbff939e0",
             "_tpl": "61817865d3a39d50044c13a4",
             "parentId": "b06b537fb3c2daec0b3093bc",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "b1cebf38ada99bddc5721427",
             "_tpl": "61816df1d3a39d50044c139e",
             "parentId": "b06b537fb3c2daec0b3093bc",
             "slotId": "mod_mount_000"
-        }, {
+        },
+        {
             "_id": "1006aebddde0f9fd739a4bb7",
             "_tpl": "61816dfa6ef05c2ce828f1ad",
             "parentId": "b06b537fb3c2daec0b3093bc",
             "slotId": "mod_mount_001"
-        }, {
+        },
+        {
             "_id": "b06b537fb3c2daec0b3093bc",
             "_tpl": "618426d96c780c1e710c9b9f",
             "parentId": "de85b4dc3eaa6fbe1aaade6c",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "1bf9f5fb90cdec7eee249cdd",
             "_tpl": "618167616ef05c2ce828f1a8",
             "parentId": "19fadb837ec65cb2c6ecbd87",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "19fadb837ec65cb2c6ecbd87",
             "_tpl": "61825d136ef05c2ce828f1cc",
             "parentId": "d9acadc4feacc8174181acf8",
             "slotId": "mod_stock_001"
-        }, {
+        },
+        {
             "_id": "1c4aa0cbaca9cbf8fa029d87",
             "_tpl": "61825d24d3a39d50044c13af",
             "parentId": "d9acadc4feacc8174181acf8",
             "slotId": "mod_stock_002"
-        }, {
+        },
+        {
             "_id": "d9acadc4feacc8174181acf8",
             "_tpl": "61825d06d92c473c770215de",
             "parentId": "de85b4dc3eaa6fbe1aaade6c",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "5e2fade807f32ca69de7cf0d",
             "_tpl": "6181688c6c780c1e710c9b04",
             "parentId": "de85b4dc3eaa6fbe1aaade6c",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "f7253aa7fdb140fe0e3fb6d2",
             "_tpl": "5bb2475ed4351e00853264e3",
             "parentId": "hideout",
@@ -6270,62 +7153,74 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "243d9dec59a4a5f1dd0cc54a",
             "_tpl": "5bb20e0ed4351e3bac1212dc",
             "parentId": "f7253aa7fdb140fe0e3fb6d2",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "deabbfebfa52dcbadc12b536",
             "_tpl": "5c05413a0db834001c390617",
             "parentId": "f7253aa7fdb140fe0e3fb6d2",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "57daf879bc3ccf953effd911",
             "_tpl": "5bb20d53d4351e4502010a69",
             "parentId": "f7253aa7fdb140fe0e3fb6d2",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "c0cdecdbf6d2f3eb6510bf2f",
             "_tpl": "5bb20d9cd4351e00334c9d8a",
             "parentId": "57daf879bc3ccf953effd911",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "e1f5fefbe99beaa63c54aeee",
             "_tpl": "544a38634bdc2d58388b4568",
             "parentId": "c0cdecdbf6d2f3eb6510bf2f",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "eb3d49feefe5376d58d0ecfc",
             "_tpl": "5bb20dcad4351e3bac1212da",
             "parentId": "c0cdecdbf6d2f3eb6510bf2f",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "e37cb14fb68eb649dfef27ac",
             "_tpl": "5bb20de5d4351e0035629e59",
             "parentId": "57daf879bc3ccf953effd911",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "efc4ad22b724c09fa9cc042b",
             "_tpl": "5bb20e49d4351e3bac1212de",
             "parentId": "57daf879bc3ccf953effd911",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "5a2dbcac88998dfaf8dc00a7",
             "_tpl": "5bb20e58d4351e00320205d7",
             "parentId": "f7253aa7fdb140fe0e3fb6d2",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "05de64beebaaaf8fe4945de6",
             "_tpl": "5bb20e70d4351e0035629f8f",
             "parentId": "5a2dbcac88998dfaf8dc00a7",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "dd9fcaec1cecc216aebeade0",
             "_tpl": "5bb20dbcd4351e44f824c04e",
             "parentId": "f7253aa7fdb140fe0e3fb6d2",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "dab7c8f57398c5eba1a7a9cd",
             "_tpl": "5d43021ca4b9362eab4b5e25",
             "parentId": "hideout",
@@ -6336,72 +7231,86 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ccddf0323afedf07cc8dcfe4",
             "_tpl": "55802f5d4bdc2dac148b458f",
             "parentId": "dab7c8f57398c5eba1a7a9cd",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "983d6cd3a9af2cb3cd8bdb11",
             "_tpl": "5aaa5dfee5b5b000140293d3",
             "parentId": "dab7c8f57398c5eba1a7a9cd",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "67dccffc83fdda43eccb0c87",
             "_tpl": "5d4405aaa4b9361e6a4e6bd3",
             "parentId": "dab7c8f57398c5eba1a7a9cd",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "2f99782c32be7bcb45fddb3f",
             "_tpl": "5d440b93a4b9364276578d4b",
             "parentId": "67dccffc83fdda43eccb0c87",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "fa6ff043378b1ae9a7acbc7f",
             "_tpl": "5d440625a4b9361eec4ae6c5",
             "parentId": "2f99782c32be7bcb45fddb3f",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "2cf9d498cae36aa9b1bde47d",
             "_tpl": "5d44064fa4b9361e4f6eb8b5",
             "parentId": "fa6ff043378b1ae9a7acbc7f",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "f9c51042cdde5575cfd072ed",
             "_tpl": "56eabcd4d2720b66698b4574",
             "parentId": "2f99782c32be7bcb45fddb3f",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "fac924bdd9770e80cacba9a7",
             "_tpl": "5d4405f0a4b9361e6a4e6bd9",
             "parentId": "67dccffc83fdda43eccb0c87",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "8a45ebebcd50b6618f9ef77d",
             "_tpl": "5b7be47f5acfc400170e2dd2",
             "parentId": "fac924bdd9770e80cacba9a7",
             "slotId": "mod_mount_004"
-        }, {
+        },
+        {
             "_id": "7fb7281de8e1529cd6e473dd",
             "_tpl": "5b7be4895acfc400170e2dd5",
             "parentId": "fac924bdd9770e80cacba9a7",
             "slotId": "mod_foregrip"
-        }, {
+        },
+        {
             "_id": "dfdead0c9ba8e1cbceab2fb4",
             "_tpl": "5649be884bdc2d79388b4577",
             "parentId": "dab7c8f57398c5eba1a7a9cd",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "c0beda3565da358cadccd7ac",
             "_tpl": "5d4406a8a4b9361e4f6eb8b7",
             "parentId": "dfdead0c9ba8e1cbceab2fb4",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "af5faf7b42f2bc0feacaa6db",
             "_tpl": "5d44334ba4b9362b346d1948",
             "parentId": "dab7c8f57398c5eba1a7a9cd",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "bc3eee4fb6caeaef28b91a85",
             "_tpl": "5ac66d725acfc43b321d4b60",
             "parentId": "hideout",
@@ -6412,47 +7321,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "40f740faf3dfd6e9f0bd1a1c",
             "_tpl": "5648b1504bdc2d9d488b4584",
             "parentId": "eb5aaeecbffdc7eea5cc00b7",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "eb5aaeecbffdc7eea5cc00b7",
             "_tpl": "59c6633186f7740cf0493bb9",
             "parentId": "bc3eee4fb6caeaef28b91a85",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "63a49dcd12588e63ae0beb96",
             "_tpl": "5ac72e895acfc43b321d4bd5",
             "parentId": "bc3eee4fb6caeaef28b91a85",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "1f226e8f3b52cc1ca6a97822",
             "_tpl": "5649ade84bdc2d1b2b8b4587",
             "parentId": "bc3eee4fb6caeaef28b91a85",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "ef5bbacb229079cd165b757f",
             "_tpl": "5ac50da15acfc4001718d287",
             "parentId": "bc3eee4fb6caeaef28b91a85",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "ffe7f47caa8f6197cbcb1a50",
             "_tpl": "5ac733a45acfc400192630e2",
             "parentId": "bc3eee4fb6caeaef28b91a85",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "dc48d215c03adc0b0bd20aad",
             "_tpl": "5ac50c185acfc400163398d4",
             "parentId": "bc3eee4fb6caeaef28b91a85",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "efcd2658d6f33054ef9b0b09",
             "_tpl": "5ac66bea5acfc43b321d4aec",
             "parentId": "bc3eee4fb6caeaef28b91a85",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "eb9e0f0277f7b85f2c513e55",
             "_tpl": "5ac66d2e5acfc43b321d4b53",
             "parentId": "hideout",
@@ -6463,47 +7381,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "6a2a902cc7cec8a114928eca",
             "_tpl": "59c6633186f7740cf0493bb9",
             "parentId": "eb9e0f0277f7b85f2c513e55",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "ae1bd14eecb29dc2f63e021a",
             "_tpl": "5648b1504bdc2d9d488b4584",
             "parentId": "6a2a902cc7cec8a114928eca",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "7c22ea96eec8a56458df816d",
             "_tpl": "5ac72e7d5acfc40016339a02",
             "parentId": "eb9e0f0277f7b85f2c513e55",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "eafab33bb854cd919e6cb2a6",
             "_tpl": "5649ade84bdc2d1b2b8b4587",
             "parentId": "eb9e0f0277f7b85f2c513e55",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "df1fc3edff400de6d348af31",
             "_tpl": "5ac50da15acfc4001718d287",
             "parentId": "eb9e0f0277f7b85f2c513e55",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "66bca3c0dcfa55e72ee1adff",
             "_tpl": "5ac72e475acfc400180ae6fe",
             "parentId": "eb9e0f0277f7b85f2c513e55",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "bedbd42e0dafcc2e62cefce2",
             "_tpl": "5ac50c185acfc400163398d4",
             "parentId": "eb9e0f0277f7b85f2c513e55",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "a2fb6f18b4565e2153b10fae",
             "_tpl": "5ac66bea5acfc43b321d4aec",
             "parentId": "eb9e0f0277f7b85f2c513e55",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "ddacd746b270532e7c761c07",
             "_tpl": "606587252535c57a13424cfd",
             "parentId": "hideout",
@@ -6514,67 +7441,80 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "757ddfff07eea58ba8bf747d",
             "_tpl": "55802f5d4bdc2dac148b458f",
             "parentId": "ddacd746b270532e7c761c07",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "ddf05c0b4fe8cd9ab44bbefc",
             "_tpl": "59d6272486f77466146386ff",
             "parentId": "ddacd746b270532e7c761c07",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "c1f2c5f286ee30bcfeb8efaa",
             "_tpl": "606587a88900dc2d9a55b659",
             "parentId": "ddacd746b270532e7c761c07",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "bb4ce7e55fa9c81eaa72d3c8",
             "_tpl": "60658776f2cb2e02a42ace2b",
             "parentId": "c1f2c5f286ee30bcfeb8efaa",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "29002d9d9bd6b993b92e2693",
             "_tpl": "6065c6e7132d4d12c81fd8e1",
             "parentId": "bb4ce7e55fa9c81eaa72d3c8",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "e3f16d4ffd57244f232c9f1d",
             "_tpl": "6065dc8a132d4d12c81fd8e3",
             "parentId": "bb4ce7e55fa9c81eaa72d3c8",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "407c5b85d8093ea0fcde7638",
             "_tpl": "6065880c132d4d12c81fd8da",
             "parentId": "c1f2c5f286ee30bcfeb8efaa",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "6a396c014cbcab7c20e685fc",
             "_tpl": "5bc09a30d4351e00367fb7c8",
             "parentId": "407c5b85d8093ea0fcde7638",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "4c09bf5adcbbddf0a282fb00",
             "_tpl": "5bc09a18d4351e003562b68e",
             "parentId": "c1f2c5f286ee30bcfeb8efaa",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "d31fa5fbabafec64fd06bb7a",
             "_tpl": "606587e18900dc2d9a55b65f",
             "parentId": "ddacd746b270532e7c761c07",
             "slotId": "mod_stock_001"
-        }, {
+        },
+        {
             "_id": "e8d05e1bc48cfcf9babd055e",
             "_tpl": "606587d11246154cad35d635",
             "parentId": "d31fa5fbabafec64fd06bb7a",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "e8e5b6943e09fdce8dd8f1c4",
             "_tpl": "606587bd6d0bd7580617bacc",
             "parentId": "ddacd746b270532e7c761c07",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "2c2953acc3228daceef9f38d",
             "_tpl": "5c488a752e221602b412af63",
             "parentId": "hideout",
@@ -6585,32 +7525,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fce7da81adb196eba6f4ddca",
             "_tpl": "5c48a2c22e221602b313fb6c",
             "parentId": "2c2953acc3228daceef9f38d",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "bcb1a1fa7bdd11be7d93e3ef",
             "_tpl": "55802d5f4bdc2dac148b458e",
             "parentId": "2c2953acc3228daceef9f38d",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "d3fbebdd60c9dff5fe3df381",
             "_tpl": "5c48a14f2e2216152006edd7",
             "parentId": "2c2953acc3228daceef9f38d",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "a48e56fd81eaa23a91f2f276",
             "_tpl": "5c48a2852e221602b21d5923",
             "parentId": "2c2953acc3228daceef9f38d",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "61dbadc75cfeb3b7c76b23dd",
             "_tpl": "5c48a2a42e221602b66d1e07",
             "parentId": "a48e56fd81eaa23a91f2f276",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "cf3bc468503c7cfec45ebada",
             "_tpl": "5b0bbe4e5acfc40dc528a72d",
             "parentId": "hideout",
@@ -6621,62 +7567,74 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fdbaeba137ccdeabeb8afebd",
             "_tpl": "5b099b965acfc400186331e6",
             "parentId": "cf3bc468503c7cfec45ebada",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "27cc9c1bc9dd220a560c0fac",
             "_tpl": "5b099ac65acfc400186331e1",
             "parentId": "cf3bc468503c7cfec45ebada",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "c225e0bbc3acb2f1b57dfa9b",
             "_tpl": "5b099a9d5acfc47a8607efe7",
             "parentId": "cf3bc468503c7cfec45ebada",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "bbe083bf8e5f1a3e3790b6d2",
             "_tpl": "5b099b7d5acfc400186331e4",
             "parentId": "4b916979b58fefcfd3048052",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "4b916979b58fefcfd3048052",
             "_tpl": "5b099a765acfc47a8607efe3",
             "parentId": "cf3bc468503c7cfec45ebada",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "3aae1dac26c440ca5bbce33a",
             "_tpl": "5b0bc22d5acfc47a8607f085",
             "parentId": "cf3bc468503c7cfec45ebada",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "e6dbffe4348accfa46baea1c",
             "_tpl": "5b099bb25acfc400186331e8",
             "parentId": "cf3bc468503c7cfec45ebada",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "ba92afefa35a0bcbbad11ea2",
             "_tpl": "58d2912286f7744e27117493",
             "parentId": "b2bae93dbccc95574bdeb664",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "b2bae93dbccc95574bdeb664",
             "_tpl": "56eabf3bd2720b75698b4569",
             "parentId": "3a8ebc8388e55cdcd7eafbae",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "3a8ebc8388e55cdcd7eafbae",
             "_tpl": "5649be884bdc2d79388b4577",
             "parentId": "a4aabf903ecf754dfbbe6d9f",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "a4aabf903ecf754dfbbe6d9f",
             "_tpl": "5b099bf25acfc4001637e683",
             "parentId": "cf3bc468503c7cfec45ebada",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "16426ac6c6fede5eeb28e114",
             "_tpl": "6165ac306ef05c2ce828ef74",
             "parentId": "hideout",
@@ -6687,77 +7645,92 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "4e983fc17fafe7d6c3bcaa37",
             "_tpl": "571659bb2459771fb2755a12",
             "parentId": "16426ac6c6fede5eeb28e114",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "3dde80afcfcde8782132bba3",
             "_tpl": "6183d53f1cb55961fa0fdcda",
             "parentId": "16426ac6c6fede5eeb28e114",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "e7e956780ed793692a64cddc",
             "_tpl": "618178aa1cb55961fa0fdc80",
             "parentId": "0be8f624f6c180f17ee77b5e",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "ded5b968dfad67aecce4f203",
             "_tpl": "61816fcad92c473c770215cc",
             "parentId": "0be8f624f6c180f17ee77b5e",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "0be8f624f6c180f17ee77b5e",
             "_tpl": "6183b0711cb55961fa0fdcad",
             "parentId": "bc4c165efccbcfff56669e3d",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "9aebb3bff384eb43fbb2cd25",
             "_tpl": "61817865d3a39d50044c13a4",
             "parentId": "bc4c165efccbcfff56669e3d",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "8dfd3a45b700acde62897931",
             "_tpl": "61816df1d3a39d50044c139e",
             "parentId": "bc4c165efccbcfff56669e3d",
             "slotId": "mod_mount_000"
-        }, {
+        },
+        {
             "_id": "a7fcb278cfa00cfdeb0ba338",
             "_tpl": "61816dfa6ef05c2ce828f1ad",
             "parentId": "bc4c165efccbcfff56669e3d",
             "slotId": "mod_mount_001"
-        }, {
+        },
+        {
             "_id": "bc4c165efccbcfff56669e3d",
             "_tpl": "6165aeedfaa1272e431521e3",
             "parentId": "16426ac6c6fede5eeb28e114",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "d42fc8ecdda4fad0d1f094f2",
             "_tpl": "618167616ef05c2ce828f1a8",
             "parentId": "5df48798ecd6dd4c10ab5e5c",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "5df48798ecd6dd4c10ab5e5c",
             "_tpl": "61825d136ef05c2ce828f1cc",
             "parentId": "b30c60f716bceb6abbd4f120",
             "slotId": "mod_stock_001"
-        }, {
+        },
+        {
             "_id": "c4bcd59efb3ac3532ec68adb",
             "_tpl": "61825d24d3a39d50044c13af",
             "parentId": "b30c60f716bceb6abbd4f120",
             "slotId": "mod_stock_002"
-        }, {
+        },
+        {
             "_id": "b30c60f716bceb6abbd4f120",
             "_tpl": "61825d06d92c473c770215de",
             "parentId": "16426ac6c6fede5eeb28e114",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "46caee1cad8fe55e143f0090",
             "_tpl": "6181688c6c780c1e710c9b04",
             "parentId": "16426ac6c6fede5eeb28e114",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "fa7a7b8c6abdad1f8a9d1eaa",
             "_tpl": "5dcbd56fdbd3d91b3e5468d5",
             "parentId": "hideout",
@@ -6768,32 +7741,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ffadfafc9badf07fdeb27d34",
             "_tpl": "5dcbd6dddbd3d91b3e5468de",
             "parentId": "fa7a7b8c6abdad1f8a9d1eaa",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "5afee0589b02ababbece187e",
             "_tpl": "5a3501acc4a282000d72293a",
             "parentId": "fa7a7b8c6abdad1f8a9d1eaa",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "a7deefed40ba414009f3d21a",
             "_tpl": "5dcbd6b46ec07c0c4347a564",
             "parentId": "fa7a7b8c6abdad1f8a9d1eaa",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "f4d8c039eba8cca7719a6dc6",
             "_tpl": "5dcbe9431e1f4616d354987e",
             "parentId": "fa7a7b8c6abdad1f8a9d1eaa",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "6fb37e228adbe9ed2b960b84",
             "_tpl": "5dcbe965e4ed22586443a79d",
             "parentId": "f4d8c039eba8cca7719a6dc6",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "19a87af0baebfa18bbecbfeb",
             "_tpl": "5cadfbf7ae92152ac412eeef",
             "parentId": "hideout",
@@ -6804,37 +7783,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "da673bfd35a5ba9973a7b1cb",
             "_tpl": "5caf17c9ae92150b30006be1",
             "parentId": "19a87af0baebfa18bbecbfeb",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "2beaef8fec0dcc4cf408c752",
             "_tpl": "5caf1041ae92157c28402e3f",
             "parentId": "19a87af0baebfa18bbecbfeb",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "bf830c9abd9d19ddc8181e4c",
             "_tpl": "5caf16a2ae92152ac412efbc",
             "parentId": "19a87af0baebfa18bbecbfeb",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "fffbff84fdfa4bd04930e43b",
             "_tpl": "5cdaa99dd7f00c002412d0b2",
             "parentId": "19a87af0baebfa18bbecbfeb",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "4c4c4cad668ccd5d5abdefdc",
             "_tpl": "5cda9bcfd7f00c0c0b53e900",
             "parentId": "fffbff84fdfa4bd04930e43b",
             "slotId": "mod_foregrip"
-        }, {
+        },
+        {
             "_id": "e72df0c78cb81b0ad61dab7a",
             "_tpl": "5caf1691ae92152ac412efb9",
             "parentId": "19a87af0baebfa18bbecbfeb",
             "slotId": "mod_scope"
-        }, {
+        },
+        {
             "_id": "dccbe2319a8d86bdafa1a8cc",
             "_tpl": "64b7af434b75259c590fa893",
             "parentId": "hideout",
@@ -6845,7 +7831,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "96ce24efde7f7fdb74b7cd72",
             "_tpl": "64b7af434b75259c590fa893",
             "parentId": "hideout",
@@ -6856,7 +7843,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7d33ea8e2eaaad24ada9a92c",
             "_tpl": "64b7af5a8532cf95ee0a0dbd",
             "parentId": "hideout",
@@ -6867,7 +7855,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "997dd0e96ce2ea6ffbb2bfae",
             "_tpl": "64b7af5a8532cf95ee0a0dbd",
             "parentId": "hideout",
@@ -6878,7 +7867,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f714e6fac3aa8ac5ab5e8b0b",
             "_tpl": "64b7af734b75259c590fa895",
             "parentId": "hideout",
@@ -6889,7 +7879,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "2acaff8c0e4dbaf8e84f5c4d",
             "_tpl": "64b7af734b75259c590fa895",
             "parentId": "hideout",
@@ -6900,7 +7891,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a9d7eabebf51477f7d615d66",
             "_tpl": "6529243824cbe3c74a05e5c1",
             "parentId": "hideout",
@@ -6911,7 +7903,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "1d966fc3c05c0cfbfb6db0bb",
             "_tpl": "6529243824cbe3c74a05e5c1",
             "parentId": "hideout",
@@ -6922,7 +7915,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bda2ff902bc93909425bf53f",
             "_tpl": "6529302b8c26af6326029fb7",
             "parentId": "hideout",
@@ -6933,7 +7927,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c7e1f40ffae087ecc96ceaaf",
             "_tpl": "6529302b8c26af6326029fb7",
             "parentId": "hideout",
@@ -6944,7 +7939,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d2ee8d41b52c9cdbc83cfd74",
             "_tpl": "6576f96220d53a5b8f3e395e",
             "parentId": "hideout",
@@ -6955,7 +7951,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "0ffccaa6b7cead2daeea355b",
             "_tpl": "6576f96220d53a5b8f3e395e",
             "parentId": "hideout",
@@ -6966,7 +7963,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "1ab4be0cf384fb2a35a00fdd",
             "_tpl": "65293c38fc460e50a509cb25",
             "parentId": "hideout",
@@ -6977,7 +7975,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d8542abf28bfc3e8358503bb",
             "_tpl": "65293c7a17e14363030ad308",
             "parentId": "hideout",
@@ -6988,7 +7987,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "dd2dda5ed65fa75cd9b5e0d4",
             "_tpl": "6183afd850224f204c1da514",
             "parentId": "hideout",
@@ -6999,77 +7999,92 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "4ee053ee2bb1ccda9bd25eda",
             "_tpl": "55d4b9964bdc2d1d4e8b456e",
             "parentId": "dd2dda5ed65fa75cd9b5e0d4",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "e64a7b1e8ebdea1e40b3b855",
             "_tpl": "618168dc8004cc50514c34fc",
             "parentId": "dd2dda5ed65fa75cd9b5e0d4",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "c4ec49550e3cfb82d2c35b8a",
             "_tpl": "6165adcdd3a39d50044c120f",
             "parentId": "dd2dda5ed65fa75cd9b5e0d4",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "4865b3fa2c0ab7e08b08cbd7",
             "_tpl": "61816dfa6ef05c2ce828f1ad",
             "parentId": "c4ec49550e3cfb82d2c35b8a",
             "slotId": "mod_mount_001"
-        }, {
+        },
+        {
             "_id": "a81f7a00b443b4aa4ede8690",
             "_tpl": "61816df1d3a39d50044c139e",
             "parentId": "c4ec49550e3cfb82d2c35b8a",
             "slotId": "mod_mount_000"
-        }, {
+        },
+        {
             "_id": "5ecee622ffb9a5f1710cfbe4",
             "_tpl": "61817865d3a39d50044c13a4",
             "parentId": "c4ec49550e3cfb82d2c35b8a",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "d5decbe4afa6bb5ccaa6c8be",
             "_tpl": "6183b084a112697a4b3a6e6c",
             "parentId": "c4ec49550e3cfb82d2c35b8a",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "394fb6b88110edddcda238a5",
             "_tpl": "61816fcad92c473c770215cc",
             "parentId": "d5decbe4afa6bb5ccaa6c8be",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "5f363dc0b8a21f911a8e83c3",
             "_tpl": "618178aa1cb55961fa0fdc80",
             "parentId": "d5decbe4afa6bb5ccaa6c8be",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "dbedc64e247aa0dfe0fa5f37",
             "_tpl": "61816734d8e3106d9806c1f3",
             "parentId": "dd2dda5ed65fa75cd9b5e0d4",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "6cda89ec7cadcd3ed2b77cdf",
             "_tpl": "618167441cb55961fa0fdc71",
             "parentId": "dbedc64e247aa0dfe0fa5f37",
             "slotId": "mod_stock_002"
-        }, {
+        },
+        {
             "_id": "6dac69fb7b13ca293888ceca",
             "_tpl": "618167528004cc50514c34f9",
             "parentId": "dbedc64e247aa0dfe0fa5f37",
             "slotId": "mod_stock_001"
-        }, {
+        },
+        {
             "_id": "ce776dc79aefff257834cacf",
             "_tpl": "618167616ef05c2ce828f1a8",
             "parentId": "6dac69fb7b13ca293888ceca",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "3f9dafa71e9aaabfcf8a0c21",
             "_tpl": "6181688c6c780c1e710c9b04",
             "parentId": "dd2dda5ed65fa75cd9b5e0d4",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "12e2cbbcd0fc1a2f9eef88d6",
             "_tpl": "623063e994fc3f7b302a9696",
             "parentId": "hideout",
@@ -7080,52 +8095,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "78dd6ebc2ed7a6f3f8ed8a9a",
             "_tpl": "62307b7b10d2321fa8741921",
             "parentId": "12e2cbbcd0fc1a2f9eef88d6",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "ee0b7f54fa9a5113a1ab11d0",
             "_tpl": "622f140da5958f63c67f1735",
             "parentId": "12e2cbbcd0fc1a2f9eef88d6",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "a0bdffc5ace5a0f57ff27259",
             "_tpl": "622b38c56762c718e457e246",
             "parentId": "12e2cbbcd0fc1a2f9eef88d6",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "0a313431edf09cf23f94053f",
             "_tpl": "622b327b267a1b13a44abea3",
             "parentId": "a0bdffc5ace5a0f57ff27259",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "c689c6fcca9a5cc85e259bd2",
             "_tpl": "622f128cec80d870d349b4e8",
             "parentId": "a0bdffc5ace5a0f57ff27259",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "605ead4693af6ce3cf0ff4cf",
             "_tpl": "6231654c71b5bc3baa1078e5",
             "parentId": "12e2cbbcd0fc1a2f9eef88d6",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "1809dee4d54ea2fa73869ae5",
             "_tpl": "622f02437762f55aaa68ac85",
             "parentId": "12e2cbbcd0fc1a2f9eef88d6",
             "slotId": "mod_mount"
-        }, {
+        },
+        {
             "_id": "6a0485e6f1427a56bedc12c1",
             "_tpl": "622b4d7df9cfc87d675d2ded",
             "parentId": "12e2cbbcd0fc1a2f9eef88d6",
             "slotId": "mod_scope"
-        }, {
+        },
+        {
             "_id": "ec02c81c21afedcabeaac058",
             "_tpl": "622efbcb99f4ea1a4d6c9a15",
             "parentId": "6a0485e6f1427a56bedc12c1",
             "slotId": "mod_scope"
-        }, {
+        },
+        {
             "_id": "ac0c9fbb17a1afe29a70903d",
             "_tpl": "62e7c4fba689e8c9c50dfc38",
             "parentId": "hideout",
@@ -7136,37 +8161,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "563f2a6be6bdfe73adbfa3c9",
             "_tpl": "62e7c98b550c8218d602cbb4",
             "parentId": "ac0c9fbb17a1afe29a70903d",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "ff3ccecbc890cb8edfdfbd8d",
             "_tpl": "62e7c880f68e7a0676050c7c",
             "parentId": "ac0c9fbb17a1afe29a70903d",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "c9ee43fd9504877bdca3b4c3",
             "_tpl": "62ea7c793043d74a0306e19f",
             "parentId": "ac0c9fbb17a1afe29a70903d",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "19e29ed0abfe83250d93ff38",
             "_tpl": "62e7c7f3c34ea971710c32fc",
             "parentId": "c9ee43fd9504877bdca3b4c3",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "405cabcf3db9bd7edb9f71b8",
             "_tpl": "634e61b0767cb15c4601a877",
             "parentId": "19e29ed0abfe83250d93ff38",
             "slotId": "mod_foregrip"
-        }, {
+        },
+        {
             "_id": "a2fe540ddc6dc14b3f4aa8ea",
             "_tpl": "630f2872911356c17d06abc5",
             "parentId": "19e29ed0abfe83250d93ff38",
             "slotId": "mod_muzzle_000"
-        }, {
+        },
+        {
             "_id": "ad8a5ee6aea053d6ba1e9949",
             "_tpl": "63171672192e68c5460cebc5",
             "parentId": "hideout",
@@ -7177,42 +8209,50 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c105a4b9cd02e3cfac60749e",
             "_tpl": "62e7c98b550c8218d602cbb4",
             "parentId": "ad8a5ee6aea053d6ba1e9949",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "5bc3de1aacd8edff4aaf253f",
             "_tpl": "62ebbc53e3c1e1ec7c02c44f",
             "parentId": "ad8a5ee6aea053d6ba1e9949",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "cb6edfade8997e810cea7eb9",
             "_tpl": "62e7c72df68e7a0676050c77",
             "parentId": "ad8a5ee6aea053d6ba1e9949",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "85effdfc60cf2ba6bdfcb523",
             "_tpl": "62ebd290c427473eff0baafb",
             "parentId": "cb6edfade8997e810cea7eb9",
             "slotId": "mod_mount"
-        }, {
+        },
+        {
             "_id": "b8afa3f0a0bbfeef18cc64ad",
             "_tpl": "62e7c7f3c34ea971710c32fc",
             "parentId": "cb6edfade8997e810cea7eb9",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "ce584fdac9cf8dae56d10603",
             "_tpl": "634e61b0767cb15c4601a877",
             "parentId": "b8afa3f0a0bbfeef18cc64ad",
             "slotId": "mod_foregrip"
-        }, {
+        },
+        {
             "_id": "bf461845cad15ce331c1c535",
             "_tpl": "630f28f0cadb1fe05e06f004",
             "parentId": "b8afa3f0a0bbfeef18cc64ad",
             "slotId": "mod_muzzle_000"
-        }, {
+        },
+        {
             "_id": "accce84b4fbbec3a50c3f0b9",
             "_tpl": "628a60ae6b1d481ff772e9c8",
             "parentId": "hideout",
@@ -7223,52 +8263,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "124ce8d8eecc799f3bd9cca8",
             "_tpl": "628a83c29179c324ed269508",
             "parentId": "accce84b4fbbec3a50c3f0b9",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "cbcbf4af24eccdfccdd8d924",
             "_tpl": "628a66b41d5e41750e314f34",
             "parentId": "accce84b4fbbec3a50c3f0b9",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "cf9b17cee6ecdd8aff8177fc",
             "_tpl": "628a664bccaab13006640e47",
             "parentId": "accce84b4fbbec3a50c3f0b9",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "cecacc7495bcccdbeb7be74c",
             "_tpl": "628a665a86cbd9750d2ff5e5",
             "parentId": "accce84b4fbbec3a50c3f0b9",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "17c0d9a1c4bbd97f824e9af1",
             "_tpl": "628a7b23b0f75035732dd565",
             "parentId": "accce84b4fbbec3a50c3f0b9",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "4ed4fdffce842f5be3c6fba1",
             "_tpl": "628a6678ccaab13006640e49",
             "parentId": "accce84b4fbbec3a50c3f0b9",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "a1b9bdfe05ec1a21cdfdf911",
             "_tpl": "5649be884bdc2d79388b4577",
             "parentId": "4ed4fdffce842f5be3c6fba1",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "ebedf5955ed95968b9bce1c9",
             "_tpl": "628a85ee6b1d481ff772e9d5",
             "parentId": "a1b9bdfe05ec1a21cdfdf911",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "bbfbce81898ceabc06f66b0e",
             "_tpl": "59d625f086f774661516605d",
             "parentId": "accce84b4fbbec3a50c3f0b9",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "19d9df7a326dbb28a8d4c0ee",
             "_tpl": "628b5638ad252a16da6dd245",
             "parentId": "hideout",
@@ -7279,52 +8329,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "96fbd2f3b0b0a00eb7b2d652",
             "_tpl": "628b8d83717774443b15e248",
             "parentId": "19d9df7a326dbb28a8d4c0ee",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "1fabd3fa6c808c3de1f8702a",
             "_tpl": "628b916469015a4e1711ed8d",
             "parentId": "96fbd2f3b0b0a00eb7b2d652",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "8b0666062f5eadffee0c6db1",
             "_tpl": "628b9be6cff66b70c002b14c",
             "parentId": "1fabd3fa6c808c3de1f8702a",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "6d9a9539e2697dab8a63baf5",
             "_tpl": "628b9471078f94059a4b9bfb",
             "parentId": "8b0666062f5eadffee0c6db1",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "6096f30e5bd6b239233cdef0",
             "_tpl": "5ac7655e5acfc40016339a19",
             "parentId": "19d9df7a326dbb28a8d4c0ee",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "794dcc7e77c9e9da4d50d294",
             "_tpl": "5cf50850d7f00c056e24104c",
             "parentId": "19d9df7a326dbb28a8d4c0ee",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "0ac98c6cef9bade98b0dac71",
             "_tpl": "628b9a40717774443b15e9f2",
             "parentId": "19d9df7a326dbb28a8d4c0ee",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "79d1dbdc53bd74878a7f14dd",
             "_tpl": "55d4ae6c4bdc2d8b2f8b456e",
             "parentId": "0ac98c6cef9bade98b0dac71",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "2db603115efcb87390b29ceb",
             "_tpl": "55d480c04bdc2d1d4e8b456a",
             "parentId": "19d9df7a326dbb28a8d4c0ee",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "1a5e752edad847aa77c3e4ad",
             "_tpl": "628b9c37a733087d0d7fe84b",
             "parentId": "hideout",
@@ -7335,52 +8395,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7d15c29bdaa09dbff4fe1384",
             "_tpl": "628b8d83717774443b15e248",
             "parentId": "1a5e752edad847aa77c3e4ad",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "ccc8ca856bddcaaebed24cff",
             "_tpl": "628b916469015a4e1711ed8d",
             "parentId": "7d15c29bdaa09dbff4fe1384",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "d60bfdf2de02e9329d1b7cdb",
             "_tpl": "628b9be6cff66b70c002b14c",
             "parentId": "ccc8ca856bddcaaebed24cff",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "c63fba3e4cb7aefe3a6cda2f",
             "_tpl": "628b9471078f94059a4b9bfb",
             "parentId": "d60bfdf2de02e9329d1b7cdb",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "e44a8fe9ce9c40dddbde8af3",
             "_tpl": "5943eeeb86f77412d6384f6b",
             "parentId": "1a5e752edad847aa77c3e4ad",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "3accd204f4bb1cde6caaf8ef",
             "_tpl": "5cf50850d7f00c056e24104c",
             "parentId": "1a5e752edad847aa77c3e4ad",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "8f321fecaa04cff40903a655",
             "_tpl": "628b9a40717774443b15e9f2",
             "parentId": "1a5e752edad847aa77c3e4ad",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "e4b3dbbec9b6d2ff1cbb2bcc",
             "_tpl": "55d4ae6c4bdc2d8b2f8b456e",
             "parentId": "8f321fecaa04cff40903a655",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "2b89e5c64621db6d6fb7d3cf",
             "_tpl": "55d480c04bdc2d1d4e8b456a",
             "parentId": "1a5e752edad847aa77c3e4ad",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "e7a17a4ff2bcd5f406f03da7",
             "_tpl": "6499849fc93611967b034949",
             "parentId": "hideout",
@@ -7391,62 +8461,74 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a3bee5bbd43fae8bfdfa48fc",
             "_tpl": "649ec107961514b22506b10c",
             "parentId": "e7a17a4ff2bcd5f406f03da7",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "9db55a0cc2aaf5ef85aa56d2",
             "_tpl": "5beec8ea0db834001a6f9dbf",
             "parentId": "e7a17a4ff2bcd5f406f03da7",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "95f2839eb5d4ad81ad5ddeba",
             "_tpl": "649ec127c93611967b034957",
             "parentId": "e7a17a4ff2bcd5f406f03da7",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "a7d1e35fbd85eeaf6dce26a5",
             "_tpl": "5beecbb80db834001d2c465e",
             "parentId": "95f2839eb5d4ad81ad5ddeba",
             "slotId": "mod_mount_001"
-        }, {
+        },
+        {
             "_id": "1ad58ddbd0602fdcdc31f8fa",
             "_tpl": "649ec2af961514b22506b10f",
             "parentId": "e7a17a4ff2bcd5f406f03da7",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "d72bc8bd80d7fbb9f0adaa3e",
             "_tpl": "649ec2f3961514b22506b111",
             "parentId": "e7a17a4ff2bcd5f406f03da7",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "62ef5bd30bcf0ccfe1bba72a",
             "_tpl": "649ec2da59cbb3c813042dca",
             "parentId": "d72bc8bd80d7fbb9f0adaa3e",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "2e4d3c0dcc32a3d4c30a8b7a",
             "_tpl": "649ec2cec93611967b03495e",
             "parentId": "62ef5bd30bcf0ccfe1bba72a",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "a5bacfc3f4faaa2a6b7bc898",
             "_tpl": "649ec30cb013f04a700e60fb",
             "parentId": "e7a17a4ff2bcd5f406f03da7",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "b7bafc6cbedaf621fa65ed9c",
             "_tpl": "649ec87d8007560a9001ab36",
             "parentId": "e7a17a4ff2bcd5f406f03da7",
             "slotId": "mod_stock_001"
-        }, {
+        },
+        {
             "_id": "cb7c7f95ef743aecafbf3e8e",
             "_tpl": "5beec8c20db834001d2c465c",
             "parentId": "b7bafc6cbedaf621fa65ed9c",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "13950de5b6675e5c3a833dde",
             "_tpl": "65290f395ae2ae97b80fdf2d",
             "parentId": "hideout",
@@ -7457,77 +8539,92 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "1e9fce7240b50eb7abf0b59a",
             "_tpl": "652911675ae2ae97b80fdf3c",
             "parentId": "13950de5b6675e5c3a833dde",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "3ccfc5b91349a7451fae8bba",
             "_tpl": "65293c38fc460e50a509cb25",
             "parentId": "13950de5b6675e5c3a833dde",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "b78d0a35bb55a0f1ae2a0da9",
             "_tpl": "6529119424cbe3c74a05e5bb",
             "parentId": "13950de5b6675e5c3a833dde",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "a9400beb6dfa5aa839cbb7c1",
             "_tpl": "652910ef50dc782999054b97",
             "parentId": "b78d0a35bb55a0f1ae2a0da9",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "f6599af9b05dbe0feb38e54d",
             "_tpl": "652910565ae2ae97b80fdf35",
             "parentId": "b78d0a35bb55a0f1ae2a0da9",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "e7a2f21fc0aaea792ebd24fa",
             "_tpl": "652910bc24cbe3c74a05e5b9",
             "parentId": "f6599af9b05dbe0feb38e54d",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "aa56aab5dc844a77b1957fd3",
             "_tpl": "6529113b5ae2ae97b80fdf39",
             "parentId": "f6599af9b05dbe0feb38e54d",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "4de68e3de4da4dc2bb0a1d89",
             "_tpl": "652911e650dc782999054b9d",
             "parentId": "aa56aab5dc844a77b1957fd3",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "4eebb010ebf7fcf9c2a4aded",
             "_tpl": "6567e751a715f85433025998",
             "parentId": "b78d0a35bb55a0f1ae2a0da9",
             "slotId": "mod_scope"
-        }, {
+        },
+        {
             "_id": "360af6c1faea3b4959ea740b",
             "_tpl": "6567e7681265c8a131069b0f",
             "parentId": "4eebb010ebf7fcf9c2a4aded",
             "slotId": "mod_scope"
-        }, {
+        },
+        {
             "_id": "e65c10fa79cafdedfea06e1f",
             "_tpl": "6529348224cbe3c74a05e5c4",
             "parentId": "13950de5b6675e5c3a833dde",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "d2e2cdf6b583ba90eba72cdc",
             "_tpl": "6529366450dc782999054ba0",
             "parentId": "e65c10fa79cafdedfea06e1f",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "c3051bffdcc537fe2eafcd0d",
             "_tpl": "6529370c405a5f51dd023db8",
             "parentId": "d2e2cdf6b583ba90eba72cdc",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "cae2adce4a7a8a09da22605c",
             "_tpl": "6529109524cbe3c74a05e5b7",
             "parentId": "13950de5b6675e5c3a833dde",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "0e9daeadadafdced379c78fc",
             "_tpl": "6183afd850224f204c1da514",
             "parentId": "hideout",
@@ -7538,77 +8635,92 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "2d214f16dabdea5e2d4a69db",
             "_tpl": "55d4b9964bdc2d1d4e8b456e",
             "parentId": "0e9daeadadafdced379c78fc",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "6e4b6da1e51ad9aea9034c46",
             "_tpl": "618168dc8004cc50514c34fc",
             "parentId": "0e9daeadadafdced379c78fc",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "502e9b39fdbcacc37ae734c0",
             "_tpl": "6165adcdd3a39d50044c120f",
             "parentId": "0e9daeadadafdced379c78fc",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "fb8923cdf99cf0e1bfee5897",
             "_tpl": "61816dfa6ef05c2ce828f1ad",
             "parentId": "502e9b39fdbcacc37ae734c0",
             "slotId": "mod_mount_001"
-        }, {
+        },
+        {
             "_id": "bb665c2c6274c686ec02c91f",
             "_tpl": "61816df1d3a39d50044c139e",
             "parentId": "502e9b39fdbcacc37ae734c0",
             "slotId": "mod_mount_000"
-        }, {
+        },
+        {
             "_id": "daa7c0d6bbc1ab7dd7edcb8e",
             "_tpl": "61817865d3a39d50044c13a4",
             "parentId": "502e9b39fdbcacc37ae734c0",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "b9fb17b919bb5fdee9ba14f4",
             "_tpl": "6183b084a112697a4b3a6e6c",
             "parentId": "502e9b39fdbcacc37ae734c0",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "2daea8a6dbc3d68cf866e885",
             "_tpl": "61816fcad92c473c770215cc",
             "parentId": "b9fb17b919bb5fdee9ba14f4",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "47be32c5915ac2da9510ffdc",
             "_tpl": "618178aa1cb55961fa0fdc80",
             "parentId": "b9fb17b919bb5fdee9ba14f4",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "f73703492ecbee16d533a1b3",
             "_tpl": "61816734d8e3106d9806c1f3",
             "parentId": "0e9daeadadafdced379c78fc",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "6b5c0f12ccb35aad75cba064",
             "_tpl": "618167441cb55961fa0fdc71",
             "parentId": "f73703492ecbee16d533a1b3",
             "slotId": "mod_stock_002"
-        }, {
+        },
+        {
             "_id": "8e6fdbab5bd6e3beb3beff6f",
             "_tpl": "618167528004cc50514c34f9",
             "parentId": "f73703492ecbee16d533a1b3",
             "slotId": "mod_stock_001"
-        }, {
+        },
+        {
             "_id": "c68d3dd7fbe7a1f34e9423d7",
             "_tpl": "618167616ef05c2ce828f1a8",
             "parentId": "8e6fdbab5bd6e3beb3beff6f",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "3df9c7f89bf598a04cd3f5ce",
             "_tpl": "6181688c6c780c1e710c9b04",
             "parentId": "0e9daeadadafdced379c78fc",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "2a2fcf4b17f8905fcbd18c02",
             "_tpl": "623063e994fc3f7b302a9696",
             "parentId": "hideout",
@@ -7619,52 +8731,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f266baab3afb1e5dbe5c4b4b",
             "_tpl": "62307b7b10d2321fa8741921",
             "parentId": "2a2fcf4b17f8905fcbd18c02",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "ee3b8ce9facf0356558c3e95",
             "_tpl": "622f140da5958f63c67f1735",
             "parentId": "2a2fcf4b17f8905fcbd18c02",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "47df8a1bf6dbf6153245a285",
             "_tpl": "622b38c56762c718e457e246",
             "parentId": "2a2fcf4b17f8905fcbd18c02",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "6eadccff3195cd95b0bdb6db",
             "_tpl": "622b327b267a1b13a44abea3",
             "parentId": "47df8a1bf6dbf6153245a285",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "aa6acfe6c4ba3b9dec23df56",
             "_tpl": "622f128cec80d870d349b4e8",
             "parentId": "47df8a1bf6dbf6153245a285",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "5e3516764de3193e18ffbfdd",
             "_tpl": "6231654c71b5bc3baa1078e5",
             "parentId": "2a2fcf4b17f8905fcbd18c02",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "1fdef3a0505fb2f0aaec0a71",
             "_tpl": "622f02437762f55aaa68ac85",
             "parentId": "2a2fcf4b17f8905fcbd18c02",
             "slotId": "mod_mount"
-        }, {
+        },
+        {
             "_id": "adae9d7ff57ceea9f08c8516",
             "_tpl": "622b4d7df9cfc87d675d2ded",
             "parentId": "2a2fcf4b17f8905fcbd18c02",
             "slotId": "mod_scope"
-        }, {
+        },
+        {
             "_id": "7bac56a64e802e047eb1b3a6",
             "_tpl": "622efbcb99f4ea1a4d6c9a15",
             "parentId": "adae9d7ff57ceea9f08c8516",
             "slotId": "mod_scope"
-        }, {
+        },
+        {
             "_id": "debdcc752ca60d8087a6df4d",
             "_tpl": "62e7c4fba689e8c9c50dfc38",
             "parentId": "hideout",
@@ -7675,37 +8797,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "9f6a6fba84ab4fe3bb9a95d2",
             "_tpl": "62e7c98b550c8218d602cbb4",
             "parentId": "debdcc752ca60d8087a6df4d",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "e881cac08ee9adbddeb2fb03",
             "_tpl": "62e7c880f68e7a0676050c7c",
             "parentId": "debdcc752ca60d8087a6df4d",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "e343a1464052b2d3f65b9abe",
             "_tpl": "62ea7c793043d74a0306e19f",
             "parentId": "debdcc752ca60d8087a6df4d",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "fc19f4bebeaf429bd506be5c",
             "_tpl": "62e7c7f3c34ea971710c32fc",
             "parentId": "e343a1464052b2d3f65b9abe",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "cdb9abf8c10bb66d9cbe2e28",
             "_tpl": "634e61b0767cb15c4601a877",
             "parentId": "fc19f4bebeaf429bd506be5c",
             "slotId": "mod_foregrip"
-        }, {
+        },
+        {
             "_id": "ad3693ce1991f94abc4ae7ce",
             "_tpl": "630f2872911356c17d06abc5",
             "parentId": "fc19f4bebeaf429bd506be5c",
             "slotId": "mod_muzzle_000"
-        }, {
+        },
+        {
             "_id": "bdfefe4ecb28f112e49eabdd",
             "_tpl": "63171672192e68c5460cebc5",
             "parentId": "hideout",
@@ -7716,42 +8845,50 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f6d9ddbaeaec28e67ea4ba21",
             "_tpl": "62e7c98b550c8218d602cbb4",
             "parentId": "bdfefe4ecb28f112e49eabdd",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "3dabf151dbb723cce48dcd4b",
             "_tpl": "62ebbc53e3c1e1ec7c02c44f",
             "parentId": "bdfefe4ecb28f112e49eabdd",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "bdd670eefeffc9a6e383cfe7",
             "_tpl": "62e7c72df68e7a0676050c77",
             "parentId": "bdfefe4ecb28f112e49eabdd",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "c7d2bd9905af9ede92aa3ab2",
             "_tpl": "62ebd290c427473eff0baafb",
             "parentId": "bdd670eefeffc9a6e383cfe7",
             "slotId": "mod_mount"
-        }, {
+        },
+        {
             "_id": "4dca32e186410c6c868f990c",
             "_tpl": "62e7c7f3c34ea971710c32fc",
             "parentId": "bdd670eefeffc9a6e383cfe7",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "f09fbeaf713b38127bfe6cef",
             "_tpl": "634e61b0767cb15c4601a877",
             "parentId": "4dca32e186410c6c868f990c",
             "slotId": "mod_foregrip"
-        }, {
+        },
+        {
             "_id": "7a3eb4e6eaff1a7dcad7f99b",
             "_tpl": "630f28f0cadb1fe05e06f004",
             "parentId": "4dca32e186410c6c868f990c",
             "slotId": "mod_muzzle_000"
-        }, {
+        },
+        {
             "_id": "1eebaa8b0df8b85864bd9dd1",
             "_tpl": "628a60ae6b1d481ff772e9c8",
             "parentId": "hideout",
@@ -7762,52 +8899,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c7de6ec7edee8cfefa7a3c7f",
             "_tpl": "628a83c29179c324ed269508",
             "parentId": "1eebaa8b0df8b85864bd9dd1",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "bff2beec4b28bea81cef3d65",
             "_tpl": "628a66b41d5e41750e314f34",
             "parentId": "1eebaa8b0df8b85864bd9dd1",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "bf8cd7b1efba8b3a06ffddda",
             "_tpl": "628a664bccaab13006640e47",
             "parentId": "1eebaa8b0df8b85864bd9dd1",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "5c1e04e17947bb9a8e99babb",
             "_tpl": "628a665a86cbd9750d2ff5e5",
             "parentId": "1eebaa8b0df8b85864bd9dd1",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "cbad8f20acff2cdf5ddbeea5",
             "_tpl": "628a7b23b0f75035732dd565",
             "parentId": "1eebaa8b0df8b85864bd9dd1",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "fef58ebb10f8f12df31adecc",
             "_tpl": "628a6678ccaab13006640e49",
             "parentId": "1eebaa8b0df8b85864bd9dd1",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "8b19d81de1448dbb1cecfb25",
             "_tpl": "5649be884bdc2d79388b4577",
             "parentId": "fef58ebb10f8f12df31adecc",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "2ab9ceec57615ad5e554c6ae",
             "_tpl": "628a85ee6b1d481ff772e9d5",
             "parentId": "8b19d81de1448dbb1cecfb25",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "6fa8d4a3bdd476c3e85c1d6d",
             "_tpl": "59d625f086f774661516605d",
             "parentId": "1eebaa8b0df8b85864bd9dd1",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "e06d1d5bd0bafc5daa43beab",
             "_tpl": "628b5638ad252a16da6dd245",
             "parentId": "hideout",
@@ -7818,52 +8965,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "6ea5de2acd2acdf2fcadd3a3",
             "_tpl": "628b8d83717774443b15e248",
             "parentId": "e06d1d5bd0bafc5daa43beab",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "bd28ba49bb7ca553f144e0ce",
             "_tpl": "628b916469015a4e1711ed8d",
             "parentId": "6ea5de2acd2acdf2fcadd3a3",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "a72a6cd7a70adc27e04f1a80",
             "_tpl": "628b9be6cff66b70c002b14c",
             "parentId": "bd28ba49bb7ca553f144e0ce",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "8fc5ce7aa3bad9ba83c63de5",
             "_tpl": "628b9471078f94059a4b9bfb",
             "parentId": "a72a6cd7a70adc27e04f1a80",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "3abc23fbb17be5d77ac23f73",
             "_tpl": "5ac7655e5acfc40016339a19",
             "parentId": "e06d1d5bd0bafc5daa43beab",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "ac5193c3a1ecb1ec5de75dbe",
             "_tpl": "5cf50850d7f00c056e24104c",
             "parentId": "e06d1d5bd0bafc5daa43beab",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "d2ef807d94ecef396ff26a54",
             "_tpl": "628b9a40717774443b15e9f2",
             "parentId": "e06d1d5bd0bafc5daa43beab",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "64c4aab6f8c9faf067e4f6ea",
             "_tpl": "55d4ae6c4bdc2d8b2f8b456e",
             "parentId": "d2ef807d94ecef396ff26a54",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "03596af173f8c68cfa2398d3",
             "_tpl": "55d480c04bdc2d1d4e8b456a",
             "parentId": "e06d1d5bd0bafc5daa43beab",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "3bb7bf8716b6edd9cfeb7c01",
             "_tpl": "628b9c37a733087d0d7fe84b",
             "parentId": "hideout",
@@ -7874,52 +9031,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ae79bf9312e63fe0aa0176c2",
             "_tpl": "628b8d83717774443b15e248",
             "parentId": "3bb7bf8716b6edd9cfeb7c01",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "f5babefbf369402b6ca25c5c",
             "_tpl": "628b916469015a4e1711ed8d",
             "parentId": "ae79bf9312e63fe0aa0176c2",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "f5e46c9272a5bd3c39b56b7c",
             "_tpl": "628b9be6cff66b70c002b14c",
             "parentId": "f5babefbf369402b6ca25c5c",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "4e5dafbdad3c9db2fbf8c8be",
             "_tpl": "628b9471078f94059a4b9bfb",
             "parentId": "f5e46c9272a5bd3c39b56b7c",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "64dcfa2e4d77c6bc7b86bc7d",
             "_tpl": "5943eeeb86f77412d6384f6b",
             "parentId": "3bb7bf8716b6edd9cfeb7c01",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "fba4d6bdfbffcb4943dab3f9",
             "_tpl": "5cf50850d7f00c056e24104c",
             "parentId": "3bb7bf8716b6edd9cfeb7c01",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "b31fafe4fafcb1fd88eb1e2d",
             "_tpl": "628b9a40717774443b15e9f2",
             "parentId": "3bb7bf8716b6edd9cfeb7c01",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "44cdc766b7eaf2afc904e9d1",
             "_tpl": "55d4ae6c4bdc2d8b2f8b456e",
             "parentId": "b31fafe4fafcb1fd88eb1e2d",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "630c03c22172eedfee12fd42",
             "_tpl": "55d480c04bdc2d1d4e8b456a",
             "parentId": "3bb7bf8716b6edd9cfeb7c01",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "a2f6071ed03fa6bba2d0d151",
             "_tpl": "6499849fc93611967b034949",
             "parentId": "hideout",
@@ -7930,62 +9097,74 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d05eb2cccaeb8ef69e0f97bc",
             "_tpl": "649ec107961514b22506b10c",
             "parentId": "a2f6071ed03fa6bba2d0d151",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "cf1f8bf3ce0fcf46d9fbf9f4",
             "_tpl": "5beec8ea0db834001a6f9dbf",
             "parentId": "a2f6071ed03fa6bba2d0d151",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "046e891c5f835caba7652558",
             "_tpl": "649ec127c93611967b034957",
             "parentId": "a2f6071ed03fa6bba2d0d151",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "c87becfcedfabc6a02dc135d",
             "_tpl": "5beecbb80db834001d2c465e",
             "parentId": "046e891c5f835caba7652558",
             "slotId": "mod_mount_001"
-        }, {
+        },
+        {
             "_id": "af96c2f6abfa927d0b0a727b",
             "_tpl": "649ec2af961514b22506b10f",
             "parentId": "a2f6071ed03fa6bba2d0d151",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "541ee4f7619eb413eecedee8",
             "_tpl": "649ec2f3961514b22506b111",
             "parentId": "a2f6071ed03fa6bba2d0d151",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "831a5e2ccefcaff29fada6a0",
             "_tpl": "649ec2da59cbb3c813042dca",
             "parentId": "541ee4f7619eb413eecedee8",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "35fa030abceea2fe7e1ea678",
             "_tpl": "649ec2cec93611967b03495e",
             "parentId": "831a5e2ccefcaff29fada6a0",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "8deda7fefaab2545e49a1aaa",
             "_tpl": "649ec30cb013f04a700e60fb",
             "parentId": "a2f6071ed03fa6bba2d0d151",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "cecc14afcbfcf510324bd1d1",
             "_tpl": "649ec87d8007560a9001ab36",
             "parentId": "a2f6071ed03fa6bba2d0d151",
             "slotId": "mod_stock_001"
-        }, {
+        },
+        {
             "_id": "8a2723a28b317bf6cc2de1a3",
             "_tpl": "5beec8c20db834001d2c465c",
             "parentId": "cecc14afcbfcf510324bd1d1",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "aaf6d69efa9cacf60adc7f8e",
             "_tpl": "65290f395ae2ae97b80fdf2d",
             "parentId": "hideout",
@@ -7996,77 +9175,92 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "cc659acaacbb1c3d11e1be2c",
             "_tpl": "652911675ae2ae97b80fdf3c",
             "parentId": "aaf6d69efa9cacf60adc7f8e",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "bbc4dba2cbf0da5f50cb90a7",
             "_tpl": "65293c38fc460e50a509cb25",
             "parentId": "aaf6d69efa9cacf60adc7f8e",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "2b59ddcddfe94a9a9b840fef",
             "_tpl": "6529119424cbe3c74a05e5bb",
             "parentId": "aaf6d69efa9cacf60adc7f8e",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "800b32bbe6abcaeedf9d3b67",
             "_tpl": "652910ef50dc782999054b97",
             "parentId": "2b59ddcddfe94a9a9b840fef",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "56710e8acdf16de24bf0eacb",
             "_tpl": "652910565ae2ae97b80fdf35",
             "parentId": "2b59ddcddfe94a9a9b840fef",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "27ccceeac258b7fb2c5ba0eb",
             "_tpl": "652910bc24cbe3c74a05e5b9",
             "parentId": "56710e8acdf16de24bf0eacb",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "282e1688caac5ec37cc3dce3",
             "_tpl": "6529113b5ae2ae97b80fdf39",
             "parentId": "56710e8acdf16de24bf0eacb",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "e932e7ef224ac79aa1ef00fc",
             "_tpl": "652911e650dc782999054b9d",
             "parentId": "282e1688caac5ec37cc3dce3",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "7bdd1b5f1acbe09ba3e99ae0",
             "_tpl": "6567e751a715f85433025998",
             "parentId": "2b59ddcddfe94a9a9b840fef",
             "slotId": "mod_scope"
-        }, {
+        },
+        {
             "_id": "db9f5a3cfa608befaa14e6fe",
             "_tpl": "6567e7681265c8a131069b0f",
             "parentId": "7bdd1b5f1acbe09ba3e99ae0",
             "slotId": "mod_scope"
-        }, {
+        },
+        {
             "_id": "0193df8c68fbfe91a6cdd5ba",
             "_tpl": "6529348224cbe3c74a05e5c4",
             "parentId": "aaf6d69efa9cacf60adc7f8e",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "f6a5e745c3c63f64713ed5eb",
             "_tpl": "6529366450dc782999054ba0",
             "parentId": "0193df8c68fbfe91a6cdd5ba",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "ac56bbe327fc9aadbcb0a0d0",
             "_tpl": "6529370c405a5f51dd023db8",
             "parentId": "f6a5e745c3c63f64713ed5eb",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "559a771fa1dc1b49acca8827",
             "_tpl": "6529109524cbe3c74a05e5b7",
             "parentId": "aaf6d69efa9cacf60adc7f8e",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "d98ab051c5da92d456bcdc1f",
             "_tpl": "62307b7b10d2321fa8741921",
             "parentId": "hideout",
@@ -8077,7 +9271,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ae52b4abba99e7fd158401bd",
             "_tpl": "630e1adbbd357927e4007c09",
             "parentId": "hideout",
@@ -8088,7 +9283,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "eacecba5bed5b258dddf2eaf",
             "_tpl": "62e7c98b550c8218d602cbb4",
             "parentId": "hideout",
@@ -8099,7 +9295,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "edf9df344ec677aacbb52f9f",
             "_tpl": "630e295c984633f1fb0e7c30",
             "parentId": "hideout",
@@ -8110,7 +9307,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e6a60edaacc44e043b69aad4",
             "_tpl": "649ec30cb013f04a700e60fb",
             "parentId": "hideout",
@@ -8121,7 +9319,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "667b4b8efce0ac366aed9eb7",
             "_tpl": "55d4887d4bdc2d962f8b4570",
             "parentId": "hideout",

--- a/db/traders/6765fbd20fdc7eb79b00000c/assort.json
+++ b/db/traders/6765fbd20fdc7eb79b00000c/assort.json
@@ -1,2048 +1,1789 @@
 {
     "barter_scheme": {
         "f7afeb9dcd44e5c2df0fdebe": [
-            [
-                {
+            [{
                     "_tpl": "590a3d9c86f774385926e510",
                     "count": 10
-                },
-                {
+                }, {
                     "_tpl": "590c645c86f77412b01304d9",
                     "count": 5
                 }
             ]
         ],
         "51a485bf649f505b4ce23cbc": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60000
                 }
             ]
         ],
         "eee701afcd64ac958917f38b": [
-            [
-                {
+            [{
                     "_tpl": "57513f9324597720a7128161",
                     "count": 2
                 }
             ]
         ],
         "ff2be5592cff0c39dc6ce2f4": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2800
                 }
             ]
         ],
         "09e0f2ebb6ddec747acfa310": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 6000
                 }
             ]
         ],
         "acfeabef6feadb2bcdff8b6f": [
-            [
-                {
+            [{
                     "_tpl": "5c0d5ae286f7741e46554302",
                     "count": 3
                 }
             ]
         ],
         "befaa9e78a9be7dc3dbaddd7": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 165
                 }
             ]
         ],
         "bec8baa49d915d21f3cf3946": [
-            [
-                {
+            [{
                     "_tpl": "59e6906286f7746c9f75e847",
                     "count": 6
                 }
             ]
         ],
         "1c23fd6f997fea6aab4092df": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 660
                 }
             ]
         ],
         "1825ca0ed5fbdab1b5cc7bba": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 17000
                 }
             ]
         ],
         "da7ed5414ccfc4564efaabd6": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1500
                 }
             ]
         ],
         "0bdbccfd208aeea0ddc47cce": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 30000
                 }
             ]
         ],
         "b7b0dde96e10bde42d78a1da": [
-            [
-                {
+            [{
                     "_tpl": "5d1b39a386f774252339976f",
                     "count": 5
                 }
             ]
         ],
         "9c5ef2be33cc074cc80fd688": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3300
                 }
             ]
         ],
         "97d8e98fdedbb04209ba6ea3": [
-            [
-                {
+            [{
                     "_tpl": "59e4d24686f7741776641ac7",
                     "count": 3
                 }
             ]
         ],
         "03b2fb63acf4bfe6fe0e72f5": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 225
                 }
             ]
         ],
         "51300aa813b4dae28bdca525": [
-            [
-                {
+            [{
                     "_tpl": "56dff2ced2720bb4668b4567",
                     "count": 6
                 }
             ]
         ],
         "c6c5b6bbf2c02eafe2a409af": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 590
                 }
             ]
         ],
         "45dd1a0dd42cb8b7613ffed6": [
-            [
-                {
+            [{
                     "_tpl": "61962b617c6c7b169525f168",
                     "count": 3
                 }
             ]
         ],
         "5b0af0012b6eafbc8ad2719e": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 740
                 }
             ]
         ],
         "d1fd1ed131adc6edf787facd": [
-            [
-                {
+            [{
                     "_tpl": "56dfef82d2720bbd668b4567",
                     "count": 2
                 }
             ]
         ],
         "cdd1ac8a6ff37aa0d0a075fd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 500
                 }
             ]
         ],
         "d8be427c92cebf3fbadfffba": [
-            [
-                {
+            [{
                     "_tpl": "56dff4ecd2720b5f5a8b4568",
                     "count": 2
                 }
             ]
         ],
         "a8f5f4b32432094bf88584fa": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 90
                 }
             ]
         ],
         "caf1de383b3581f1bffc6030": [
-            [
-                {
+            [{
                     "_tpl": "56dff421d2720b5f5a8b4567",
                     "count": 4
                 }
             ]
         ],
         "fe19a2dcbac6ce46f4ebbb02": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 45
                 }
             ]
         ],
         "cedad22a07a58bcb25e5013b": [
-            [
-                {
+            [{
                     "_tpl": "56dff3afd2720bba668b4567",
                     "count": 2
                 }
             ]
         ],
         "a5fac979afb4bdfeddda0eb9": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 205
                 }
             ]
         ],
         "dffb5680abbcfbc31faec6b6": [
-            [
-                {
+            [{
                     "_tpl": "56dff216d2720bbd668b4568",
                     "count": 2
                 }
             ]
         ],
         "5cab97f1b7972fba8773ac4d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 54
                 }
             ]
         ],
         "b85ebc4dee217a25b8a3cc32": [
-            [
-                {
+            [{
                     "_tpl": "56dff4a2d2720bbd668b456a",
                     "count": 3
                 }
             ]
         ],
         "5ae1d9ecacebd3325d720dbe": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 130
                 }
             ]
         ],
         "3cae97dbd4c5d296fd1aecde": [
-            [
-                {
+            [{
                     "_tpl": "573719762459775a626ccbc1",
                     "count": 3
                 }
             ]
         ],
         "7be0adcab6acc382e17becd2": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 63
                 }
             ]
         ],
         "addc13cb33a8fb54eb3237da": [
-            [
-                {
+            [{
                     "_tpl": "56dff0bed2720bb0668b4567",
                     "count": 2
                 }
             ]
         ],
         "bbf7baeca1b654c5c9f0bcfb": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 82
                 }
             ]
         ],
         "dd396513b7f0d941a4e7bdc4": [
-            [
-                {
+            [{
                     "_tpl": "56dff338d2720bbd668b4569",
                     "count": 2
                 }
             ]
         ],
         "14ea806be1d4475cf9fbce2d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 82
                 }
             ]
         ],
         "36b47feeadeeface1d34eecf": [
-            [
-                {
+            [{
                     "_tpl": "5d0375ff86f774186372f685",
                     "count": 1
                 }
             ]
         ],
         "caf3d9bf3d2bf4efd49ece0b": [
-            [
-                {
+            [{
                     "_tpl": "59e361e886f774176c10a2a5",
                     "count": 4
                 }
             ]
         ],
         "267823eb62a2f7acf8cfceb5": [
-            [
-                {
+            [{
                     "_tpl": "5d4041f086f7743cac3f22a7",
                     "count": 2
                 }
             ]
         ],
         "75fe098ddbb4f58bbe3c17cc": [
-            [
-                {
+            [{
                     "_tpl": "5d03784a86f774203e7e0c4d",
                     "count": 2
                 }
             ]
         ],
         "edbdebc5a978f4f73afeedea": [
-            [
-                {
+            [{
                     "_tpl": "5e2aee0a86f774755a234b62",
                     "count": 2
                 }
             ]
         ],
         "c70681b0caba7a7c4a9551dd": [
-            [
-                {
+            [{
                     "_tpl": "5d1b32c186f774252167a530",
                     "count": 1
                 }
             ]
         ],
         "6ffbead04e4e9bf14db45e9c": [
-            [
-                {
+            [{
                     "_tpl": "5d1b304286f774253763a528",
                     "count": 1
                 }
             ]
         ],
         "57932e2b7dce3ebb31ba4a08": [
-            [
-                {
+            [{
                     "_tpl": "5d1b392c86f77425243e98fe",
                     "count": 4
                 }
             ]
         ],
         "ad6bb74e267087fc01c9fd1e": [
-            [
-                {
+            [{
                     "_tpl": "5751496424597720a27126da",
                     "count": 2
                 }
             ]
         ],
         "7e3872a04bef1b68da53ddaf": [
-            [
-                {
+            [{
                     "_tpl": "57514643245977207f2c2d09",
                     "count": 3
                 }
             ]
         ],
         "3bd165f6627ba5d97bdabaa5": [
-            [
-                {
+            [{
                     "_tpl": "59e358a886f7741776641ac3",
                     "count": 2
                 }
             ]
         ],
         "acd38f7af0feacccbce1ce3c": [
-            [
-                {
+            [{
                     "_tpl": "57347d5f245977448b40fa81",
                     "count": 1
                 }
             ]
         ],
         "ccde5ef196dcf7d4f7c0ad84": [
-            [
-                {
+            [{
                     "_tpl": "5e2af2bc86f7746d3f3c33fc",
                     "count": 2
                 }
             ]
         ],
         "507bfdceec87dbcbe7a28081": [
-            [
-                {
+            [{
                     "_tpl": "5bc9c29cd4351e003562b8a3",
                     "count": 1
                 }
             ]
         ],
         "851dafd2930c1452d223755b": [
-            [
-                {
+            [{
                     "_tpl": "5672cb304bdc2dc2088b456a",
                     "count": 1
                 }
             ]
         ],
         "f55e3c9de4a7abd5afe4c2df": [
-            [
-                {
+            [{
                     "_tpl": "57347d90245977448f7b7f65",
                     "count": 2
                 }
             ]
         ],
         "73b0fc2dd4c9c1f3543cd9c1": [
-            [
-                {
+            [{
                     "_tpl": "590a386e86f77429692b27ab",
                     "count": 2
                 }
             ]
         ],
         "ad5ec232ca5bbeae937bb5ad": [
-            [
-                {
+            [{
                     "_tpl": "5751435d24597720a27126d1",
                     "count": 1
                 }
             ]
         ],
         "bbadda2559edb2baf09d5dc1": [
-            [
-                {
+            [{
                     "_tpl": "5734779624597737e04bf329",
                     "count": 2
                 }
             ]
         ],
         "ac71f96dbe4b231cadcee132": [
-            [
-                {
+            [{
                     "_tpl": "59e35abd86f7741778269d82",
                     "count": 1
                 }
             ]
         ],
         "3eecf5deccce8335fccaffd1": [
-            [
-                {
+            [{
                     "_tpl": "575062b524597720a31c09a1",
                     "count": 1
                 }
             ]
         ],
         "ebcdcc2b7eb9c20ab06acaf5": [
-            [
-                {
+            [{
                     "_tpl": "5c13cd2486f774072c757944",
                     "count": 2
                 }
             ]
         ],
         "fdfcedae16be8feddc0ea7ee": [
-            [
-                {
+            [{
                     "_tpl": "57347d8724597744596b4e76",
                     "count": 2
                 }
             ]
         ],
         "cabdb4c1495b6815b4ba9f51": [
-            [
-                {
+            [{
                     "_tpl": "544fb6cc4bdc2d34748b456e",
                     "count": 1
                 }
             ]
         ],
         "7ddc89ffbe95aaac2e3e4ac3": [
-            [
-                {
+            [{
                     "_tpl": "5448ff904bdc2d6f028b456e",
                     "count": 1
                 }
             ]
         ],
         "53d1c415aeddbb8fbeceb0ef": [
-            [
-                {
+            [{
                     "_tpl": "544fb62a4bdc2dfb738b4568",
                     "count": 1
                 }
             ]
         ],
         "4ec114a9eb0dfafdb5facafe": [
-            [
-                {
+            [{
                     "_tpl": "57513fcc24597720a31c09a6",
                     "count": 1
                 }
             ]
         ],
         "2ff88da5b0a91bd0feaacac7": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5600
                 }
             ]
         ],
         "44dbab6cee357ded1e3b729f": [
-            [
-                {
+            [{
                     "_tpl": "5e023cf8186a883be655e54f",
                     "count": 2
                 }
             ]
         ],
         "a6debb8e4c29f589c5d9c3db": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 205
                 }
             ]
         ],
         "d3934fcbf9db76cffbf0e971": [
-            [
-                {
+            [{
                     "_tpl": "57a0dfb82459774d3078b56c",
                     "count": 4
                 }
             ]
         ],
         "bac7a48f8a8eba54a6abd1ac": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 880
                 }
             ]
         ],
         "e506bfbaddaf6cf680f4d3a7": [
-            [
-                {
+            [{
                     "_tpl": "59e36c6f86f774176c10a2a7",
                     "count": 3
                 }
             ]
         ],
         "0751b54d74e5bccbcbdaf625": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 21000
                 }
             ]
         ],
         "243a72c0ecab68e63ef4ba65": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 26000
                 }
             ]
         ],
         "b6d8749a9b609e46eb910dca": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60000
                 }
             ]
         ],
         "aba8dd2f419d3f90e42aabcf": [
-            [
-                {
+            [{
                     "_tpl": "5e023e88277cce2b522ff2b1",
                     "count": 3
                 }
             ]
         ],
         "e3b3d99c6be49f6ca07560a1": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 390
                 }
             ]
         ],
         "ae3d89a1f2366cddefdbf3f6": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 14500
                 }
             ]
         ],
         "f63d3e4ae77e8abdfe36d7af": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 37500
                 }
             ]
         ],
         "0e6da835c1a9f1edda83df89": [
-            [
-                {
+            [{
                     "_tpl": "5656d7c34bdc2d9d198b4587",
                     "count": 5
                 }
             ]
         ],
         "2cdea03f665c4ce65c7d1f1e": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1050
                 }
             ]
         ],
         "6aa3acbe6be11ce5ed522ce1": [
-            [
-                {
+            [{
                     "_tpl": "5a38ebd9c4a282000d722a5b",
                     "count": 4
                 }
             ]
         ],
         "cf7f0cf0b168de8bad9dbada": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 185
                 }
             ]
         ],
         "fe2aa27f123fc25e462af7b6": [
-            [
-                {
+            [{
                     "_tpl": "59e4d3d286f774176a36250a",
                     "count": 3
                 }
             ]
         ],
         "e523a8d2d5ab18ddcbbbb827": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 150
                 }
             ]
         ],
         "6921eaa048c0405619f2948d": [
-            [
-                {
+            [{
                     "_tpl": "59e4cf5286f7741778269d8a",
                     "count": 4
                 }
             ]
         ],
         "690ba255e7d8ed06ec14f87d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 65
                 }
             ]
         ],
         "b2ef9af5e4aa25efee78a9ec": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 930
                 }
             ]
         ],
         "3daccfae304d967f54cef4bb": [
-            [
-                {
+            [{
                     "_tpl": "5734781f24597737e04bf32a",
                     "count": 3
                 }
             ]
         ],
         "cd706d2bc5c4e45dfeb87b57": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 26250
                 }
             ]
         ],
         "38beda0d56a9c7636acfcd1f": [
-            [
-                {
+            [{
                     "_tpl": "590a386e86f77429692b27ab",
                     "count": 4
                 }
             ]
         ],
         "cba9defaede775b699fafea7": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 29000
                 }
             ]
         ],
         "d4dbec374aeddbcaab371ffd": [
-            [
-                {
+            [{
                     "_tpl": "60194943740c5d77f6705eea",
                     "count": 4
                 }
             ]
         ],
         "afd727ab3a4cc49c59f4ba4e": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 95
                 }
             ]
         ],
         "4eaaaffcabc67c45bed2e97e": [
-            [
-                {
+            [{
                     "_tpl": "59e68f6f86f7746c9f75e846",
                     "count": 2
                 }
             ]
         ],
         "9a707c8ebfb1d1d14d05c867": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 400
                 }
             ]
         ],
         "bfbfac0770bde5ab59d90fbc": [
-            [
-                {
+            [{
                     "_tpl": "54527ac44bdc2d36668b4567",
                     "count": 2
                 }
             ]
         ],
         "5cc11aa5f5afd1befeb8aa3b": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1200
                 }
             ]
         ],
         "c392f5cafebb09f0d2cbacce": [
-            [
-                {
+            [{
                     "_tpl": "59e6927d86f77411da468256",
                     "count": 3
                 }
             ]
         ],
         "e27cc9d11b5fe4dda9c8a16e": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 80
                 }
             ]
         ],
         "af5833ffb06b7b103bd80bdb": [
-            [
-                {
+            [{
                     "_tpl": "59e6918f86f7746c9f75e849",
                     "count": 3
                 }
             ]
         ],
         "73cbff75d4bbdd6bbf76362d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 120
                 }
             ]
         ],
         "0aa1e4932e90c16b2c7ddbee": [
-            [
-                {
+            [{
                     "_tpl": "58820d1224597753c90aeb13",
                     "count": 2
                 }
             ]
         ],
         "cd106018ca64ceacb8ff2f9c": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 45
                 }
             ]
         ],
         "6ea1ffe9eee54b1cf36376cf": [
-            [
-                {
+            [{
                     "_tpl": "573477e124597737dd42e191",
                     "count": 1
-                },
-                {
+                }, {
                     "_tpl": "5bc9c29cd4351e003562b8a3",
                     "count": 2
                 }
             ]
         ],
         "ec82a5f1dfb49c7c191ef8bd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 36600
                 }
             ]
         ],
         "9fedefc8bf5bbf109deee2eb": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 42000
                 }
             ]
         ],
         "4147f4c1ccaef366bfccec6b": [
-            [
-                {
+            [{
                     "_tpl": "5a608bf24f39f98ffc77720e",
                     "count": 2
                 }
             ]
         ],
         "d4cd7de283faedfbbe72abd1": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1100
                 }
             ]
         ],
         "7e5f4bd20de1cc072b1bd1ac": [
-            [
-                {
+            [{
                     "_tpl": "58dd3ad986f77403051cba8f",
                     "count": 6
                 }
             ]
         ],
         "379aa33c1fbf1afbfeba5f8d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 550
                 }
             ]
         ],
         "0b59f7cfdee039c2b1ef60cd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 18600
                 }
             ]
         ],
         "769bf3edae3ccccefdabaecf": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1860
                 }
             ]
         ],
         "b9b6184222b2a9f7a8a1381e": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 33000
                 }
             ]
         ],
         "25d9cdc19f953ca2b7e2e19d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 37000
                 }
             ]
         ],
         "60c72fc9bbd53cbeec2a0867": [
-            [
-                {
+            [{
                     "_tpl": "5d1b39a386f774252339976f",
                     "count": 2
-                },
-                {
+                }, {
                     "_tpl": "57347c1124597737fb1379e3",
                     "count": 3
                 }
             ]
         ],
         "bafde5fee8bf01e574dffdfd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 33300
                 }
             ]
         ],
         "b0e4c1aadbd05c70bb4bae11": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1700
                 }
             ]
         ],
         "9dd2c749743a53c9efa92df6": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 42000
                 }
             ]
         ],
         "d55017fe6e6cf9e0bfeb4dcd": [
-            [
-                {
+            [{
                     "_tpl": "590c645c86f77412b01304d9",
                     "count": 3
                 }
             ]
         ],
         "268df6124c7584f8acd980ed": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 57000
                 }
             ]
         ],
         "eb9e0f0277f7b85f2c513e55": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 45000
                 }
             ]
         ],
         "bbeaaaedce2a9bf8fd1a8251": [
-            [
-                {
+            [{
                     "_tpl": "5d403f9186f7743cac3f229b",
                     "count": 2
-                },
-                {
+                }, {
                     "_tpl": "5bc9c377d4351e3bac12251b",
                     "count": 2
                 }
             ]
         ],
         "bc3eee4fb6caeaef28b91a85": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 46000
                 }
             ]
         ],
         "5bf4e8e362ffdfdb08c8ddee": [
-            [
-                {
+            [{
                     "_tpl": "5af0548586f7743a532b7e99",
                     "count": 2
                 }
             ]
         ],
         "e6a9ac9a2a6d58d04642b3b2": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 37500
                 }
             ]
         ],
         "7cbf7a98ba8c769aa75c04fa": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5400
                 }
             ]
         ],
         "24f5d14dd6a1d2f4d5dedaab": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 18000
                 }
             ]
         ],
         "b1c647f0b20aa881ba8fd022": [
-            [
-                {
+            [{
                     "_tpl": "590a373286f774287540368b",
                     "count": 5
                 }
             ]
         ],
         "cf3bc468503c7cfec45ebada": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 95000
                 }
             ]
         ],
         "9b1f0add467fc69d1bc4ccb4": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3300
                 }
             ]
         ],
         "f5fbec96e2bde57b45bceacd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24500
                 }
             ]
         ],
         "1ffe68bf509adbcc118b7ece": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2800
                 }
             ]
         ],
         "dcab6a885f5298acfab2ebfd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 4400
                 }
             ]
         ],
         "009d6cecd1806d108ca1f87d": [
-            [
-                {
+            [{
                     "_tpl": "5c07df7f0db834001b73588a",
                     "count": 5
                 }
             ]
         ],
         "f7253aa7fdb140fe0e3fb6d2": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 77500
                 }
             ]
         ],
         "ef57451fccdd2dab9877e7c9": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2550
                 }
             ]
         ],
         "f5dc47ad4ca0c2eecb6dbdbc": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 30000
                 }
             ]
         ],
         "ead9d3a507d7d92f2e24b9a0": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 31000
                 }
             ]
         ],
         "b076af4f8db6d01773b6ec8d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2250
                 }
             ]
         ],
         "df6171d1caf99a2a2731aeea": [
-            [
-                {
+            [{
                     "_tpl": "5d1b2ffd86f77425243e8d17",
                     "count": 1
                 }
             ]
         ],
         "ed1d018635ec71b82a0fdf69": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 36600
                 }
             ]
         ],
         "bbc9ffadaceab18bcfbd9ec2": [
-            [
-                {
+            [{
                     "_tpl": "59e6920f86f77411d82aa167",
                     "count": 3
                 }
             ]
         ],
         "feaec87b5a2fdd40ffa3fe4f": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 120
                 }
             ]
         ],
         "eafae65d6aad97aceca88ac7": [
-            [
-                {
+            [{
                     "_tpl": "56dff026d2720bb8668b4567",
                     "count": 2
                 }
             ]
         ],
         "28bfa3ec60199dc7bde5edfd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1200
                 }
             ]
         ],
         "4d2ff8d2c0ccadf9b93c90d0": [
-            [
-                {
+            [{
                     "_tpl": "61962d879bb3d20b0946d385",
                     "count": 2
                 }
             ]
         ],
         "5ef33313f8f51144ae07f65f": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 420
                 }
             ]
         ],
         "b8284dc99eed2dac03e047a4": [
-            [
-                {
+            [{
                     "_tpl": "5c0d668f86f7747ccb7f13b2",
                     "count": 3
                 }
             ]
         ],
         "be0bad95ab0da15c1ab12214": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1200
                 }
             ]
         ],
         "afeb2a8f9c2808713f59aacf": [
-            [
-                {
+            [{
                     "_tpl": "5448fee04bdc2dbc018b4567",
                     "count": 1
                 }
             ]
         ],
         "ee3fde0c8c92e698bd9bd19f": [
-            [
-                {
+            [{
                     "_tpl": "590a3d9c86f774385926e510",
                     "count": 1
                 }
             ]
         ],
         "aab4525ecf51da1f42fcd762": [
-            [
-                {
+            [{
                     "_tpl": "590c31c586f774245e3141b2",
                     "count": 2
                 }
             ]
         ],
         "1754f6dbbfa616d96eb70fcc": [
-            [
-                {
+            [{
                     "_tpl": "5d1b2fa286f77425227d1674",
                     "count": 1
                 }
             ]
         ],
         "8a099caacbfbf8b1dcdaf63b": [
-            [
-                {
+            [{
                     "_tpl": "5b4335ba86f7744d2837a264",
                     "count": 7
                 }
             ]
         ],
         "2c2953acc3228daceef9f38d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 94000
                 }
             ]
         ],
         "ea9ac15897f831abaf7b1211": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3600
                 }
             ]
         ],
         "3252770cddbeb28272aa70c7": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 38000
                 }
             ]
         ],
         "068d2acdaeeebbdbced8cb9f": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 34000
                 }
             ]
         ],
         "7e9679dec77bb78d6efba17b": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3400
                 }
             ]
         ],
         "60a6fef0eea83306ecc3c048": [
-            [
-                {
+            [{
                     "_tpl": "5cadf6e5ae921500113bb973",
                     "count": 5
                 }
             ]
         ],
         "c10f9da0a3cdc89fd50df6ff": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 340
                 }
             ]
         ],
         "09c7ad74c8d8f4f3f5e7ffdd": [
-            [
-                {
+            [{
                     "_tpl": "560d5e524bdc2d25448b4571",
                     "count": 10
                 }
             ]
         ],
         "7c5baaacf488e2abad22f2d1": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 210
                 }
             ]
         ],
         "8cc0e55afbbbeb4155258a4d": [
-            [
-                {
+            [{
                     "_tpl": "5cadf6ddae9215051e1c23b2",
                     "count": 3
                 }
             ]
         ],
         "22cfd4ea7fcbff22238357c1": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 840
                 }
             ]
         ],
         "b88ad5eb1bdebda76f6aff1f": [
-            [
-                {
+            [{
                     "_tpl": "590c392f86f77444754deb29",
                     "count": 4
                 }
             ]
         ],
         "19a87af0baebfa18bbecbfeb": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 106000
                 }
             ]
         ],
         "c7f609cf854ed2d2a2d2a49a": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 6000
                 }
             ]
         ],
         "0dead76e1dc5cdb01db6abc1": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 15500
                 }
             ]
         ],
         "acd6e280bed6cd2af5c9cb1e": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1900
                 }
             ]
         ],
         "a11cffe3dad659dced532fed": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 27000
                 }
             ]
         ],
         "5db2bc2d1aa10e5dcc26d799": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5700
                 }
             ]
         ],
         "f0eaf4f5a4a65d9ef3f9478f": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24600
                 }
             ]
         ],
         "525e9188f021e8b2acff23be": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5700
                 }
             ]
         ],
         "b6ff87ecb676eef0a7d0c5ea": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3600
                 }
             ]
         ],
         "dedfbfbeace1d679e4da8bdd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5200
                 }
             ]
         ],
         "f4061aa0190c0c542fa5eadf": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 4600
                 }
             ]
         ],
         "d3f4fad38fbd5a9c885ffb7b": [
-            [
-                {
+            [{
                     "_tpl": "59e3577886f774176a362503",
                     "count": 8
                 }
             ]
         ],
         "dab7c8f57398c5eba1a7a9cd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 183000
                 }
             ]
         ],
         "ccfd666d9cbcaa0da2bbffcf": [
-            [
-                {
+            [{
                     "_tpl": "590c651286f7741e566b6461",
                     "count": 6
                 }
             ]
         ],
         "fa7a7b8c6abdad1f8a9d1eaa": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 123000
                 }
             ]
         ],
         "80a3e7b7fc957d25ceefa219": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2250
                 }
             ]
         ],
         "edefb4eeb3d4e7ef61fd351c": [
-            [
-                {
+            [{
                     "_tpl": "58864a4f2459770fcc257101",
                     "count": 2
                 }
             ]
         ],
         "08032bf34904cddba9dc7c94": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 225
                 }
             ]
         ],
         "3a153a2ade193cc210e32712": [
-            [
-                {
+            [{
                     "_tpl": "5e023e53d4353e3302577c4c",
                     "count": 3
                 }
             ]
         ],
         "dca9ffdfd90ff5fd4d6cc9d0": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 160
                 }
             ]
         ],
         "ef8d6189a0ac59db6f9aafcf": [
-            [
-                {
+            [{
                     "_tpl": "5e023e6e34d52a55c3304f71",
                     "count": 5
                 }
             ]
         ],
         "39e1acb06dbcfbe6d4640dba": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 98
                 }
             ]
         ],
         "fc44da03ac88feee8bde7fbd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 4800
                 }
             ]
         ],
         "a39ac3e862cce0de1eff0cca": [
-            [
-                {
+            [{
                     "_tpl": "5a6086ea4f39f99cd479502f",
                     "count": 3
                 }
             ]
         ],
         "1e0942ffd38bae1b29f8ee34": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1500
                 }
             ]
         ],
         "9ce25be3e360b9a02c34bfeb": [
-            [
-                {
+            [{
                     "_tpl": "573478bc24597738002c6175",
                     "count": 5
                 }
             ]
         ],
         "8ecb75b20c8fefdc113e9bf2": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 76000
                 }
             ]
         ],
         "a4df4950e5655243d23e00ff": [
-            [
-                {
+            [{
                     "_tpl": "54527a984bdc2d4e668b4567",
                     "count": 4
                 }
             ]
         ],
         "a37ee9bde17850b919eaf0ba": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 270
                 }
             ]
         ],
         "acd2a2d83adfb4bfd7d1b04d": [
-            [
-                {
+            [{
                     "_tpl": "59e690b686f7746c9f75e848",
                     "count": 3
                 }
             ]
         ],
         "744cefdce2142d0ddbcb7fff": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1400
                 }
             ]
         ],
         "779deae5707a54522bdaa6ca": [
-            [
-                {
+            [{
                     "_tpl": "59e0d99486f7744a32234762",
                     "count": 4
                 }
             ]
         ],
         "e0f97cb7b2afb81efbee3d05": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1200
                 }
             ]
         ],
         "afd34f681f6efeaa0321bb84": [
-            [
-                {
+            [{
                     "_tpl": "5d1b317c86f7742523398392",
                     "count": 1
-                },
-                {
+                }, {
                     "_tpl": "5d63d33b86f7746ea9275524",
                     "count": 5
                 }
             ]
         ],
         "ddacd746b270532e7c761c07": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 98000
                 }
             ]
         ],
         "ab2dc3ce4e83c14fa8d7ec23": [
-            [
-                {
+            [{
                     "_tpl": "61bf7b6302b3924be92fa8c3",
                     "count": 6
-                },
-                {
+                }, {
                     "_tpl": "619cbfeb6b8a1b37a54eebfa",
                     "count": 2
                 }
             ]
         ],
         "16426ac6c6fede5eeb28e114": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 110000
                 }
             ]
         ],
         "721924cb66db16bffacd4d06": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 22500
                 }
             ]
         ],
         "61bac5b8c3a2c58b10e35ad6": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3100
                 }
             ]
         ],
         "66ca525ad612fc82421fbaa3": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3700
                 }
             ]
         ],
         "d7aa8ebca8cacbc741cafd9a": [
-            [
-                {
+            [{
                     "_tpl": "619cbfccbedcde2f5b3f7bdd",
                     "count": 2
                 }
             ]
         ],
         "ddcdced49ce92c83f133a8b8": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 85000
                 }
             ]
         ],
         "1e53fcc5df55cc4baeb7a9ac": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1900
                 }
             ]
         ],
         "de85b4dc3eaa6fbe1aaade6c": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 78000
                 }
             ]
         ],
         "aac07961f94d3ec2d9600f5d": [
-            [
-                {
+            [{
                     "_tpl": "56dff061d2720bb5668b4567",
                     "count": 4
                 }
             ]
         ],
         "cbe2c68fda18333b59afadd0": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 750
                 }
             ]
         ],
         "e2da3ebbadea1fe55aa25c99": [
-            [
-                {
+            [{
                     "_tpl": "57a0e5022459774d1673f889",
                     "count": 2
                 }
             ]
         ],
         "02ceeeaeb7ffcab7df0e7fde": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 580
                 }
             ]
         ],
         "dccbe2319a8d86bdafa1a8cc": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "96ce24efde7f7fdb74b7cd72": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 660
                 }
             ]
         ],
         "7d33ea8e2eaaad24ada9a92c": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "997dd0e96ce2ea6ffbb2bfae": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 120
                 }
             ]
         ],
         "f714e6fac3aa8ac5ab5e8b0b": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "2acaff8c0e4dbaf8e84f5c4d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 85
                 }
             ]
         ],
         "a9d7eabebf51477f7d615d66": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "1d966fc3c05c0cfbfb6db0bb": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 950
                 }
             ]
         ],
         "bda2ff902bc93909425bf53f": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "c7e1f40ffae087ecc96ceaaf": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 450
                 }
             ]
         ],
         "d2ee8d41b52c9cdbc83cfd74": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "0ffccaa6b7cead2daeea355b": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 120
                 }
             ]
         ],
         "1ab4be0cf384fb2a35a00fdd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3100
                 }
             ]
         ],
         "d8542abf28bfc3e8358503bb": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 4500
                 }
             ]
         ],
         "0e9daeadadafdced379c78fc": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "dd2dda5ed65fa75cd9b5e0d4": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 110000
                 }
             ]
         ],
         "2a2fcf4b17f8905fcbd18c02": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "12e2cbbcd0fc1a2f9eef88d6": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 63000
                 }
             ]
         ],
         "1eebaa8b0df8b85864bd9dd1": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "accce84b4fbbec3a50c3f0b9": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 90000
                 }
             ]
         ],
         "e06d1d5bd0bafc5daa43beab": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "19d9df7a326dbb28a8d4c0ee": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 66000
                 }
             ]
         ],
         "3bb7bf8716b6edd9cfeb7c01": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "1a5e752edad847aa77c3e4ad": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 75000
                 }
             ]
         ],
         "debdcc752ca60d8087a6df4d": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "ac0c9fbb17a1afe29a70903d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 57000
                 }
             ]
         ],
         "bdfefe4ecb28f112e49eabdd": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "ad8a5ee6aea053d6ba1e9949": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 64000
                 }
             ]
         ],
         "a2f6071ed03fa6bba2d0d151": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "e7a17a4ff2bcd5f406f03da7": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 66000
                 }
             ]
         ],
         "aaf6d69efa9cacf60adc7f8e": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "13950de5b6675e5c3a833dde": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 190000
                 }
             ]
         ],
         "d98ab051c5da92d456bcdc1f": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2100
                 }
             ]
         ],
         "ae52b4abba99e7fd158401bd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1400
                 }
             ]
         ],
         "eacecba5bed5b258dddf2eaf": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3000
                 }
             ]
         ],
         "edf9df344ec677aacbb52f9f": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 7500
                 }
             ]
         ],
         "e6a60edaacc44e043b69aad4": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3600
                 }
             ]
         ],
         "667b4b8efce0ac366aed9eb7": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1700
                 }
             ]
         ]
     },
-    "items": [
-        {
+    "items": [{
             "_id": "09c7ad74c8d8f4f3f5e7ffdd",
             "_tpl": "5cadf6e5ae921500113bb973",
             "parentId": "hideout",
@@ -2053,8 +1794,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "60a6fef0eea83306ecc3c048",
             "_tpl": "5cadf6ddae9215051e1c23b2",
             "parentId": "hideout",
@@ -2065,8 +1805,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "0dead76e1dc5cdb01db6abc1",
             "_tpl": "5caf1109ae9215753c44119f",
             "parentId": "hideout",
@@ -2077,8 +1816,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "8cc0e55afbbbeb4155258a4d",
             "_tpl": "5cadf6eeae921500134b2799",
             "parentId": "hideout",
@@ -2089,8 +1827,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7c5baaacf488e2abad22f2d1",
             "_tpl": "5cadf6e5ae921500113bb973",
             "parentId": "hideout",
@@ -2101,8 +1838,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c10f9da0a3cdc89fd50df6ff",
             "_tpl": "5cadf6ddae9215051e1c23b2",
             "parentId": "hideout",
@@ -2113,8 +1849,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "22cfd4ea7fcbff22238357c1",
             "_tpl": "5cadf6eeae921500134b2799",
             "parentId": "hideout",
@@ -2125,8 +1860,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "3cae97dbd4c5d296fd1aecde",
             "_tpl": "56dff421d2720b5f5a8b4567",
             "parentId": "hideout",
@@ -2137,8 +1871,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "4ec114a9eb0dfafdb5facafe",
             "_tpl": "573733c72459776b0b7b51b0",
             "parentId": "hideout",
@@ -2149,14 +1882,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d05fa7bd2725e7fda3fed110",
             "_tpl": "56dff421d2720b5f5a8b4567",
             "parentId": "4ec114a9eb0dfafdb5facafe",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 30
+            }
+        }, {
             "_id": "caf1de383b3581f1bffc6030",
             "_tpl": "56dff216d2720bbd668b4568",
             "parentId": "hideout",
@@ -2167,8 +1902,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "53d1c415aeddbb8fbeceb0ef",
             "_tpl": "5737339e2459776af261abeb",
             "parentId": "hideout",
@@ -2179,14 +1913,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a373a1aaf894bcabb62bc805",
             "_tpl": "56dff216d2720bbd668b4568",
             "parentId": "53d1c415aeddbb8fbeceb0ef",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 30
+            }
+        }, {
             "_id": "dffb5680abbcfbc31faec6b6",
             "_tpl": "56dff338d2720bbd668b4569",
             "parentId": "hideout",
@@ -2197,8 +1933,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "851dafd2930c1452d223755b",
             "_tpl": "57372e4a24597768553071c2",
             "parentId": "hideout",
@@ -2209,14 +1944,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "cba9db87d2e9eecf455896bf",
             "_tpl": "56dff338d2720bbd668b4569",
             "parentId": "851dafd2930c1452d223755b",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 30
+            }
+        }, {
             "_id": "507bfdceec87dbcbe7a28081",
             "_tpl": "57372e1924597768553071c1",
             "parentId": "hideout",
@@ -2227,14 +1964,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7dd74a4c68ba7698a2b58ba5",
             "_tpl": "56dff338d2720bbd668b4569",
             "parentId": "507bfdceec87dbcbe7a28081",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 120
+            }
+        }, {
             "_id": "ccde5ef196dcf7d4f7c0ad84",
             "_tpl": "57372deb245977685d4159b3",
             "parentId": "hideout",
@@ -2245,14 +1984,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f9dd1f9622fd3beac2a5c98e",
             "_tpl": "56dff338d2720bbd668b4569",
             "parentId": "ccde5ef196dcf7d4f7c0ad84",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 120
+            }
+        }, {
             "_id": "dd396513b7f0d941a4e7bdc4",
             "_tpl": "56dff4ecd2720b5f5a8b4568",
             "parentId": "hideout",
@@ -2263,8 +2004,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "cabdb4c1495b6815b4ba9f51",
             "_tpl": "5737300424597769942d5a01",
             "parentId": "hideout",
@@ -2275,14 +2015,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "9a5ddde0ed95037cff6254fa",
             "_tpl": "56dff4ecd2720b5f5a8b4568",
             "parentId": "cabdb4c1495b6815b4ba9f51",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 30
+            }
+        }, {
             "_id": "fdfcedae16be8feddc0ea7ee",
             "_tpl": "57372fc52459776998772ca1",
             "parentId": "hideout",
@@ -2293,14 +2035,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "cfadd751f5ff6edae16a36d8",
             "_tpl": "56dff4ecd2720b5f5a8b4568",
             "parentId": "fdfcedae16be8feddc0ea7ee",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 120
+            }
+        }, {
             "_id": "ebcdcc2b7eb9c20ab06acaf5",
             "_tpl": "57372f7d245977699b53e301",
             "parentId": "hideout",
@@ -2311,14 +2055,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f8d11adad37752aae24bc63f",
             "_tpl": "56dff4ecd2720b5f5a8b4568",
             "parentId": "ebcdcc2b7eb9c20ab06acaf5",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 120
+            }
+        }, {
             "_id": "d8be427c92cebf3fbadfffba",
             "_tpl": "56dff0bed2720bb0668b4567",
             "parentId": "hideout",
@@ -2329,8 +2075,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7ddc89ffbe95aaac2e3e4ac3",
             "_tpl": "5737330a2459776af32363a1",
             "parentId": "hideout",
@@ -2341,14 +2086,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "dbb06caa9ca450adbbf1d2c1",
             "_tpl": "56dff0bed2720bb0668b4567",
             "parentId": "7ddc89ffbe95aaac2e3e4ac3",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 30
+            }
+        }, {
             "_id": "addc13cb33a8fb54eb3237da",
             "_tpl": "56dff4a2d2720bbd668b456a",
             "parentId": "hideout",
@@ -2359,8 +2106,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "3eecf5deccce8335fccaffd1",
             "_tpl": "57372f5c24597769917c0131",
             "parentId": "hideout",
@@ -2371,14 +2117,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "edaf0fb48dce55dd1d84bdef",
             "_tpl": "56dff4a2d2720bbd668b456a",
             "parentId": "3eecf5deccce8335fccaffd1",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 30
+            }
+        }, {
             "_id": "ac71f96dbe4b231cadcee132",
             "_tpl": "57372f2824597769a270a191",
             "parentId": "hideout",
@@ -2389,14 +2137,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ff0ffece639fdad59863cd00",
             "_tpl": "56dff4a2d2720bbd668b456a",
             "parentId": "ac71f96dbe4b231cadcee132",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 120
+            }
+        }, {
             "_id": "bbadda2559edb2baf09d5dc1",
             "_tpl": "57372ee1245977685d4159b5",
             "parentId": "hideout",
@@ -2407,14 +2157,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b4f966b4d67e2bbb10eae2d8",
             "_tpl": "56dff4a2d2720bbd668b456a",
             "parentId": "bbadda2559edb2baf09d5dc1",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 120
+            }
+        }, {
             "_id": "b85ebc4dee217a25b8a3cc32",
             "_tpl": "56dff3afd2720bba668b4567",
             "parentId": "hideout",
@@ -2425,8 +2177,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ad5ec232ca5bbeae937bb5ad",
             "_tpl": "57372ebf2459776862260582",
             "parentId": "hideout",
@@ -2437,14 +2188,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "1b4dc0b0ee3cd37375ce9aba",
             "_tpl": "56dff3afd2720bba668b4567",
             "parentId": "ad5ec232ca5bbeae937bb5ad",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 30
+            }
+        }, {
             "_id": "73b0fc2dd4c9c1f3543cd9c1",
             "_tpl": "57372e94245977685648d3e1",
             "parentId": "hideout",
@@ -2455,14 +2208,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "416b89bbfc5135eaea387492",
             "_tpl": "56dff3afd2720bba668b4567",
             "parentId": "73b0fc2dd4c9c1f3543cd9c1",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 120
+            }
+        }, {
             "_id": "f55e3c9de4a7abd5afe4c2df",
             "_tpl": "57372e73245977685d4159b4",
             "parentId": "hideout",
@@ -2473,14 +2228,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b8eaab2aade4e9accc75b2a3",
             "_tpl": "56dff3afd2720bba668b4567",
             "parentId": "f55e3c9de4a7abd5afe4c2df",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 120
+            }
+        }, {
             "_id": "ef57451fccdd2dab9877e7c9",
             "_tpl": "5bed61680db834001d2c45ab",
             "parentId": "hideout",
@@ -2491,8 +2248,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "cedad22a07a58bcb25e5013b",
             "_tpl": "56dff2ced2720bb4668b4567",
             "parentId": "hideout",
@@ -2503,8 +2259,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "acd38f7af0feacccbce1ce3c",
             "_tpl": "57372db0245977685d4159b2",
             "parentId": "hideout",
@@ -2515,14 +2270,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "62f790f5dd75a5dd7b9ea9af",
             "_tpl": "56dff2ced2720bb4668b4567",
             "parentId": "acd38f7af0feacccbce1ce3c",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 30
+            }
+        }, {
             "_id": "3bd165f6627ba5d97bdabaa5",
             "_tpl": "57372d4c245977685a3da2a1",
             "parentId": "hideout",
@@ -2533,14 +2290,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "94de91c587dbe8ddadf0edc7",
             "_tpl": "56dff2ced2720bb4668b4567",
             "parentId": "3bd165f6627ba5d97bdabaa5",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 120
+            }
+        }, {
             "_id": "7e3872a04bef1b68da53ddaf",
             "_tpl": "57372d1b2459776862260581",
             "parentId": "hideout",
@@ -2551,14 +2310,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "8edf6a6a2be7bded04410ddc",
             "_tpl": "56dff2ced2720bb4668b4567",
             "parentId": "7e3872a04bef1b68da53ddaf",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 120
+            }
+        }, {
             "_id": "51300aa813b4dae28bdca525",
             "_tpl": "56dfef82d2720bbd668b4567",
             "parentId": "hideout",
@@ -2569,8 +2330,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "267823eb62a2f7acf8cfceb5",
             "_tpl": "57372ac324597767001bc261",
             "parentId": "hideout",
@@ -2581,14 +2341,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e9e2b0761b5c84bd06b599ab",
             "_tpl": "56dfef82d2720bbd668b4567",
             "parentId": "267823eb62a2f7acf8cfceb5",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 30
+            }
+        }, {
             "_id": "caf3d9bf3d2bf4efd49ece0b",
             "_tpl": "57372a7f24597766fe0de0c1",
             "parentId": "hideout",
@@ -2599,14 +2361,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d9d7cea43bf483805bb852cc",
             "_tpl": "56dfef82d2720bbd668b4567",
             "parentId": "caf3d9bf3d2bf4efd49ece0b",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 120
+            }
+        }, {
             "_id": "36b47feeadeeface1d34eecf",
             "_tpl": "5737292724597765e5728562",
             "parentId": "hideout",
@@ -2617,14 +2381,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "19fb7ecaf0cabd1edbe52fff",
             "_tpl": "56dfef82d2720bbd668b4567",
             "parentId": "36b47feeadeeface1d34eecf",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 120
+            }
+        }, {
             "_id": "d1fd1ed131adc6edf787facd",
             "_tpl": "56dff061d2720bb5668b4567",
             "parentId": "hideout",
@@ -2635,8 +2401,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ad6bb74e267087fc01c9fd1e",
             "_tpl": "57372c89245977685d4159b1",
             "parentId": "hideout",
@@ -2647,14 +2412,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fefedc5221d73fe8bae09cb6",
             "_tpl": "56dff061d2720bb5668b4567",
             "parentId": "ad6bb74e267087fc01c9fd1e",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 30
+            }
+        }, {
             "_id": "57932e2b7dce3ebb31ba4a08",
             "_tpl": "57372c56245977685e584582",
             "parentId": "hideout",
@@ -2665,14 +2432,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a80867bd9d721d8c9f7f4eae",
             "_tpl": "56dff061d2720bb5668b4567",
             "parentId": "57932e2b7dce3ebb31ba4a08",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 120
+            }
+        }, {
             "_id": "6ffbead04e4e9bf14db45e9c",
             "_tpl": "57372c21245977670937c6c2",
             "parentId": "hideout",
@@ -2683,14 +2452,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bacdcb132add30efa0aa0efa",
             "_tpl": "56dff061d2720bb5668b4567",
             "parentId": "6ffbead04e4e9bf14db45e9c",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 120
+            }
+        }, {
             "_id": "aac07961f94d3ec2d9600f5d",
             "_tpl": "61962b617c6c7b169525f168",
             "parentId": "hideout",
@@ -2701,8 +2472,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "45dd1a0dd42cb8b7613ffed6",
             "_tpl": "56dff026d2720bb8668b4567",
             "parentId": "hideout",
@@ -2713,8 +2483,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c70681b0caba7a7c4a9551dd",
             "_tpl": "57372bd3245977670b7cd243",
             "parentId": "hideout",
@@ -2725,14 +2494,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "cb39bdf126dadb0c67cc6a20",
             "_tpl": "56dff026d2720bb8668b4567",
             "parentId": "c70681b0caba7a7c4a9551dd",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 30
+            }
+        }, {
             "_id": "edbdebc5a978f4f73afeedea",
             "_tpl": "57372bad245977670b7cd242",
             "parentId": "hideout",
@@ -2743,14 +2514,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "1d2e3b679fcb269c125ccb71",
             "_tpl": "56dff026d2720bb8668b4567",
             "parentId": "edbdebc5a978f4f73afeedea",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 120
+            }
+        }, {
             "_id": "75fe098ddbb4f58bbe3c17cc",
             "_tpl": "57372b832459776701014e41",
             "parentId": "hideout",
@@ -2761,14 +2534,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "677e8966dd164a4cc34b65c8",
             "_tpl": "56dff026d2720bb8668b4567",
             "parentId": "75fe098ddbb4f58bbe3c17cc",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 120
+            }
+        }, {
             "_id": "eafae65d6aad97aceca88ac7",
             "_tpl": "5c0d5e4486f77478390952fe",
             "parentId": "hideout",
@@ -2779,8 +2554,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "1754f6dbbfa616d96eb70fcc",
             "_tpl": "5c1262a286f7743f8a69aab2",
             "parentId": "hideout",
@@ -2791,14 +2565,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7c4b42ec00bcf001296684dc",
             "_tpl": "5c0d5e4486f77478390952fe",
             "parentId": "1754f6dbbfa616d96eb70fcc",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 30
+            }
+        }, {
             "_id": "1825ca0ed5fbdab1b5cc7bba",
             "_tpl": "55d482194bdc2d1d4e8b456b",
             "parentId": "hideout",
@@ -2809,8 +2585,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7be0adcab6acc382e17becd2",
             "_tpl": "56dff421d2720b5f5a8b4567",
             "parentId": "hideout",
@@ -2821,8 +2596,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fe19a2dcbac6ce46f4ebbb02",
             "_tpl": "56dff216d2720bbd668b4568",
             "parentId": "hideout",
@@ -2833,8 +2607,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "5cab97f1b7972fba8773ac4d",
             "_tpl": "56dff338d2720bbd668b4569",
             "parentId": "hideout",
@@ -2845,8 +2618,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "14ea806be1d4475cf9fbce2d",
             "_tpl": "56dff4ecd2720b5f5a8b4568",
             "parentId": "hideout",
@@ -2857,8 +2629,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a8f5f4b32432094bf88584fa",
             "_tpl": "56dff0bed2720bb0668b4567",
             "parentId": "hideout",
@@ -2869,8 +2640,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bbf7baeca1b654c5c9f0bcfb",
             "_tpl": "56dff4a2d2720bbd668b456a",
             "parentId": "hideout",
@@ -2881,8 +2651,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "5ae1d9ecacebd3325d720dbe",
             "_tpl": "56dff3afd2720bba668b4567",
             "parentId": "hideout",
@@ -2893,8 +2662,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a5fac979afb4bdfeddda0eb9",
             "_tpl": "56dff2ced2720bb4668b4567",
             "parentId": "hideout",
@@ -2905,8 +2673,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c6c5b6bbf2c02eafe2a409af",
             "_tpl": "56dfef82d2720bbd668b4567",
             "parentId": "hideout",
@@ -2917,8 +2684,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "cdd1ac8a6ff37aa0d0a075fd",
             "_tpl": "56dff061d2720bb5668b4567",
             "parentId": "hideout",
@@ -2929,8 +2695,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "cbe2c68fda18333b59afadd0",
             "_tpl": "61962b617c6c7b169525f168",
             "parentId": "hideout",
@@ -2941,8 +2706,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "5b0af0012b6eafbc8ad2719e",
             "_tpl": "56dff026d2720bb8668b4567",
             "parentId": "hideout",
@@ -2953,8 +2717,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "28bfa3ec60199dc7bde5edfd",
             "_tpl": "5c0d5e4486f77478390952fe",
             "parentId": "hideout",
@@ -2965,8 +2728,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "0aa1e4932e90c16b2c7ddbee",
             "_tpl": "59e6927d86f77411da468256",
             "parentId": "hideout",
@@ -2977,8 +2739,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c392f5cafebb09f0d2cbacce",
             "_tpl": "59e6918f86f7746c9f75e849",
             "parentId": "hideout",
@@ -2989,8 +2750,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "af5833ffb06b7b103bd80bdb",
             "_tpl": "59e6920f86f77411d82aa167",
             "parentId": "hideout",
@@ -3001,8 +2761,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bbc9ffadaceab18bcfbd9ec2",
             "_tpl": "5c0d5ae286f7741e46554302",
             "parentId": "hideout",
@@ -3013,8 +2772,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "afeb2a8f9c2808713f59aacf",
             "_tpl": "5c11279ad174af029d64592b",
             "parentId": "hideout",
@@ -3025,14 +2783,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f43d5abbfdf50eb24daee0c3",
             "_tpl": "5c0d5ae286f7741e46554302",
             "parentId": "afeb2a8f9c2808713f59aacf",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 20
+            }
+        }, {
             "_id": "b6ff87ecb676eef0a7d0c5ea",
             "_tpl": "5d1340cad7ad1a0b0b249869",
             "parentId": "hideout",
@@ -3043,8 +2803,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "acfeabef6feadb2bcdff8b6f",
             "_tpl": "54527a984bdc2d4e668b4567",
             "parentId": "hideout",
@@ -3055,8 +2814,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "eee701afcd64ac958917f38b",
             "_tpl": "5447ac644bdc2d6c208b4567",
             "parentId": "hideout",
@@ -3067,14 +2825,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "14c30ec07e6815ad6b21eb5c",
             "_tpl": "54527a984bdc2d4e668b4567",
             "parentId": "eee701afcd64ac958917f38b",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 50
+            }
+        }, {
             "_id": "a4df4950e5655243d23e00ff",
             "_tpl": "60194943740c5d77f6705eea",
             "parentId": "hideout",
@@ -3085,8 +2845,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d4dbec374aeddbcaab371ffd",
             "_tpl": "59e68f6f86f7746c9f75e846",
             "parentId": "hideout",
@@ -3097,8 +2856,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b076af4f8db6d01773b6ec8d",
             "_tpl": "5c0548ae0db834001966a3c2",
             "parentId": "hideout",
@@ -3109,8 +2867,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7e9679dec77bb78d6efba17b",
             "_tpl": "5c6d42cb2e2216000e69d7d1",
             "parentId": "hideout",
@@ -3121,8 +2878,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "4eaaaffcabc67c45bed2e97e",
             "_tpl": "59e6906286f7746c9f75e847",
             "parentId": "hideout",
@@ -3133,8 +2889,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bec8baa49d915d21f3cf3946",
             "_tpl": "54527ac44bdc2d36668b4567",
             "parentId": "hideout",
@@ -3145,8 +2900,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bfbfac0770bde5ab59d90fbc",
             "_tpl": "59e690b686f7746c9f75e848",
             "parentId": "hideout",
@@ -3157,8 +2911,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "acd2a2d83adfb4bfd7d1b04d",
             "_tpl": "601949593ae8f707c4608daa",
             "parentId": "hideout",
@@ -3169,8 +2922,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ae3d89a1f2366cddefdbf3f6",
             "_tpl": "59c1383d86f774290a37e0ca",
             "parentId": "hideout",
@@ -3181,8 +2933,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "cd106018ca64ceacb8ff2f9c",
             "_tpl": "59e6927d86f77411da468256",
             "parentId": "hideout",
@@ -3193,8 +2944,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e27cc9d11b5fe4dda9c8a16e",
             "_tpl": "59e6918f86f7746c9f75e849",
             "parentId": "hideout",
@@ -3205,8 +2955,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "73cbff75d4bbdd6bbf76362d",
             "_tpl": "59e6920f86f77411d82aa167",
             "parentId": "hideout",
@@ -3217,8 +2966,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "feaec87b5a2fdd40ffa3fe4f",
             "_tpl": "5c0d5ae286f7741e46554302",
             "parentId": "hideout",
@@ -3229,8 +2977,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "befaa9e78a9be7dc3dbaddd7",
             "_tpl": "54527a984bdc2d4e668b4567",
             "parentId": "hideout",
@@ -3241,8 +2988,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a37ee9bde17850b919eaf0ba",
             "_tpl": "60194943740c5d77f6705eea",
             "parentId": "hideout",
@@ -3253,8 +2999,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "afd727ab3a4cc49c59f4ba4e",
             "_tpl": "59e68f6f86f7746c9f75e846",
             "parentId": "hideout",
@@ -3265,8 +3010,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "9a707c8ebfb1d1d14d05c867",
             "_tpl": "59e6906286f7746c9f75e847",
             "parentId": "hideout",
@@ -3277,8 +3021,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "1c23fd6f997fea6aab4092df",
             "_tpl": "54527ac44bdc2d36668b4567",
             "parentId": "hideout",
@@ -3289,8 +3032,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "5cc11aa5f5afd1befeb8aa3b",
             "_tpl": "59e690b686f7746c9f75e848",
             "parentId": "hideout",
@@ -3301,8 +3043,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "744cefdce2142d0ddbcb7fff",
             "_tpl": "601949593ae8f707c4608daa",
             "parentId": "hideout",
@@ -3313,8 +3054,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "6aa3acbe6be11ce5ed522ce1",
             "_tpl": "59e4cf5286f7741778269d8a",
             "parentId": "hideout",
@@ -3325,8 +3065,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "6921eaa048c0405619f2948d",
             "_tpl": "59e4d3d286f774176a36250a",
             "parentId": "hideout",
@@ -3337,8 +3076,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fe2aa27f123fc25e462af7b6",
             "_tpl": "59e4d24686f7741776641ac7",
             "parentId": "hideout",
@@ -3349,8 +3087,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a11cffe3dad659dced532fed",
             "_tpl": "5cbdc23eae9215001136a407",
             "parentId": "hideout",
@@ -3361,8 +3098,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "97d8e98fdedbb04209ba6ea3",
             "_tpl": "5656d7c34bdc2d9d198b4587",
             "parentId": "hideout",
@@ -3373,8 +3109,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b7b0dde96e10bde42d78a1da",
             "_tpl": "5649ed104bdc2d3d1c8b458b",
             "parentId": "hideout",
@@ -3385,14 +3120,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "049c9c978ad53edbd5f1dcce",
             "_tpl": "5656d7c34bdc2d9d198b4587",
             "parentId": "b7b0dde96e10bde42d78a1da",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 20
+            }
+        }, {
             "_id": "0e6da835c1a9f1edda83df89",
             "_tpl": "59e0d99486f7744a32234762",
             "parentId": "hideout",
@@ -3403,8 +3140,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "779deae5707a54522bdaa6ca",
             "_tpl": "601aa3d2b2bcb34913271e6d",
             "parentId": "hideout",
@@ -3415,8 +3151,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f0eaf4f5a4a65d9ef3f9478f",
             "_tpl": "5cfe8010d7ad1a59283b14c6",
             "parentId": "hideout",
@@ -3427,8 +3162,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "721924cb66db16bffacd4d06",
             "_tpl": "61695095d92c473c7702147a",
             "parentId": "hideout",
@@ -3439,8 +3173,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "cf7f0cf0b168de8bad9dbada",
             "_tpl": "59e4cf5286f7741778269d8a",
             "parentId": "hideout",
@@ -3451,8 +3184,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "690ba255e7d8ed06ec14f87d",
             "_tpl": "59e4d3d286f774176a36250a",
             "parentId": "hideout",
@@ -3463,8 +3195,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e523a8d2d5ab18ddcbbbb827",
             "_tpl": "59e4d24686f7741776641ac7",
             "parentId": "hideout",
@@ -3475,8 +3206,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "03b2fb63acf4bfe6fe0e72f5",
             "_tpl": "5656d7c34bdc2d9d198b4587",
             "parentId": "hideout",
@@ -3487,8 +3217,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "2cdea03f665c4ce65c7d1f1e",
             "_tpl": "59e0d99486f7744a32234762",
             "parentId": "hideout",
@@ -3499,8 +3228,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e0f97cb7b2afb81efbee3d05",
             "_tpl": "601aa3d2b2bcb34913271e6d",
             "parentId": "hideout",
@@ -3511,8 +3239,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "edefb4eeb3d4e7ef61fd351c",
             "_tpl": "5e023e53d4353e3302577c4c",
             "parentId": "hideout",
@@ -3523,8 +3250,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "3a153a2ade193cc210e32712",
             "_tpl": "5e023e6e34d52a55c3304f71",
             "parentId": "hideout",
@@ -3535,8 +3261,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f4061aa0190c0c542fa5eadf",
             "_tpl": "5d25a7b88abbc3054f3e60bc",
             "parentId": "hideout",
@@ -3547,8 +3272,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ef8d6189a0ac59db6f9aafcf",
             "_tpl": "5e023e88277cce2b522ff2b1",
             "parentId": "hideout",
@@ -3559,8 +3283,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7cbf7a98ba8c769aa75c04fa",
             "_tpl": "5addcce35acfc4001a5fc635",
             "parentId": "hideout",
@@ -3571,8 +3294,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "1e53fcc5df55cc4baeb7a9ac",
             "_tpl": "61840bedd92c473c77021635",
             "parentId": "hideout",
@@ -3583,8 +3305,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "aba8dd2f419d3f90e42aabcf",
             "_tpl": "58dd3ad986f77403051cba8f",
             "parentId": "hideout",
@@ -3595,8 +3316,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ea9ac15897f831abaf7b1211",
             "_tpl": "5c503ad32e2216398b5aada2",
             "parentId": "hideout",
@@ -3607,8 +3327,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "dedfbfbeace1d679e4da8bdd",
             "_tpl": "5d25a6a48abbc306c62e6310",
             "parentId": "hideout",
@@ -3619,8 +3338,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7e5f4bd20de1cc072b1bd1ac",
             "_tpl": "5a608bf24f39f98ffc77720e",
             "parentId": "hideout",
@@ -3631,8 +3349,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "dcab6a885f5298acfab2ebfd",
             "_tpl": "5b7d37845acfc400170e2f87",
             "parentId": "hideout",
@@ -3643,8 +3360,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "61bac5b8c3a2c58b10e35ad6",
             "_tpl": "617131a4568c120fdd29482d",
             "parentId": "hideout",
@@ -3655,8 +3371,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "4147f4c1ccaef366bfccec6b",
             "_tpl": "5a6086ea4f39f99cd479502f",
             "parentId": "hideout",
@@ -3667,8 +3382,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "5db2bc2d1aa10e5dcc26d799",
             "_tpl": "5cf12a15d7f00c05464b293f",
             "parentId": "hideout",
@@ -3679,8 +3393,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "24f5d14dd6a1d2f4d5dedaab",
             "_tpl": "5addccf45acfc400185c2989",
             "parentId": "hideout",
@@ -3691,8 +3404,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a39ac3e862cce0de1eff0cca",
             "_tpl": "5efb0c1bd79ff02a1f5e68d9",
             "parentId": "hideout",
@@ -3703,8 +3415,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f5fbec96e2bde57b45bceacd",
             "_tpl": "5b7bef9c5acfc43d102852ec",
             "parentId": "hideout",
@@ -3715,8 +3426,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "08032bf34904cddba9dc7c94",
             "_tpl": "5e023e53d4353e3302577c4c",
             "parentId": "hideout",
@@ -3727,8 +3437,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "dca9ffdfd90ff5fd4d6cc9d0",
             "_tpl": "5e023e6e34d52a55c3304f71",
             "parentId": "hideout",
@@ -3739,8 +3448,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "39e1acb06dbcfbe6d4640dba",
             "_tpl": "5e023e88277cce2b522ff2b1",
             "parentId": "hideout",
@@ -3751,8 +3459,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e3b3d99c6be49f6ca07560a1",
             "_tpl": "58dd3ad986f77403051cba8f",
             "parentId": "hideout",
@@ -3763,8 +3470,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "379aa33c1fbf1afbfeba5f8d",
             "_tpl": "5a608bf24f39f98ffc77720e",
             "parentId": "hideout",
@@ -3775,8 +3481,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d4cd7de283faedfbbe72abd1",
             "_tpl": "5a6086ea4f39f99cd479502f",
             "parentId": "hideout",
@@ -3787,8 +3492,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "1e0942ffd38bae1b29f8ee34",
             "_tpl": "5efb0c1bd79ff02a1f5e68d9",
             "parentId": "hideout",
@@ -3799,8 +3503,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "44dbab6cee357ded1e3b729f",
             "_tpl": "57a0dfb82459774d3078b56c",
             "parentId": "hideout",
@@ -3811,8 +3514,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d3934fcbf9db76cffbf0e971",
             "_tpl": "57a0e5022459774d1673f889",
             "parentId": "hideout",
@@ -3823,8 +3525,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "2ff88da5b0a91bd0feaacac7",
             "_tpl": "57838f9f2459774a150289a0",
             "parentId": "hideout",
@@ -3835,8 +3536,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e2da3ebbadea1fe55aa25c99",
             "_tpl": "61962d879bb3d20b0946d385",
             "parentId": "hideout",
@@ -3847,8 +3547,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "4d2ff8d2c0ccadf9b93c90d0",
             "_tpl": "5c0d668f86f7747ccb7f13b2",
             "parentId": "hideout",
@@ -3859,8 +3558,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "aab4525ecf51da1f42fcd762",
             "_tpl": "5c12619186f7743f871c8a32",
             "parentId": "hideout",
@@ -3871,14 +3569,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7dbaafadefb7ff7bd64d059a",
             "_tpl": "5c0d668f86f7747ccb7f13b2",
             "parentId": "aab4525ecf51da1f42fcd762",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 8
+            }
+        }, {
             "_id": "b8284dc99eed2dac03e047a4",
             "_tpl": "5c0d688c86f77413ae3407b2",
             "parentId": "hideout",
@@ -3889,8 +3589,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ee3fde0c8c92e698bd9bd19f",
             "_tpl": "5c1260dc86f7746b106e8748",
             "parentId": "hideout",
@@ -3901,14 +3600,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bcdc5ba23dc583d7012ff2b5",
             "_tpl": "5c0d688c86f77413ae3407b2",
             "parentId": "ee3fde0c8c92e698bd9bd19f",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 8
+            }
+        }, {
             "_id": "0b59f7cfdee039c2b1ef60cd",
             "_tpl": "5a9e81fba2750c00164f6b11",
             "parentId": "hideout",
@@ -3919,8 +3620,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a6debb8e4c29f589c5d9c3db",
             "_tpl": "57a0dfb82459774d3078b56c",
             "parentId": "hideout",
@@ -3931,8 +3631,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bac7a48f8a8eba54a6abd1ac",
             "_tpl": "57a0e5022459774d1673f889",
             "parentId": "hideout",
@@ -3943,8 +3642,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "02ceeeaeb7ffcab7df0e7fde",
             "_tpl": "61962d879bb3d20b0946d385",
             "parentId": "hideout",
@@ -3955,8 +3653,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "5ef33313f8f51144ae07f65f",
             "_tpl": "5c0d668f86f7747ccb7f13b2",
             "parentId": "hideout",
@@ -3967,8 +3664,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "be0bad95ab0da15c1ab12214",
             "_tpl": "5c0d688c86f77413ae3407b2",
             "parentId": "hideout",
@@ -3979,8 +3675,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "38beda0d56a9c7636acfcd1f",
             "_tpl": "59e6687d86f77411d949b251",
             "parentId": "hideout",
@@ -3991,56 +3686,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "dce9af3db4ca20a4e02c6afe",
             "_tpl": "59e649f986f77411d949b246",
             "parentId": "38beda0d56a9c7636acfcd1f",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "8fcc8f0a6bf1e3cbae9a43e8",
             "_tpl": "59e898ee86f77427614bd225",
             "parentId": "dce9af3db4ca20a4e02c6afe",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "fac624b8a9ad4dd29e6c3956",
             "_tpl": "59e8a00d86f7742ad93b569c",
             "parentId": "38beda0d56a9c7636acfcd1f",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "adffd82f6fababef4ae6e2dc",
             "_tpl": "59e6318286f77444dd62c4cc",
             "parentId": "38beda0d56a9c7636acfcd1f",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "28feccabc9efaa1de8abec56",
             "_tpl": "59e6449086f7746c9f75e822",
             "parentId": "38beda0d56a9c7636acfcd1f",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "f393dd26a5edbbee9e670e3d",
             "_tpl": "59e8977386f77415a553c453",
             "parentId": "38beda0d56a9c7636acfcd1f",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "ffec80acbfb452e77aeff2ad",
             "_tpl": "59e89d0986f77427600d226e",
             "parentId": "38beda0d56a9c7636acfcd1f",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "afdf8794674a1d3426779ecd",
             "_tpl": "59d625f086f774661516605d",
             "parentId": "38beda0d56a9c7636acfcd1f",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "3daccfae304d967f54cef4bb",
             "_tpl": "59e6152586f77473dc057aa1",
             "parentId": "hideout",
@@ -4051,56 +3737,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "3aecda730aa19f90d72465fb",
             "_tpl": "59e649f986f77411d949b246",
             "parentId": "3daccfae304d967f54cef4bb",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "aeffa95668faeadabbcd360e",
             "_tpl": "59e6284f86f77440d569536f",
             "parentId": "3aecda730aa19f90d72465fb",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "af1dd17fcc8deceb4220fff3",
             "_tpl": "59e61eb386f77440d64f5daf",
             "parentId": "3daccfae304d967f54cef4bb",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "ca510ecabbca250fb13abd4b",
             "_tpl": "59e6318286f77444dd62c4cc",
             "parentId": "3daccfae304d967f54cef4bb",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "0a6babef55e6f508ebc9f7c6",
             "_tpl": "59e6449086f7746c9f75e822",
             "parentId": "3daccfae304d967f54cef4bb",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "cc66f740a228bb0b7a11b76f",
             "_tpl": "59d650cf86f7741b846413a4",
             "parentId": "3daccfae304d967f54cef4bb",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "2a6a2b25a192560ba197047b",
             "_tpl": "59e6227d86f77440d64f5dc2",
             "parentId": "3daccfae304d967f54cef4bb",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "82adbbea37bcfc433f4f4e9c",
             "_tpl": "59d625f086f774661516605d",
             "parentId": "3daccfae304d967f54cef4bb",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "df6171d1caf99a2a2731aeea",
             "_tpl": "5c07c60e0db834002330051f",
             "parentId": "hideout",
@@ -4111,62 +3788,52 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "afafa951ba6f08ee1c18b5ec",
             "_tpl": "5c0e2ff6d174af02a1659d4a",
             "parentId": "df6171d1caf99a2a2731aeea",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "eeaf1ff2d11bfe6ae5eb1a78",
             "_tpl": "5aaa5e60e5b5b000140293d6",
             "parentId": "df6171d1caf99a2a2731aeea",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "ed5b52da70ec28f441f0f7ea",
             "_tpl": "5c0e2f26d174af02a9625114",
             "parentId": "df6171d1caf99a2a2731aeea",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "9ed41d2e78f4074ca76ea8fe",
             "_tpl": "5c0e2f94d174af029f650d56",
             "parentId": "ed5b52da70ec28f441f0f7ea",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "1d05eaac2c8f7a8da6ae2e84",
             "_tpl": "5c0fafb6d174af02a96260ba",
             "parentId": "9ed41d2e78f4074ca76ea8fe",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "adec9d6e1f3b3d68f8d1efcd",
             "_tpl": "5ae30e795acfc408fb139a0b",
             "parentId": "9ed41d2e78f4074ca76ea8fe",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "ded5e42abaa32658bfea7674",
             "_tpl": "5c0e2f5cd174af02a012cfc9",
             "parentId": "ed5b52da70ec28f441f0f7ea",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "afece77afc0a8d0acbc85ed1",
             "_tpl": "5c0faeddd174af02a962601f",
             "parentId": "df6171d1caf99a2a2731aeea",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "a2f56dbebbff77ed09fe81a7",
             "_tpl": "5c0faf68d174af02a96260b8",
             "parentId": "df6171d1caf99a2a2731aeea",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "e506bfbaddaf6cf680f4d3a7",
             "_tpl": "57dc2fa62459775949412633",
             "parentId": "hideout",
@@ -4177,50 +3844,42 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e5b346201ebfea0dccb39d46",
             "_tpl": "57e3dba62459770f0c32322b",
             "parentId": "e506bfbaddaf6cf680f4d3a7",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "8df9df2eefbf16c2c946e6f3",
             "_tpl": "57dc347d245977596754e7a1",
             "parentId": "e506bfbaddaf6cf680f4d3a7",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "4ef099324beac67aaca7b53d",
             "_tpl": "564ca99c4bdc2d16268b4589",
             "parentId": "e506bfbaddaf6cf680f4d3a7",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "0b7aadd2bd11c1adfdb5f5f3",
             "_tpl": "57dc324a24597759501edc20",
             "parentId": "e506bfbaddaf6cf680f4d3a7",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "9f0676a581fe701299ccb7dc",
             "_tpl": "57dc334d245977597164366f",
             "parentId": "e506bfbaddaf6cf680f4d3a7",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "33f7bd40065b3f38776e6afb",
             "_tpl": "59d36a0086f7747e673f3946",
             "parentId": "e506bfbaddaf6cf680f4d3a7",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "e27c17bef9e27e805e2dff3e",
             "_tpl": "57dc32dc245977596d4ef3d3",
             "parentId": "33f7bd40065b3f38776e6afb",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "da7ed5414ccfc4564efaabd6",
             "_tpl": "55d4837c4bdc2d1d4e8b456c",
             "parentId": "hideout",
@@ -4231,8 +3890,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "769bf3edae3ccccefdabaecf",
             "_tpl": "5aaa5e60e5b5b000140293d6",
             "parentId": "hideout",
@@ -4243,8 +3901,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b2ef9af5e4aa25efee78a9ec",
             "_tpl": "59e5d83b86f7745aed03d262",
             "parentId": "hideout",
@@ -4255,8 +3912,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "60c72fc9bbd53cbeec2a0867",
             "_tpl": "5ac4cd105acfc40016339859",
             "parentId": "hideout",
@@ -4267,56 +3923,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "0e83ddf7fa260e7d1382d204",
             "_tpl": "59c6633186f7740cf0493bb9",
             "parentId": "60c72fc9bbd53cbeec2a0867",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "4a0e27c1b830e6fb2cae0d9c",
             "_tpl": "5648b1504bdc2d9d488b4584",
             "parentId": "0e83ddf7fa260e7d1382d204",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "efa1c8c03c0da2bc2805fe5a",
             "_tpl": "5ac7655e5acfc40016339a19",
             "parentId": "60c72fc9bbd53cbeec2a0867",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "ee47cfcd9e9890647e0a5d7b",
             "_tpl": "5649ade84bdc2d1b2b8b4587",
             "parentId": "60c72fc9bbd53cbeec2a0867",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "52e6e18eb4d2e4de20e339eb",
             "_tpl": "5ac50da15acfc4001718d287",
             "parentId": "60c72fc9bbd53cbeec2a0867",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "ac6961d60b7beeef7ebb778f",
             "_tpl": "5ac72e475acfc400180ae6fe",
             "parentId": "60c72fc9bbd53cbeec2a0867",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "305723dcbd4e4beaefa2ca6a",
             "_tpl": "5ac50c185acfc400163398d4",
             "parentId": "60c72fc9bbd53cbeec2a0867",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "2aab492a9246fcaddf8dc5d6",
             "_tpl": "55d480c04bdc2d1d4e8b456a",
             "parentId": "60c72fc9bbd53cbeec2a0867",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "d55017fe6e6cf9e0bfeb4dcd",
             "_tpl": "5ac66d015acfc400180ae6e4",
             "parentId": "hideout",
@@ -4327,56 +3974,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "3ebdd01ba2a9f3a1c1d7afcb",
             "_tpl": "59c6633186f7740cf0493bb9",
             "parentId": "d55017fe6e6cf9e0bfeb4dcd",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "556daca1abf04bdc832a0c4b",
             "_tpl": "5648b1504bdc2d9d488b4584",
             "parentId": "3ebdd01ba2a9f3a1c1d7afcb",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "c1841bb66fbdbb0eabae721d",
             "_tpl": "5ac72e725acfc400180ae701",
             "parentId": "d55017fe6e6cf9e0bfeb4dcd",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "4bdcfeeaad12cd6cf5ca39bf",
             "_tpl": "5649ade84bdc2d1b2b8b4587",
             "parentId": "d55017fe6e6cf9e0bfeb4dcd",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "d9d993080284d08affed8b4c",
             "_tpl": "5ac50da15acfc4001718d287",
             "parentId": "d55017fe6e6cf9e0bfeb4dcd",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "763525b805c2221aa03d205a",
             "_tpl": "5ac733a45acfc400192630e2",
             "parentId": "d55017fe6e6cf9e0bfeb4dcd",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "590cfd31924caafa12f12cc2",
             "_tpl": "5ac50c185acfc400163398d4",
             "parentId": "d55017fe6e6cf9e0bfeb4dcd",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "fcccef810aaad08bd0cab9ab",
             "_tpl": "5ac66c5d5acfc4001718d314",
             "parentId": "d55017fe6e6cf9e0bfeb4dcd",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "f7afeb9dcd44e5c2df0fdebe",
             "_tpl": "5447a9cd4bdc2dbd208b4567",
             "parentId": "hideout",
@@ -4387,80 +4025,67 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "13aba59ca0b2d67d756b9dea",
             "_tpl": "55d4b9964bdc2d1d4e8b456e",
             "parentId": "f7afeb9dcd44e5c2df0fdebe",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "a95eaeec95a024bad83c2d82",
             "_tpl": "55d4887d4bdc2d962f8b4570",
             "parentId": "f7afeb9dcd44e5c2df0fdebe",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "82d935bd73c95d5017a03ffe",
             "_tpl": "544a38634bdc2d58388b4568",
             "parentId": "25d01e8e3bc0dbeffca9c59b",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "f1e9c3cabacc7efe8aaebc1a",
             "_tpl": "5ae30e795acfc408fb139a0b",
             "parentId": "25d01e8e3bc0dbeffca9c59b",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "25d01e8e3bc0dbeffca9c59b",
             "_tpl": "55d3632e4bdc2d972f8b4569",
             "parentId": "06a61c974ade41bed2d81545",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "3bea6f87c61fe27e44cb30be",
             "_tpl": "637f57a68d137b27f70c4968",
             "parentId": "9b938df8628c6dfb9aedc2be",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "9b938df8628c6dfb9aedc2be",
             "_tpl": "5ae30db85acfc408fb139a05",
             "parentId": "06a61c974ade41bed2d81545",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "1f90b1bdc2107e8f56ac8ffb",
             "_tpl": "5ae30bad5acfc400185c2dc4",
             "parentId": "06a61c974ade41bed2d81545",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "06a61c974ade41bed2d81545",
             "_tpl": "55d355e64bdc2d962f8b4569",
             "parentId": "f7afeb9dcd44e5c2df0fdebe",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "3fcdbbecf7b4bd0bad2ad482",
             "_tpl": "55d4ae6c4bdc2d8b2f8b456e",
             "parentId": "bb079fffcf5c314023947fd9",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "bb079fffcf5c314023947fd9",
             "_tpl": "5649be884bdc2d79388b4577",
             "parentId": "f7afeb9dcd44e5c2df0fdebe",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "895baec8ce75eda10c36c3fb",
             "_tpl": "55d44fd14bdc2d962f8b456e",
             "parentId": "f7afeb9dcd44e5c2df0fdebe",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "9ce25be3e360b9a02c34bfeb",
             "_tpl": "5fbcc1d9016cce60e8341ab3",
             "parentId": "hideout",
@@ -4471,80 +4096,67 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f72fb2a5b7ddedc7c91e4a6a",
             "_tpl": "5fbcbd6c187fea44d52eda14",
             "parentId": "9ce25be3e360b9a02c34bfeb",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "cafe8fbcab4eed8e1d3d16dd",
             "_tpl": "55d4887d4bdc2d962f8b4570",
             "parentId": "9ce25be3e360b9a02c34bfeb",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "bbf88da0a1357ebadda6b51d",
             "_tpl": "5fbcc3e4d6fa9c00c571bb58",
             "parentId": "9ce25be3e360b9a02c34bfeb",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "b3a132ffae4d8fa98d9cfdfa",
             "_tpl": "5fbbfacda56d053a3543f799",
             "parentId": "bbf88da0a1357ebadda6b51d",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "531effb0ca6deb5cd1f6c8a7",
             "_tpl": "5fbc22ccf24b94483f726483",
             "parentId": "b3a132ffae4d8fa98d9cfdfa",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "7bbebae2dccc59173ad16c74",
             "_tpl": "5fbcbd10ab884124df0cd563",
             "parentId": "531effb0ca6deb5cd1f6c8a7",
             "slotId": "mod_muzzle_000"
-        },
-        {
+        }, {
             "_id": "4fac6f3475f12ec25c90cade",
             "_tpl": "5fbc210bf24b94483f726481",
             "parentId": "b3a132ffae4d8fa98d9cfdfa",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "dcef94e2c5a49d35ade47ec1",
             "_tpl": "5fbc226eca32ed67276c155d",
             "parentId": "bbf88da0a1357ebadda6b51d",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "4f6be6a28c8f60cd7bfc9a48",
             "_tpl": "5fc0fa362770a0045c59c677",
             "parentId": "dcef94e2c5a49d35ade47ec1",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "cfdafcdcd3cf7ed2a7dbaab1",
             "_tpl": "5fc0fa957283c4046c58147e",
             "parentId": "bbf88da0a1357ebadda6b51d",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "c8aa4c78fbaccf75112e57ba",
             "_tpl": "5fbcc437d724d907e2077d5c",
             "parentId": "9ce25be3e360b9a02c34bfeb",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "445d0a7d88cfbf9becffc2ac",
             "_tpl": "5fbcc640016cce60e8341acc",
             "parentId": "9ce25be3e360b9a02c34bfeb",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "6ea1ffe9eee54b1cf36376cf",
             "_tpl": "59ff346386f77477562ff5e2",
             "parentId": "hideout",
@@ -4555,68 +4167,57 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b5bbeef5bf667dd19eeb5724",
             "_tpl": "59d64ec286f774171d1e0a42",
             "parentId": "6ea1ffe9eee54b1cf36376cf",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "25cdd661ddd2f0be21527b83",
             "_tpl": "59d64f2f86f77417193ef8b3",
             "parentId": "b5bbeef5bf667dd19eeb5724",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "2fe1a7aa746cf5e3bfd3da92",
             "_tpl": "59d64fc686f774171b243fe2",
             "parentId": "6ea1ffe9eee54b1cf36376cf",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "df4882e7bc7f796ea8f3c4bd",
             "_tpl": "5a0071d486f77404e23a12b2",
             "parentId": "6ea1ffe9eee54b1cf36376cf",
             "slotId": "mod_pistol_grip_akms"
-        },
-        {
+        }, {
             "_id": "6fcc0e5329fdba91cc6cef1a",
             "_tpl": "59d6507c86f7741b846413a2",
             "parentId": "6ea1ffe9eee54b1cf36376cf",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "fcdb1081a3f9ffad42e4a655",
             "_tpl": "59d650cf86f7741b846413a4",
             "parentId": "6ea1ffe9eee54b1cf36376cf",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "458bb96d37e3127bd4f2e0ad",
             "_tpl": "5a0ed824fcdbcb0176308b0d",
             "parentId": "fcdb1081a3f9ffad42e4a655",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "bbcdc23440953f7b9ceffe3e",
             "_tpl": "59ff3b6a86f77477562ff5ed",
             "parentId": "6ea1ffe9eee54b1cf36376cf",
             "slotId": "mod_stock_akms"
-        },
-        {
+        }, {
             "_id": "68e6fc29a72bd3fe9bc387d1",
             "_tpl": "5a0060fc86f7745793204432",
             "parentId": "6ea1ffe9eee54b1cf36376cf",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "8edaf1cd40dcdc10eceeeecc",
             "_tpl": "5a0f096dfcdbcb0176308b15",
             "parentId": "6ea1ffe9eee54b1cf36376cf",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "acd6e280bed6cd2af5c9cb1e",
             "_tpl": "5cbdaf89ae9215000e5b9c94",
             "parentId": "hideout",
@@ -4627,8 +4228,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b0e4c1aadbd05c70bb4bae11",
             "_tpl": "5ac66c5d5acfc4001718d314",
             "parentId": "hideout",
@@ -4639,8 +4239,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ff2be5592cff0c39dc6ce2f4",
             "_tpl": "5448c1d04bdc2dff2f8b4569",
             "parentId": "hideout",
@@ -4651,8 +4250,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fc44da03ac88feee8bde7fbd",
             "_tpl": "5e21a3c67e40bd02257a008a",
             "parentId": "hideout",
@@ -4663,8 +4261,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "5bf4e8e362ffdfdb08c8ddee",
             "_tpl": "5ac66d9b5acfc4001633997a",
             "parentId": "hideout",
@@ -4675,56 +4272,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "1ad42621d9eeae6619212f9c",
             "_tpl": "59c6633186f7740cf0493bb9",
             "parentId": "5bf4e8e362ffdfdb08c8ddee",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "85dbdcbec0dbefbb6157a572",
             "_tpl": "5648b1504bdc2d9d488b4584",
             "parentId": "1ad42621d9eeae6619212f9c",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "cc5daf3e75cb0be0a9d126cf",
             "_tpl": "5ac72e945acfc43f3b691116",
             "parentId": "5bf4e8e362ffdfdb08c8ddee",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "14ccbebf9fa5fdae4110bbde",
             "_tpl": "5649ade84bdc2d1b2b8b4587",
             "parentId": "5bf4e8e362ffdfdb08c8ddee",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "0ffed87271fc3e8c9d8a6a7d",
             "_tpl": "5ac50da15acfc4001718d287",
             "parentId": "5bf4e8e362ffdfdb08c8ddee",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "bdfdc1efbbaedafaf20faedb",
             "_tpl": "5ac733a45acfc400192630e2",
             "parentId": "5bf4e8e362ffdfdb08c8ddee",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "da8b048af6eab745a3427bac",
             "_tpl": "5ac50c185acfc400163398d4",
             "parentId": "5bf4e8e362ffdfdb08c8ddee",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "de493c5952ffcd84ca00bff8",
             "_tpl": "55d480c04bdc2d1d4e8b456a",
             "parentId": "5bf4e8e362ffdfdb08c8ddee",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "d7aa8ebca8cacbc741cafd9a",
             "_tpl": "6184055050224f204c1da540",
             "parentId": "hideout",
@@ -4735,92 +4323,77 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "db90d52b89fb7bc9b7fecb5c",
             "_tpl": "55d4b9964bdc2d1d4e8b456e",
             "parentId": "d7aa8ebca8cacbc741cafd9a",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "8dfc76e2eaec2e41f2e7eaef",
             "_tpl": "61840bedd92c473c77021635",
             "parentId": "d7aa8ebca8cacbc741cafd9a",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "d76f9bef4c7eaed6acc4db98",
             "_tpl": "618405198004cc50514c3594",
             "parentId": "d7aa8ebca8cacbc741cafd9a",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "ad5f2bba4abb68eb1987f1d0",
             "_tpl": "6183fd9e8004cc50514c358f",
             "parentId": "d76f9bef4c7eaed6acc4db98",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "6c2c08eb407f8a5bff93cc5c",
             "_tpl": "618407a850224f204c1da549",
             "parentId": "ad5f2bba4abb68eb1987f1d0",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "6a7faf83c66cba7f49cbaf6a",
             "_tpl": "61816fcad92c473c770215cc",
             "parentId": "ad5f2bba4abb68eb1987f1d0",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "dbcbc4faa7087875dc3be4bc",
             "_tpl": "61817865d3a39d50044c13a4",
             "parentId": "d76f9bef4c7eaed6acc4db98",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "64e9aa5d7d000ea7adecc7bd",
             "_tpl": "61816df1d3a39d50044c139e",
             "parentId": "d76f9bef4c7eaed6acc4db98",
             "slotId": "mod_mount_000"
-        },
-        {
+        }, {
             "_id": "f2a62d5edadaf23af6a691c1",
             "_tpl": "61816dfa6ef05c2ce828f1ad",
             "parentId": "d76f9bef4c7eaed6acc4db98",
             "slotId": "mod_mount_001"
-        },
-        {
+        }, {
             "_id": "11dcf8c6eb15c46dbfaa8cf8",
             "_tpl": "61816734d8e3106d9806c1f3",
             "parentId": "d7aa8ebca8cacbc741cafd9a",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "a21d39aeab2cceee868bebdf",
             "_tpl": "618167528004cc50514c34f9",
             "parentId": "11dcf8c6eb15c46dbfaa8cf8",
             "slotId": "mod_stock_001"
-        },
-        {
+        }, {
             "_id": "36ff63e4fdeff885cfcbbddd",
             "_tpl": "618167616ef05c2ce828f1a8",
             "parentId": "a21d39aeab2cceee868bebdf",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "b8afc4b29d061d2ba2dbccdd",
             "_tpl": "618167441cb55961fa0fdc71",
             "parentId": "11dcf8c6eb15c46dbfaa8cf8",
             "slotId": "mod_stock_002"
-        },
-        {
+        }, {
             "_id": "c804783caeff93f3e2edc4a2",
             "_tpl": "6181688c6c780c1e710c9b04",
             "parentId": "d7aa8ebca8cacbc741cafd9a",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "009d6cecd1806d108ca1f87d",
             "_tpl": "5bb2475ed4351e00853264e3",
             "parentId": "hideout",
@@ -4831,74 +4404,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "0ebfb6c22be78adaa1fa01d8",
             "_tpl": "5bb20e0ed4351e3bac1212dc",
             "parentId": "009d6cecd1806d108ca1f87d",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "029ddb77f1d45c074bc98ef6",
             "_tpl": "5c05413a0db834001c390617",
             "parentId": "009d6cecd1806d108ca1f87d",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "c08cd00e41533f9fd65e8c1b",
             "_tpl": "5bb20d53d4351e4502010a69",
             "parentId": "009d6cecd1806d108ca1f87d",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "d7aa11adea3f755f7ca6d0ca",
             "_tpl": "5bb20d9cd4351e00334c9d8a",
             "parentId": "c08cd00e41533f9fd65e8c1b",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "4f8e7fc9bbb6ff6fba11bccb",
             "_tpl": "544a38634bdc2d58388b4568",
             "parentId": "d7aa11adea3f755f7ca6d0ca",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "4d3e5f5f0cf13e0aef008e1b",
             "_tpl": "5bb20dcad4351e3bac1212da",
             "parentId": "d7aa11adea3f755f7ca6d0ca",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "c7bdecbabaaedce201aa0c07",
             "_tpl": "5bb20de5d4351e0035629e59",
             "parentId": "c08cd00e41533f9fd65e8c1b",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "bced98d0ad6c0dc5fc8c48c5",
             "_tpl": "5bb20e49d4351e3bac1212de",
             "parentId": "c08cd00e41533f9fd65e8c1b",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "139b4327386ad3e466a4d4ce",
             "_tpl": "5bb20e58d4351e00320205d7",
             "parentId": "009d6cecd1806d108ca1f87d",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "fec2dc53bed4b9a9c7bb844f",
             "_tpl": "5bb20e70d4351e0035629f8f",
             "parentId": "139b4327386ad3e466a4d4ce",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "cfbe1a6cf30aefbfdacadf2a",
             "_tpl": "5bb20dbcd4351e44f824c04e",
             "parentId": "009d6cecd1806d108ca1f87d",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "d3f4fad38fbd5a9c885ffb7b",
             "_tpl": "5d43021ca4b9362eab4b5e25",
             "parentId": "hideout",
@@ -4909,86 +4470,72 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "42eb9869c4bbe9ab9f4df7ff",
             "_tpl": "55802f5d4bdc2dac148b458f",
             "parentId": "d3f4fad38fbd5a9c885ffb7b",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "e7e2c083e2201cea431bcfac",
             "_tpl": "5aaa5dfee5b5b000140293d3",
             "parentId": "d3f4fad38fbd5a9c885ffb7b",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "2ffd6054dfbfdb180ebd9d37",
             "_tpl": "5d4405aaa4b9361e6a4e6bd3",
             "parentId": "d3f4fad38fbd5a9c885ffb7b",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "b9f401f05cdac0cdfacf37ae",
             "_tpl": "5d440b93a4b9364276578d4b",
             "parentId": "2ffd6054dfbfdb180ebd9d37",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "ca1e04034ac2a0fbb0584b09",
             "_tpl": "5d440625a4b9361eec4ae6c5",
             "parentId": "b9f401f05cdac0cdfacf37ae",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "f58a9f7ddb509e362daa2a4a",
             "_tpl": "5d44064fa4b9361e4f6eb8b5",
             "parentId": "ca1e04034ac2a0fbb0584b09",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "cc5304c6b1c66e0e9fa07906",
             "_tpl": "56eabcd4d2720b66698b4574",
             "parentId": "b9f401f05cdac0cdfacf37ae",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "2cc467768896cbe4d7ddcbc2",
             "_tpl": "5d4405f0a4b9361e6a4e6bd9",
             "parentId": "2ffd6054dfbfdb180ebd9d37",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "31db8af5462663b31a6acbf7",
             "_tpl": "5b7be47f5acfc400170e2dd2",
             "parentId": "2cc467768896cbe4d7ddcbc2",
             "slotId": "mod_mount_004"
-        },
-        {
+        }, {
             "_id": "1f0c74eb6bb6ebd9ecc0d5b1",
             "_tpl": "5b7be4895acfc400170e2dd5",
             "parentId": "2cc467768896cbe4d7ddcbc2",
             "slotId": "mod_foregrip"
-        },
-        {
+        }, {
             "_id": "bf407c87abb3ee3a7efdfaa2",
             "_tpl": "5649be884bdc2d79388b4577",
             "parentId": "d3f4fad38fbd5a9c885ffb7b",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "8c46fba1aec27a63fe89bafd",
             "_tpl": "5d4406a8a4b9361e4f6eb8b7",
             "parentId": "bf407c87abb3ee3a7efdfaa2",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "5d00c1969dfdccd6642dad94",
             "_tpl": "5d44334ba4b9362b346d1948",
             "parentId": "d3f4fad38fbd5a9c885ffb7b",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "bbeaaaedce2a9bf8fd1a8251",
             "_tpl": "5ac66d725acfc43b321d4b60",
             "parentId": "hideout",
@@ -4999,56 +4546,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "17c2bad9b6d8cccbda7ed4fd",
             "_tpl": "5648b1504bdc2d9d488b4584",
             "parentId": "ae3bb6bce5a15febdf4807b7",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "ae3bb6bce5a15febdf4807b7",
             "_tpl": "59c6633186f7740cf0493bb9",
             "parentId": "bbeaaaedce2a9bf8fd1a8251",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "4f0be201f0b0a4ddfa6f88d4",
             "_tpl": "5ac72e895acfc43b321d4bd5",
             "parentId": "bbeaaaedce2a9bf8fd1a8251",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "e77e3ecdf5917dde68fceb05",
             "_tpl": "5649ade84bdc2d1b2b8b4587",
             "parentId": "bbeaaaedce2a9bf8fd1a8251",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "67dfacf57c2c4aec53be83b5",
             "_tpl": "5ac50da15acfc4001718d287",
             "parentId": "bbeaaaedce2a9bf8fd1a8251",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "dc8ebbd1c76bcaae2bd2b750",
             "_tpl": "5ac733a45acfc400192630e2",
             "parentId": "bbeaaaedce2a9bf8fd1a8251",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "ac2ee5dedae9ede66b0c5bdc",
             "_tpl": "5ac50c185acfc400163398d4",
             "parentId": "bbeaaaedce2a9bf8fd1a8251",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "15b8cb1a6db7cd36fce2571f",
             "_tpl": "5ac66bea5acfc43b321d4aec",
             "parentId": "bbeaaaedce2a9bf8fd1a8251",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "9c5ef2be33cc074cc80fd688",
             "_tpl": "564ca9df4bdc2d35148b4569",
             "parentId": "hideout",
@@ -5059,8 +4597,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "09e0f2ebb6ddec747acfa310",
             "_tpl": "544a378f4bdc2d30388b4567",
             "parentId": "hideout",
@@ -5071,8 +4608,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "525e9188f021e8b2acff23be",
             "_tpl": "5d1340bdd7ad1a0e8d245aab",
             "parentId": "hideout",
@@ -5083,8 +4619,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "9b1f0add467fc69d1bc4ccb4",
             "_tpl": "5b1fb3e15acfc4001637f068",
             "parentId": "hideout",
@@ -5095,8 +4630,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "afd34f681f6efeaa0321bb84",
             "_tpl": "606587252535c57a13424cfd",
             "parentId": "hideout",
@@ -5107,80 +4641,67 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "63cdcde3b79dba649d1ef1b1",
             "_tpl": "55802f5d4bdc2dac148b458f",
             "parentId": "afd34f681f6efeaa0321bb84",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "dfaafc6ad69ea1deebac9cae",
             "_tpl": "59d6272486f77466146386ff",
             "parentId": "afd34f681f6efeaa0321bb84",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "c229ec04febbe6f88f2beb90",
             "_tpl": "606587a88900dc2d9a55b659",
             "parentId": "afd34f681f6efeaa0321bb84",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "8ea098cdaae040fee1371a62",
             "_tpl": "60658776f2cb2e02a42ace2b",
             "parentId": "c229ec04febbe6f88f2beb90",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "d7f5f9b5ffc9bf7dcdc4770f",
             "_tpl": "6065c6e7132d4d12c81fd8e1",
             "parentId": "8ea098cdaae040fee1371a62",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "d1ae3a1ded58d04c89ffe14e",
             "_tpl": "6065dc8a132d4d12c81fd8e3",
             "parentId": "8ea098cdaae040fee1371a62",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "4d049b61e3bdccdcb22f392c",
             "_tpl": "6065880c132d4d12c81fd8da",
             "parentId": "c229ec04febbe6f88f2beb90",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "b3e0be61acdfbd6a452eddae",
             "_tpl": "5bc09a30d4351e00367fb7c8",
             "parentId": "4d049b61e3bdccdcb22f392c",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "3cea6dbf68c2dbcdbc6083d9",
             "_tpl": "5bc09a18d4351e003562b68e",
             "parentId": "c229ec04febbe6f88f2beb90",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "db13cef5a5de88b3d8e1abff",
             "_tpl": "606587e18900dc2d9a55b65f",
             "parentId": "afd34f681f6efeaa0321bb84",
             "slotId": "mod_stock_001"
-        },
-        {
+        }, {
             "_id": "dcbafbad8beef891b74a13de",
             "_tpl": "606587d11246154cad35d635",
             "parentId": "db13cef5a5de88b3d8e1abff",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "b1e8cfc65e81e1bae6b39bb4",
             "_tpl": "606587bd6d0bd7580617bacc",
             "parentId": "afd34f681f6efeaa0321bb84",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "8a099caacbfbf8b1dcdaf63b",
             "_tpl": "5c488a752e221602b412af63",
             "parentId": "hideout",
@@ -5191,38 +4712,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "98ff93ffde463cf85aec63a2",
             "_tpl": "5c48a2c22e221602b313fb6c",
             "parentId": "8a099caacbfbf8b1dcdaf63b",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "ae5af0cfeb295faaaafe64f6",
             "_tpl": "55802d5f4bdc2dac148b458e",
             "parentId": "8a099caacbfbf8b1dcdaf63b",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "6bf9a033109de0d0d54a6aac",
             "_tpl": "5c48a14f2e2216152006edd7",
             "parentId": "8a099caacbfbf8b1dcdaf63b",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "0915f0dd1ed16ecbc3ca16c8",
             "_tpl": "5c48a2852e221602b21d5923",
             "parentId": "8a099caacbfbf8b1dcdaf63b",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "5d597ff21abb99c7ea7de0ea",
             "_tpl": "5c48a2a42e221602b66d1e07",
             "parentId": "0915f0dd1ed16ecbc3ca16c8",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "b1c647f0b20aa881ba8fd022",
             "_tpl": "5b0bbe4e5acfc40dc528a72d",
             "parentId": "hideout",
@@ -5233,74 +4748,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "80cfca0f5eda6a4f97bb6fad",
             "_tpl": "5b099b965acfc400186331e6",
             "parentId": "b1c647f0b20aa881ba8fd022",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "95a7028a70ce8b6f540b48f7",
             "_tpl": "5b099ac65acfc400186331e1",
             "parentId": "b1c647f0b20aa881ba8fd022",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "27f2ecb3e503c4f57ef7796a",
             "_tpl": "5b099a9d5acfc47a8607efe7",
             "parentId": "b1c647f0b20aa881ba8fd022",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "ced53204fac6a7b5ae1f4b9b",
             "_tpl": "5b099b7d5acfc400186331e4",
             "parentId": "410ae6ceeb2fd89151aab4bd",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "410ae6ceeb2fd89151aab4bd",
             "_tpl": "5b099a765acfc47a8607efe3",
             "parentId": "b1c647f0b20aa881ba8fd022",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "215223de7cd828cb10e6ddad",
             "_tpl": "5b0bc22d5acfc47a8607f085",
             "parentId": "b1c647f0b20aa881ba8fd022",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "e2afc14ac68ddcea0f078395",
             "_tpl": "5b099bb25acfc400186331e8",
             "parentId": "b1c647f0b20aa881ba8fd022",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "c3ccaaa97ca0008b0f7cebc5",
             "_tpl": "58d2912286f7744e27117493",
             "parentId": "1e091e6d3597b937aae760b6",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "1e091e6d3597b937aae760b6",
             "_tpl": "56eabf3bd2720b75698b4569",
             "parentId": "0af38bfaa1970f5614af80fd",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "0af38bfaa1970f5614af80fd",
             "_tpl": "5649be884bdc2d79388b4577",
             "parentId": "a5ddfda4b104c23b77a9bff1",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "a5ddfda4b104c23b77a9bff1",
             "_tpl": "5b099bf25acfc4001637e683",
             "parentId": "b1c647f0b20aa881ba8fd022",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "ab2dc3ce4e83c14fa8d7ec23",
             "_tpl": "6165ac306ef05c2ce828ef74",
             "parentId": "hideout",
@@ -5311,92 +4814,77 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "3c1ddabec4b2a61fd138a2d2",
             "_tpl": "571659bb2459771fb2755a12",
             "parentId": "ab2dc3ce4e83c14fa8d7ec23",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "f3beca9efaf9f5ee64c8eca2",
             "_tpl": "6183d53f1cb55961fa0fdcda",
             "parentId": "ab2dc3ce4e83c14fa8d7ec23",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "d62c8edb1b5cdca015a3d47f",
             "_tpl": "618178aa1cb55961fa0fdc80",
             "parentId": "8bac77df6b2efe3de8c2d4d5",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "5aaf374e5cf4bd8ee1e4d98c",
             "_tpl": "61816fcad92c473c770215cc",
             "parentId": "8bac77df6b2efe3de8c2d4d5",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "8bac77df6b2efe3de8c2d4d5",
             "_tpl": "6183b0711cb55961fa0fdcad",
             "parentId": "b41ef74c3aa93adbe2c7cf71",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "adbb07dd6ee8da098c88d12f",
             "_tpl": "61817865d3a39d50044c13a4",
             "parentId": "b41ef74c3aa93adbe2c7cf71",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "e77f4f4f39adebc1e4d5ae3f",
             "_tpl": "61816df1d3a39d50044c139e",
             "parentId": "b41ef74c3aa93adbe2c7cf71",
             "slotId": "mod_mount_000"
-        },
-        {
+        }, {
             "_id": "aaa27b00c73cecaabfa4c87f",
             "_tpl": "61816dfa6ef05c2ce828f1ad",
             "parentId": "b41ef74c3aa93adbe2c7cf71",
             "slotId": "mod_mount_001"
-        },
-        {
+        }, {
             "_id": "b41ef74c3aa93adbe2c7cf71",
             "_tpl": "6165aeedfaa1272e431521e3",
             "parentId": "ab2dc3ce4e83c14fa8d7ec23",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "b5b336a22cfaa10d9bee8f1c",
             "_tpl": "618167616ef05c2ce828f1a8",
             "parentId": "c4d427dccb3defec461ccf5f",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "c4d427dccb3defec461ccf5f",
             "_tpl": "61825d136ef05c2ce828f1cc",
             "parentId": "deeeae2278a5bafccbdde3ca",
             "slotId": "mod_stock_001"
-        },
-        {
+        }, {
             "_id": "370aea4ca4b1a3b10926087a",
             "_tpl": "61825d24d3a39d50044c13af",
             "parentId": "deeeae2278a5bafccbdde3ca",
             "slotId": "mod_stock_002"
-        },
-        {
+        }, {
             "_id": "deeeae2278a5bafccbdde3ca",
             "_tpl": "61825d06d92c473c770215de",
             "parentId": "ab2dc3ce4e83c14fa8d7ec23",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "c8f7dc63cf8ae3c05cde1dfb",
             "_tpl": "6181688c6c780c1e710c9b04",
             "parentId": "ab2dc3ce4e83c14fa8d7ec23",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "ccfd666d9cbcaa0da2bbffcf",
             "_tpl": "5dcbd56fdbd3d91b3e5468d5",
             "parentId": "hideout",
@@ -5407,38 +4895,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c1a02c2f1253e0edbde1cddf",
             "_tpl": "5dcbd6dddbd3d91b3e5468de",
             "parentId": "ccfd666d9cbcaa0da2bbffcf",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "f5f1c33d1b1576789fdd95b7",
             "_tpl": "5a3501acc4a282000d72293a",
             "parentId": "ccfd666d9cbcaa0da2bbffcf",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "6703184bbbc920e77759bef0",
             "_tpl": "5dcbd6b46ec07c0c4347a564",
             "parentId": "ccfd666d9cbcaa0da2bbffcf",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "df3efd356bc2f2d7faf9b702",
             "_tpl": "5dcbe9431e1f4616d354987e",
             "parentId": "ccfd666d9cbcaa0da2bbffcf",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "7dedb9fdd14deaab7bbf7ceb",
             "_tpl": "5dcbe965e4ed22586443a79d",
             "parentId": "df3efd356bc2f2d7faf9b702",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "b88ad5eb1bdebda76f6aff1f",
             "_tpl": "5cadfbf7ae92152ac412eeef",
             "parentId": "hideout",
@@ -5449,44 +4931,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "1722caec8acb7bcabf9cefb3",
             "_tpl": "5caf17c9ae92150b30006be1",
             "parentId": "b88ad5eb1bdebda76f6aff1f",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "c2243f141ed80ff96da63e65",
             "_tpl": "5caf1041ae92157c28402e3f",
             "parentId": "b88ad5eb1bdebda76f6aff1f",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "33d949838bab210faee021ca",
             "_tpl": "5caf16a2ae92152ac412efbc",
             "parentId": "b88ad5eb1bdebda76f6aff1f",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "97eeebc2eb1d6cfa9ac55fcb",
             "_tpl": "5cdaa99dd7f00c002412d0b2",
             "parentId": "b88ad5eb1bdebda76f6aff1f",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "ce3eecabaaefb4c451a7ecae",
             "_tpl": "5cda9bcfd7f00c0c0b53e900",
             "parentId": "97eeebc2eb1d6cfa9ac55fcb",
             "slotId": "mod_foregrip"
-        },
-        {
+        }, {
             "_id": "8a9a05ea3c4eaf4fcbb67d12",
             "_tpl": "5caf1691ae92152ac412efb9",
             "parentId": "b88ad5eb1bdebda76f6aff1f",
             "slotId": "mod_scope"
-        },
-        {
+        }, {
             "_id": "c7f609cf854ed2d2a2d2a49a",
             "_tpl": "5caf1041ae92157c28402e3f",
             "parentId": "hideout",
@@ -5497,8 +4972,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "068d2acdaeeebbdbced8cb9f",
             "_tpl": "5c6592372e221600133e47d7",
             "parentId": "hideout",
@@ -5509,8 +4983,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "3252770cddbeb28272aa70c7",
             "_tpl": "5c6175362e221600133e3b94",
             "parentId": "hideout",
@@ -5521,8 +4994,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "80a3e7b7fc957d25ceefa219",
             "_tpl": "5df8f541c41b2312ea3335e3",
             "parentId": "hideout",
@@ -5533,8 +5005,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "1ffe68bf509adbcc118b7ece",
             "_tpl": "5b7c2d1d5acfc43d1028532a",
             "parentId": "hideout",
@@ -5545,8 +5016,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "66ca525ad612fc82421fbaa3",
             "_tpl": "618168dc8004cc50514c34fc",
             "parentId": "hideout",
@@ -5557,8 +5027,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "cba9defaede775b699fafea7",
             "_tpl": "59e6687d86f77411d949b251",
             "parentId": "hideout",
@@ -5569,56 +5038,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bb2efa7f3eb6be8a53ae49b3",
             "_tpl": "59e649f986f77411d949b246",
             "parentId": "cba9defaede775b699fafea7",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "c49256dc4a5ecd3d76e9a3a8",
             "_tpl": "59e898ee86f77427614bd225",
             "parentId": "bb2efa7f3eb6be8a53ae49b3",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "c6eae474a7de6bbf4bac0aca",
             "_tpl": "59e8a00d86f7742ad93b569c",
             "parentId": "cba9defaede775b699fafea7",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "a2b4db4fbcaae62cacff3dd9",
             "_tpl": "59e6318286f77444dd62c4cc",
             "parentId": "cba9defaede775b699fafea7",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "a433161adaaac69ac46405fa",
             "_tpl": "59e6449086f7746c9f75e822",
             "parentId": "cba9defaede775b699fafea7",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "eaeb36b8eb5e6cb51fa6b3f9",
             "_tpl": "59e8977386f77415a553c453",
             "parentId": "cba9defaede775b699fafea7",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "0ad93af908b994e9e73eaeba",
             "_tpl": "59e89d0986f77427600d226e",
             "parentId": "cba9defaede775b699fafea7",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "bf65f2d8effba561abaa5efb",
             "_tpl": "59d625f086f774661516605d",
             "parentId": "cba9defaede775b699fafea7",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "cd706d2bc5c4e45dfeb87b57",
             "_tpl": "59e6152586f77473dc057aa1",
             "parentId": "hideout",
@@ -5629,56 +5089,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7e22bedfaea53cf09baea054",
             "_tpl": "59e649f986f77411d949b246",
             "parentId": "cd706d2bc5c4e45dfeb87b57",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "cbfac4aa77c5eb00de9a8cac",
             "_tpl": "59e6284f86f77440d569536f",
             "parentId": "7e22bedfaea53cf09baea054",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "2bd9e686b3f13b5d33aed7d5",
             "_tpl": "59e61eb386f77440d64f5daf",
             "parentId": "cd706d2bc5c4e45dfeb87b57",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "76daafb3bfa52ad0262bb3c2",
             "_tpl": "59e6318286f77444dd62c4cc",
             "parentId": "cd706d2bc5c4e45dfeb87b57",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "ad5fdaa76d2c56f4fc6dceb4",
             "_tpl": "59e6449086f7746c9f75e822",
             "parentId": "cd706d2bc5c4e45dfeb87b57",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "8dedcbfb7d99fe25d4ef13fa",
             "_tpl": "59d650cf86f7741b846413a4",
             "parentId": "cd706d2bc5c4e45dfeb87b57",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "ed8a35505afce2db26d30a71",
             "_tpl": "59e6227d86f77440d64f5dc2",
             "parentId": "cd706d2bc5c4e45dfeb87b57",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "e3e1bfdeb367d8583fc76b09",
             "_tpl": "59d625f086f774661516605d",
             "parentId": "cd706d2bc5c4e45dfeb87b57",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "ed1d018635ec71b82a0fdf69",
             "_tpl": "5c07c60e0db834002330051f",
             "parentId": "hideout",
@@ -5689,62 +5140,52 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "6ebcb5e02d5ec2db1cb048cc",
             "_tpl": "5c0e2ff6d174af02a1659d4a",
             "parentId": "ed1d018635ec71b82a0fdf69",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "27caed6d4fc37dd40abf064a",
             "_tpl": "5aaa5e60e5b5b000140293d6",
             "parentId": "ed1d018635ec71b82a0fdf69",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "ee6c9cf5e813afcdfd30b1ba",
             "_tpl": "5c0e2f26d174af02a9625114",
             "parentId": "ed1d018635ec71b82a0fdf69",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "bca8861d9dc82ff0a27a38e1",
             "_tpl": "5c0e2f94d174af029f650d56",
             "parentId": "ee6c9cf5e813afcdfd30b1ba",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "cc499d2c61cdda014ee70547",
             "_tpl": "5c0fafb6d174af02a96260ba",
             "parentId": "bca8861d9dc82ff0a27a38e1",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "68caa0fbb6b26a090bdcbca7",
             "_tpl": "5ae30e795acfc408fb139a0b",
             "parentId": "bca8861d9dc82ff0a27a38e1",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "3f0eb0f2d7894dacb6bbd16c",
             "_tpl": "5c0e2f5cd174af02a012cfc9",
             "parentId": "ee6c9cf5e813afcdfd30b1ba",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "a10e4e5b9f3bedeab54dbf92",
             "_tpl": "5c0faeddd174af02a962601f",
             "parentId": "ed1d018635ec71b82a0fdf69",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "ce9c34bc374e6ccdbf62cfdf",
             "_tpl": "5c0faf68d174af02a96260b8",
             "parentId": "ed1d018635ec71b82a0fdf69",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "0751b54d74e5bccbcbdaf625",
             "_tpl": "57dc2fa62459775949412633",
             "parentId": "hideout",
@@ -5755,50 +5196,42 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d045f1ffd7dd0ab2bdbf4ddc",
             "_tpl": "57e3dba62459770f0c32322b",
             "parentId": "0751b54d74e5bccbcbdaf625",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "9dcabfbf9b502551e422b0ff",
             "_tpl": "57dc347d245977596754e7a1",
             "parentId": "0751b54d74e5bccbcbdaf625",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "07bd2f9aae2b5cd83dad7dbd",
             "_tpl": "564ca99c4bdc2d16268b4589",
             "parentId": "0751b54d74e5bccbcbdaf625",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "b9e49a6c3d069f9eb4bac76c",
             "_tpl": "57dc324a24597759501edc20",
             "parentId": "0751b54d74e5bccbcbdaf625",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "2ae4f515dd418cedcb7bc291",
             "_tpl": "57dc334d245977597164366f",
             "parentId": "0751b54d74e5bccbcbdaf625",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "0e7c4ebbcdf8bbde1e1ddcea",
             "_tpl": "59d36a0086f7747e673f3946",
             "parentId": "0751b54d74e5bccbcbdaf625",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "b1caff7cbd2bd0bd5a72ccae",
             "_tpl": "57dc32dc245977596d4ef3d3",
             "parentId": "0e7c4ebbcdf8bbde1e1ddcea",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "243a72c0ecab68e63ef4ba65",
             "_tpl": "583990e32459771419544dd2",
             "parentId": "hideout",
@@ -5809,50 +5242,42 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "11808cb6ab744bf0ba3c430a",
             "_tpl": "5649ad3f4bdc2df8348b4585",
             "parentId": "243a72c0ecab68e63ef4ba65",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "6a68203f9bb27fc6a93c7f0b",
             "_tpl": "57dc347d245977596754e7a1",
             "parentId": "243a72c0ecab68e63ef4ba65",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "bf2cafca018df0777dbbfce3",
             "_tpl": "564ca99c4bdc2d16268b4589",
             "parentId": "243a72c0ecab68e63ef4ba65",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "eafce170a7edc43106f2eee4",
             "_tpl": "57dc324a24597759501edc20",
             "parentId": "243a72c0ecab68e63ef4ba65",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "6e2e54a3aac5de6a790e3e68",
             "_tpl": "57dc334d245977597164366f",
             "parentId": "243a72c0ecab68e63ef4ba65",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "8fdeefcfcfbc66cf8e11db16",
             "_tpl": "57dc32dc245977596d4ef3d3",
             "parentId": "0a7eac3b6ce89ddc97bb1158",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "0a7eac3b6ce89ddc97bb1158",
             "_tpl": "59d36a0086f7747e673f3946",
             "parentId": "243a72c0ecab68e63ef4ba65",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "b6d8749a9b609e46eb910dca",
             "_tpl": "5839a40f24597726f856b511",
             "parentId": "hideout",
@@ -5863,50 +5288,42 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b4c3537e3e1f4f873eb0faf6",
             "_tpl": "5649ad3f4bdc2df8348b4585",
             "parentId": "b6d8749a9b609e46eb910dca",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "40e9e49d3adfdef25ca8eada",
             "_tpl": "57dc347d245977596754e7a1",
             "parentId": "b6d8749a9b609e46eb910dca",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "3bcba5b8efacec70fad8a534",
             "_tpl": "564ca99c4bdc2d16268b4589",
             "parentId": "b6d8749a9b609e46eb910dca",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "afba03c0eabc769e2957b407",
             "_tpl": "57ffb0e42459777d047111c5",
             "parentId": "b6d8749a9b609e46eb910dca",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "dcaf6853bcd9e7bb016dc72e",
             "_tpl": "5839a7742459773cf9693481",
             "parentId": "b6d8749a9b609e46eb910dca",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "c3ca7ce0ddf049388217a12f",
             "_tpl": "59d36a0086f7747e673f3946",
             "parentId": "b6d8749a9b609e46eb910dca",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "78ba09e25976ec90b5abcba3",
             "_tpl": "57dc32dc245977596d4ef3d3",
             "parentId": "c3ca7ce0ddf049388217a12f",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "bafde5fee8bf01e574dffdfd",
             "_tpl": "5ac4cd105acfc40016339859",
             "parentId": "hideout",
@@ -5917,56 +5334,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ebcc1d36c1edc5edebbe4366",
             "_tpl": "59c6633186f7740cf0493bb9",
             "parentId": "bafde5fee8bf01e574dffdfd",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "b7a20c6db4ef0c53414c0e4c",
             "_tpl": "5648b1504bdc2d9d488b4584",
             "parentId": "ebcc1d36c1edc5edebbe4366",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "fabe8981421e2ae4eb5fd0b0",
             "_tpl": "5ac7655e5acfc40016339a19",
             "parentId": "bafde5fee8bf01e574dffdfd",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "db316bf0553d8ff6fbd7cbae",
             "_tpl": "5649ade84bdc2d1b2b8b4587",
             "parentId": "bafde5fee8bf01e574dffdfd",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "b8c62d01cc7d6d35fadc1a9e",
             "_tpl": "5ac50da15acfc4001718d287",
             "parentId": "bafde5fee8bf01e574dffdfd",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "08a9178e7dcaac5ce4261ef9",
             "_tpl": "5ac72e475acfc400180ae6fe",
             "parentId": "bafde5fee8bf01e574dffdfd",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "95ffc100f5eacffdb4b21f7c",
             "_tpl": "5ac50c185acfc400163398d4",
             "parentId": "bafde5fee8bf01e574dffdfd",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "bbfbdeccdfda2cefccddaccf",
             "_tpl": "55d480c04bdc2d1d4e8b456a",
             "parentId": "bafde5fee8bf01e574dffdfd",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "ead9d3a507d7d92f2e24b9a0",
             "_tpl": "5bf3e0490db83400196199af",
             "parentId": "hideout",
@@ -5977,56 +5385,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "0698b285c82aecebe907ad9a",
             "_tpl": "59c6633186f7740cf0493bb9",
             "parentId": "ead9d3a507d7d92f2e24b9a0",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "1f1aff1645dac7fdbffb7dc9",
             "_tpl": "5648b0744bdc2d363b8b4578",
             "parentId": "0698b285c82aecebe907ad9a",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "53dfffc0eaa595b9d3ffce8c",
             "_tpl": "5649aa744bdc2ded0b8b457e",
             "parentId": "ead9d3a507d7d92f2e24b9a0",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "a34e730e5b22dd92dd5e31a1",
             "_tpl": "57e3dba62459770f0c32322b",
             "parentId": "ead9d3a507d7d92f2e24b9a0",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "13ccbcdb59f4f6809f079b3b",
             "_tpl": "5649af094bdc2df8348b4586",
             "parentId": "ead9d3a507d7d92f2e24b9a0",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "54bfaead7b6f4dcba3e2619f",
             "_tpl": "5649b0544bdc2d1b2b8b458a",
             "parentId": "ead9d3a507d7d92f2e24b9a0",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "bbbc7afbd67cbfdee95bfd01",
             "_tpl": "5ab626e4d8ce87272e4c6e43",
             "parentId": "ead9d3a507d7d92f2e24b9a0",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "ab9ca24bef18b433beda5cfc",
             "_tpl": "564ca99c4bdc2d16268b4589",
             "parentId": "ead9d3a507d7d92f2e24b9a0",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "f5dc47ad4ca0c2eecb6dbdbc",
             "_tpl": "5bf3e03b0db834001d2c4a9c",
             "parentId": "hideout",
@@ -6037,56 +5436,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "4e2d6dedd9226c10eabe3efd",
             "_tpl": "59c6633186f7740cf0493bb9",
             "parentId": "f5dc47ad4ca0c2eecb6dbdbc",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "cdba0cfbebf4a48e7cba8bc3",
             "_tpl": "5648b0744bdc2d363b8b4578",
             "parentId": "4e2d6dedd9226c10eabe3efd",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "de7cdceb1eaeee71b5122622",
             "_tpl": "5649aa744bdc2ded0b8b457e",
             "parentId": "f5dc47ad4ca0c2eecb6dbdbc",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "9efc9e427c42a626e49e7ab0",
             "_tpl": "57e3dba62459770f0c32322b",
             "parentId": "f5dc47ad4ca0c2eecb6dbdbc",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "0016a46ac17d5e365eefaed6",
             "_tpl": "5649af094bdc2df8348b4586",
             "parentId": "f5dc47ad4ca0c2eecb6dbdbc",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "ca6bfbe36aa1ff0da9d3d195",
             "_tpl": "5649b0544bdc2d1b2b8b458a",
             "parentId": "f5dc47ad4ca0c2eecb6dbdbc",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "afee84d60bdb1b4fdc0c89a8",
             "_tpl": "5649b1c04bdc2d16268b457c",
             "parentId": "f5dc47ad4ca0c2eecb6dbdbc",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "96c9672eefbeec070bce5e1a",
             "_tpl": "564ca99c4bdc2d16268b4589",
             "parentId": "f5dc47ad4ca0c2eecb6dbdbc",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "0bdbccfd208aeea0ddc47cce",
             "_tpl": "5644bd2b4bdc2d3b4c8b4572",
             "parentId": "hideout",
@@ -6097,56 +5487,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e3f44cfee308eb569a344f59",
             "_tpl": "5648b0744bdc2d363b8b4578",
             "parentId": "a23fae1e7c448d32b2c106ca",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "a23fae1e7c448d32b2c106ca",
             "_tpl": "59c6633186f7740cf0493bb9",
             "parentId": "0bdbccfd208aeea0ddc47cce",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "1ff1fcc16558ab9b45a9b136",
             "_tpl": "5649aa744bdc2ded0b8b457e",
             "parentId": "0bdbccfd208aeea0ddc47cce",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "92a0eccdbca0e144ca57f49c",
             "_tpl": "5649ad3f4bdc2df8348b4585",
             "parentId": "0bdbccfd208aeea0ddc47cce",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "deb7be56eaeb6d36cdeb6c76",
             "_tpl": "5649af094bdc2df8348b4586",
             "parentId": "0bdbccfd208aeea0ddc47cce",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "e9d455d82d1abd050a98d44a",
             "_tpl": "5649b0544bdc2d1b2b8b458a",
             "parentId": "0bdbccfd208aeea0ddc47cce",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "1cfc9db40b2ffcff3be9b95f",
             "_tpl": "5649b1c04bdc2d16268b457c",
             "parentId": "0bdbccfd208aeea0ddc47cce",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "152d254cfc6ca2cc15612c7c",
             "_tpl": "564ca99c4bdc2d16268b4589",
             "parentId": "0bdbccfd208aeea0ddc47cce",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "b9b6184222b2a9f7a8a1381e",
             "_tpl": "5ab8e9fcd8ce870019439434",
             "parentId": "hideout",
@@ -6157,56 +5538,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f23994fa80a4ca7bc37e3e3a",
             "_tpl": "59c6633186f7740cf0493bb9",
             "parentId": "b9b6184222b2a9f7a8a1381e",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "ad9d71f5bcccfca84a5f0a67",
             "_tpl": "5648b0744bdc2d363b8b4578",
             "parentId": "f23994fa80a4ca7bc37e3e3a",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "bf1afa8a8f4079db5c2cfcec",
             "_tpl": "5649aa744bdc2ded0b8b457e",
             "parentId": "b9b6184222b2a9f7a8a1381e",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "fe8b6ffe0ff45ad9b19db3d7",
             "_tpl": "57e3dba62459770f0c32322b",
             "parentId": "b9b6184222b2a9f7a8a1381e",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "36ead7aa77bf2cc8ad4535c5",
             "_tpl": "5649af094bdc2df8348b4586",
             "parentId": "b9b6184222b2a9f7a8a1381e",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "92a7ac88e78390ffbbcc51d5",
             "_tpl": "5649b0544bdc2d1b2b8b458a",
             "parentId": "b9b6184222b2a9f7a8a1381e",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "b0ee508dd4dd8afaa20bdbd9",
             "_tpl": "5ab626e4d8ce87272e4c6e43",
             "parentId": "b9b6184222b2a9f7a8a1381e",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "eb1e88c6edbeaa760c1c5ab0",
             "_tpl": "564ca99c4bdc2d16268b4589",
             "parentId": "b9b6184222b2a9f7a8a1381e",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "268df6124c7584f8acd980ed",
             "_tpl": "5ac66d015acfc400180ae6e4",
             "parentId": "hideout",
@@ -6217,56 +5589,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "cbfe467b40fcb70d5cab923c",
             "_tpl": "59c6633186f7740cf0493bb9",
             "parentId": "268df6124c7584f8acd980ed",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "e6a7f016e7daaaeaa3d08d44",
             "_tpl": "5648b1504bdc2d9d488b4584",
             "parentId": "cbfe467b40fcb70d5cab923c",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "12ecf8f6352bca25dd6a32e6",
             "_tpl": "5ac72e725acfc400180ae701",
             "parentId": "268df6124c7584f8acd980ed",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "b40f4fd049edff1b88fb7aea",
             "_tpl": "5649ade84bdc2d1b2b8b4587",
             "parentId": "268df6124c7584f8acd980ed",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "a86cd9eef68bcbaeae3d0d98",
             "_tpl": "5ac50da15acfc4001718d287",
             "parentId": "268df6124c7584f8acd980ed",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "2daf2083dbef4bb6bddb5da0",
             "_tpl": "5ac733a45acfc400192630e2",
             "parentId": "268df6124c7584f8acd980ed",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "aadf6cddbf3dabbcefb27eaa",
             "_tpl": "5ac50c185acfc400163398d4",
             "parentId": "268df6124c7584f8acd980ed",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "daedc215e5cca911ac26f17f",
             "_tpl": "5ac66c5d5acfc4001718d314",
             "parentId": "268df6124c7584f8acd980ed",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "9dd2c749743a53c9efa92df6",
             "_tpl": "5ac66cb05acfc40198510a10",
             "parentId": "hideout",
@@ -6277,56 +5640,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b25e27fec16ee28e5bb552c6",
             "_tpl": "59c6633186f7740cf0493bb9",
             "parentId": "9dd2c749743a53c9efa92df6",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "0eda86230bf5e67f4d5fdaf6",
             "_tpl": "5648b1504bdc2d9d488b4584",
             "parentId": "b25e27fec16ee28e5bb552c6",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "b8aafda67b9cbc168f06ef64",
             "_tpl": "5ac72e615acfc43f67248aa0",
             "parentId": "9dd2c749743a53c9efa92df6",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "eecbe29ccbcfcddeee9b7a10",
             "_tpl": "5649ade84bdc2d1b2b8b4587",
             "parentId": "9dd2c749743a53c9efa92df6",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "dea23ceed6947607b9fdd47a",
             "_tpl": "5ac50da15acfc4001718d287",
             "parentId": "9dd2c749743a53c9efa92df6",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "fb593e2aefbaa3637ff37bfc",
             "_tpl": "5ac72e475acfc400180ae6fe",
             "parentId": "9dd2c749743a53c9efa92df6",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "adbdd82d349cfafceb813f9c",
             "_tpl": "5ac50c185acfc400163398d4",
             "parentId": "9dd2c749743a53c9efa92df6",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "cc0a74b4ada6c42aa42dd6df",
             "_tpl": "5ac66c5d5acfc4001718d314",
             "parentId": "9dd2c749743a53c9efa92df6",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "51a485bf649f505b4ce23cbc",
             "_tpl": "5447a9cd4bdc2dbd208b4567",
             "parentId": "hideout",
@@ -6337,80 +5691,67 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "05b0430ccc611a1a222cd57d",
             "_tpl": "55d4b9964bdc2d1d4e8b456e",
             "parentId": "51a485bf649f505b4ce23cbc",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "bbaeba2d41be3fbfa3998e5f",
             "_tpl": "55d4887d4bdc2d962f8b4570",
             "parentId": "51a485bf649f505b4ce23cbc",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "bba58e81f0ddc05fcc7de629",
             "_tpl": "544a38634bdc2d58388b4568",
             "parentId": "d7facbe19de72bed5dce5e80",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "05c9996cbbdaf7ac2adf8f67",
             "_tpl": "5ae30e795acfc408fb139a0b",
             "parentId": "d7facbe19de72bed5dce5e80",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "d7facbe19de72bed5dce5e80",
             "_tpl": "55d3632e4bdc2d972f8b4569",
             "parentId": "fc2b86ff54ce0aed7802b31c",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "ebfc0464cd0cbcea79d1ffb2",
             "_tpl": "637f57a68d137b27f70c4968",
             "parentId": "f8f7b2bc4aa6d307d92eff6e",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "f8f7b2bc4aa6d307d92eff6e",
             "_tpl": "5ae30db85acfc408fb139a05",
             "parentId": "fc2b86ff54ce0aed7802b31c",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "7ff3a3ee9fff75e0bc8d4eff",
             "_tpl": "5ae30bad5acfc400185c2dc4",
             "parentId": "fc2b86ff54ce0aed7802b31c",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "fc2b86ff54ce0aed7802b31c",
             "_tpl": "55d355e64bdc2d962f8b4569",
             "parentId": "51a485bf649f505b4ce23cbc",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "f8a368a4eb9ad93b3303af49",
             "_tpl": "55d4ae6c4bdc2d8b2f8b456e",
             "parentId": "51710dec4caf7c46c0af1d38",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "51710dec4caf7c46c0af1d38",
             "_tpl": "5649be884bdc2d79388b4577",
             "parentId": "51a485bf649f505b4ce23cbc",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "f60bf2ed0afd2ae134c0048c",
             "_tpl": "55d44fd14bdc2d962f8b456e",
             "parentId": "51a485bf649f505b4ce23cbc",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "8ecb75b20c8fefdc113e9bf2",
             "_tpl": "5fbcc1d9016cce60e8341ab3",
             "parentId": "hideout",
@@ -6421,80 +5762,67 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f23abcda787b7bd2705a9bce",
             "_tpl": "5fbcbd6c187fea44d52eda14",
             "parentId": "8ecb75b20c8fefdc113e9bf2",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "e3ebf7e4e07bf7c3f017d2ba",
             "_tpl": "55d4887d4bdc2d962f8b4570",
             "parentId": "8ecb75b20c8fefdc113e9bf2",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "43bc14df0a69423a9ecd8fb8",
             "_tpl": "5fbcc3e4d6fa9c00c571bb58",
             "parentId": "8ecb75b20c8fefdc113e9bf2",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "ed1b7bf882017f43f96dee90",
             "_tpl": "5fbbfacda56d053a3543f799",
             "parentId": "43bc14df0a69423a9ecd8fb8",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "9b40d4cba0304f15f4c6b483",
             "_tpl": "5fbc22ccf24b94483f726483",
             "parentId": "ed1b7bf882017f43f96dee90",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "ce46a731cc547fceaa2bfcc9",
             "_tpl": "5fbcbd10ab884124df0cd563",
             "parentId": "9b40d4cba0304f15f4c6b483",
             "slotId": "mod_muzzle_000"
-        },
-        {
+        }, {
             "_id": "da9cae1d6fe78e86fd7a8afc",
             "_tpl": "5fbc210bf24b94483f726481",
             "parentId": "ed1b7bf882017f43f96dee90",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "b25e1d8daaf1cf3c2bd5c9f9",
             "_tpl": "5fbc226eca32ed67276c155d",
             "parentId": "43bc14df0a69423a9ecd8fb8",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "fbe35ac554f28fed26ae9a67",
             "_tpl": "5fc0fa362770a0045c59c677",
             "parentId": "b25e1d8daaf1cf3c2bd5c9f9",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "b34496d4da4453ce83410f4a",
             "_tpl": "5fc0fa957283c4046c58147e",
             "parentId": "43bc14df0a69423a9ecd8fb8",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "a4a84bcedfb76b7afb08b97d",
             "_tpl": "5fbcc437d724d907e2077d5c",
             "parentId": "8ecb75b20c8fefdc113e9bf2",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "4df4b9bef11ccc4fdc1060b7",
             "_tpl": "5fbcc640016cce60e8341acc",
             "parentId": "8ecb75b20c8fefdc113e9bf2",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "ec82a5f1dfb49c7c191ef8bd",
             "_tpl": "59ff346386f77477562ff5e2",
             "parentId": "hideout",
@@ -6505,68 +5833,57 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "9ad66a9dafcef1659ad0ecdc",
             "_tpl": "59d64ec286f774171d1e0a42",
             "parentId": "ec82a5f1dfb49c7c191ef8bd",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "05a651b8bfdfd7abd811b13d",
             "_tpl": "59d64f2f86f77417193ef8b3",
             "parentId": "9ad66a9dafcef1659ad0ecdc",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "a4b4ecd3075c9c7bd6f0aaee",
             "_tpl": "59d64fc686f774171b243fe2",
             "parentId": "ec82a5f1dfb49c7c191ef8bd",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "acc69ed0530414fc4d10c0ec",
             "_tpl": "5a0071d486f77404e23a12b2",
             "parentId": "ec82a5f1dfb49c7c191ef8bd",
             "slotId": "mod_pistol_grip_akms"
-        },
-        {
+        }, {
             "_id": "da3e4cace90a53e4acbd46ac",
             "_tpl": "59d6507c86f7741b846413a2",
             "parentId": "ec82a5f1dfb49c7c191ef8bd",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "277227a60b6af2e03b72f6d8",
             "_tpl": "59d650cf86f7741b846413a4",
             "parentId": "ec82a5f1dfb49c7c191ef8bd",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "7a9cb865edf9b0bc25693c29",
             "_tpl": "5a0ed824fcdbcb0176308b0d",
             "parentId": "277227a60b6af2e03b72f6d8",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "4d749ea867b665b9be9c794d",
             "_tpl": "59ff3b6a86f77477562ff5ed",
             "parentId": "ec82a5f1dfb49c7c191ef8bd",
             "slotId": "mod_stock_akms"
-        },
-        {
+        }, {
             "_id": "7e2bfbd6ff16cd59225e18e2",
             "_tpl": "5a0060fc86f7745793204432",
             "parentId": "ec82a5f1dfb49c7c191ef8bd",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "ac0c9b1680cbdcfce7afa698",
             "_tpl": "5a0f096dfcdbcb0176308b15",
             "parentId": "ec82a5f1dfb49c7c191ef8bd",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "25d9cdc19f953ca2b7e2e19d",
             "_tpl": "5abcbc27d8ce8700182eceeb",
             "parentId": "hideout",
@@ -6577,56 +5894,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e3a5bd1f38b04ae3cdf2662b",
             "_tpl": "59d64f2f86f77417193ef8b3",
             "parentId": "fc3ebbb75f6fec2df5af8822",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "fc3ebbb75f6fec2df5af8822",
             "_tpl": "59d64ec286f774171d1e0a42",
             "parentId": "25d9cdc19f953ca2b7e2e19d",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "c1cfa89b78bdbf8fdba05ecf",
             "_tpl": "59e61eb386f77440d64f5daf",
             "parentId": "25d9cdc19f953ca2b7e2e19d",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "cffcddffcb3e42f65dffdfd9",
             "_tpl": "5a0071d486f77404e23a12b2",
             "parentId": "25d9cdc19f953ca2b7e2e19d",
             "slotId": "mod_pistol_grip_akms"
-        },
-        {
+        }, {
             "_id": "e454b7ab19dc3ff745aceafd",
             "_tpl": "59d6507c86f7741b846413a2",
             "parentId": "25d9cdc19f953ca2b7e2e19d",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "e4055ebe228423ad8baf138c",
             "_tpl": "59d650cf86f7741b846413a4",
             "parentId": "25d9cdc19f953ca2b7e2e19d",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "d80536b25ec3a21def43ae4f",
             "_tpl": "5abcd472d8ce8700166032ae",
             "parentId": "25d9cdc19f953ca2b7e2e19d",
             "slotId": "mod_stock_akms"
-        },
-        {
+        }, {
             "_id": "a99f46aed1df7a85cc731633",
             "_tpl": "5a0060fc86f7745793204432",
             "parentId": "25d9cdc19f953ca2b7e2e19d",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "f63d3e4ae77e8abdfe36d7af",
             "_tpl": "59d6088586f774275f37482f",
             "parentId": "hideout",
@@ -6637,68 +5945,57 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "6fc23e1fb2f1f0486c2d2ac3",
             "_tpl": "59d64ec286f774171d1e0a42",
             "parentId": "f63d3e4ae77e8abdfe36d7af",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "ce64bbafab0fb1da8e0ab99e",
             "_tpl": "59d64f2f86f77417193ef8b3",
             "parentId": "6fc23e1fb2f1f0486c2d2ac3",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "3b8d5b6db7ea40ac5bbcea45",
             "_tpl": "59d64fc686f774171b243fe2",
             "parentId": "f63d3e4ae77e8abdfe36d7af",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "5cf55df4d2cbf143a7afbaa5",
             "_tpl": "59e62cc886f77440d40b52a1",
             "parentId": "f63d3e4ae77e8abdfe36d7af",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "fec9527aa8be6a23cdfcca34",
             "_tpl": "59d6507c86f7741b846413a2",
             "parentId": "f63d3e4ae77e8abdfe36d7af",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "5d89123facdcbded86eb1c7f",
             "_tpl": "59d650cf86f7741b846413a4",
             "parentId": "f63d3e4ae77e8abdfe36d7af",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "7e5a820fe9f7ba89b6b8e67f",
             "_tpl": "5a0ed824fcdbcb0176308b0d",
             "parentId": "5d89123facdcbded86eb1c7f",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "82f9acaaff3ccbbd337f4e09",
             "_tpl": "59d6514b86f774171a068a08",
             "parentId": "f63d3e4ae77e8abdfe36d7af",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "20409428d34ff9b9b4ee71fa",
             "_tpl": "59d625f086f774661516605d",
             "parentId": "f63d3e4ae77e8abdfe36d7af",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "1f81bebe7df8f929ba6e5fcd",
             "_tpl": "5a0f096dfcdbcb0176308b15",
             "parentId": "f63d3e4ae77e8abdfe36d7af",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "9fedefc8bf5bbf109deee2eb",
             "_tpl": "5a0ec13bfcdbcb00165aa685",
             "parentId": "hideout",
@@ -6709,56 +6006,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "5df56b4a11eb4df6e4efe2dd",
             "_tpl": "59d64f2f86f77417193ef8b3",
             "parentId": "7fb2b3fbadcf875e9edac17b",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "7fb2b3fbadcf875e9edac17b",
             "_tpl": "59d64ec286f774171d1e0a42",
             "parentId": "9fedefc8bf5bbf109deee2eb",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "04f4c2dfb5d36abfdb3d83bd",
             "_tpl": "59d64fc686f774171b243fe2",
             "parentId": "9fedefc8bf5bbf109deee2eb",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "6eaec9d20c5f3f3c9b5e2f9c",
             "_tpl": "59e62cc886f77440d40b52a1",
             "parentId": "9fedefc8bf5bbf109deee2eb",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "7326ed6eb49ce5acada80abd",
             "_tpl": "59d6507c86f7741b846413a2",
             "parentId": "9fedefc8bf5bbf109deee2eb",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "f30696bc3eebe1f82ebc9a6e",
             "_tpl": "59d650cf86f7741b846413a4",
             "parentId": "9fedefc8bf5bbf109deee2eb",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "a5e6ccebeb3921ddac8ba6f8",
             "_tpl": "59d6514b86f774171a068a08",
             "parentId": "9fedefc8bf5bbf109deee2eb",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "2f5d5ac4deac3ff2ffc77c2a",
             "_tpl": "5a01c29586f77474660c694c",
             "parentId": "9fedefc8bf5bbf109deee2eb",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "e6a9ac9a2a6d58d04642b3b2",
             "_tpl": "5ac66d9b5acfc4001633997a",
             "parentId": "hideout",
@@ -6769,56 +6057,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "dce7ebc9dad20ccc1facac45",
             "_tpl": "59c6633186f7740cf0493bb9",
             "parentId": "e6a9ac9a2a6d58d04642b3b2",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "bac1c5b6ba92b0eaffcb11ae",
             "_tpl": "5648b1504bdc2d9d488b4584",
             "parentId": "dce7ebc9dad20ccc1facac45",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "ddbb45d5432ceaf1fc30fe3d",
             "_tpl": "5ac72e945acfc43f3b691116",
             "parentId": "e6a9ac9a2a6d58d04642b3b2",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "6f12f1fc8ad59c7fdeef4e9e",
             "_tpl": "5649ade84bdc2d1b2b8b4587",
             "parentId": "e6a9ac9a2a6d58d04642b3b2",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "b3b92b31c3bcfccc69a375b4",
             "_tpl": "5ac50da15acfc4001718d287",
             "parentId": "e6a9ac9a2a6d58d04642b3b2",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "0bcd95becaa5d7589ccbb10d",
             "_tpl": "5ac733a45acfc400192630e2",
             "parentId": "e6a9ac9a2a6d58d04642b3b2",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "f2afc01b501cded821b24d9c",
             "_tpl": "5ac50c185acfc400163398d4",
             "parentId": "e6a9ac9a2a6d58d04642b3b2",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "ba1bedbad2cccad557aa6aae",
             "_tpl": "55d480c04bdc2d1d4e8b456a",
             "parentId": "e6a9ac9a2a6d58d04642b3b2",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "ddcdced49ce92c83f133a8b8",
             "_tpl": "6184055050224f204c1da540",
             "parentId": "hideout",
@@ -6829,92 +6108,77 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "aadf48efcdda991dafbf5a1b",
             "_tpl": "55d4b9964bdc2d1d4e8b456e",
             "parentId": "ddcdced49ce92c83f133a8b8",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "0fadfbbaf3be47a45fb73ffb",
             "_tpl": "61840bedd92c473c77021635",
             "parentId": "ddcdced49ce92c83f133a8b8",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "b2b5f9a097fe1c1c474f0e5e",
             "_tpl": "618405198004cc50514c3594",
             "parentId": "ddcdced49ce92c83f133a8b8",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "eb9d56a613582c728b6d8abb",
             "_tpl": "6183fd9e8004cc50514c358f",
             "parentId": "b2b5f9a097fe1c1c474f0e5e",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "6b91b2adb1f06aaf1aaf4947",
             "_tpl": "618407a850224f204c1da549",
             "parentId": "eb9d56a613582c728b6d8abb",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "76e3f4e8caa1d1ebbca2a5cf",
             "_tpl": "61816fcad92c473c770215cc",
             "parentId": "eb9d56a613582c728b6d8abb",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "284f48e2de3a260bda7c5eae",
             "_tpl": "61817865d3a39d50044c13a4",
             "parentId": "b2b5f9a097fe1c1c474f0e5e",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "67d3da27cccdedf39eacee95",
             "_tpl": "61816df1d3a39d50044c139e",
             "parentId": "b2b5f9a097fe1c1c474f0e5e",
             "slotId": "mod_mount_000"
-        },
-        {
+        }, {
             "_id": "8f06bbddc26e79b08bbe23a8",
             "_tpl": "61816dfa6ef05c2ce828f1ad",
             "parentId": "b2b5f9a097fe1c1c474f0e5e",
             "slotId": "mod_mount_001"
-        },
-        {
+        }, {
             "_id": "2e92d8e2abcaa69f0aaac17e",
             "_tpl": "61816734d8e3106d9806c1f3",
             "parentId": "ddcdced49ce92c83f133a8b8",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "201decbfd1df6515bd55045c",
             "_tpl": "618167528004cc50514c34f9",
             "parentId": "2e92d8e2abcaa69f0aaac17e",
             "slotId": "mod_stock_001"
-        },
-        {
+        }, {
             "_id": "dbcddf10ef9154c6ec06fee8",
             "_tpl": "618167616ef05c2ce828f1a8",
             "parentId": "201decbfd1df6515bd55045c",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "bec407a92363e4b5d2f68082",
             "_tpl": "618167441cb55961fa0fdc71",
             "parentId": "2e92d8e2abcaa69f0aaac17e",
             "slotId": "mod_stock_002"
-        },
-        {
+        }, {
             "_id": "93cd8602bc0c5f32c3f088d2",
             "_tpl": "6181688c6c780c1e710c9b04",
             "parentId": "ddcdced49ce92c83f133a8b8",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "de85b4dc3eaa6fbe1aaade6c",
             "_tpl": "618428466ef05c2ce828f218",
             "parentId": "hideout",
@@ -6925,92 +6189,77 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "17ced69c083bc7fb207eb5a0",
             "_tpl": "571659bb2459771fb2755a12",
             "parentId": "de85b4dc3eaa6fbe1aaade6c",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "ec2acd8e95fafc7e01e6dcd4",
             "_tpl": "61840d85568c120fdd2962a5",
             "parentId": "de85b4dc3eaa6fbe1aaade6c",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "e072bb3a04facd8ab643cdfb",
             "_tpl": "618407a850224f204c1da549",
             "parentId": "a6378eafeb55a51091dec65c",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "6dfd3249b234de5a1dd3b0f2",
             "_tpl": "61816fcad92c473c770215cc",
             "parentId": "a6378eafeb55a51091dec65c",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "a6378eafeb55a51091dec65c",
             "_tpl": "6183fd911cb55961fa0fdce9",
             "parentId": "b06b537fb3c2daec0b3093bc",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "5dceb7efcaedd4fbbff939e0",
             "_tpl": "61817865d3a39d50044c13a4",
             "parentId": "b06b537fb3c2daec0b3093bc",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "b1cebf38ada99bddc5721427",
             "_tpl": "61816df1d3a39d50044c139e",
             "parentId": "b06b537fb3c2daec0b3093bc",
             "slotId": "mod_mount_000"
-        },
-        {
+        }, {
             "_id": "1006aebddde0f9fd739a4bb7",
             "_tpl": "61816dfa6ef05c2ce828f1ad",
             "parentId": "b06b537fb3c2daec0b3093bc",
             "slotId": "mod_mount_001"
-        },
-        {
+        }, {
             "_id": "b06b537fb3c2daec0b3093bc",
             "_tpl": "618426d96c780c1e710c9b9f",
             "parentId": "de85b4dc3eaa6fbe1aaade6c",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "1bf9f5fb90cdec7eee249cdd",
             "_tpl": "618167616ef05c2ce828f1a8",
             "parentId": "19fadb837ec65cb2c6ecbd87",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "19fadb837ec65cb2c6ecbd87",
             "_tpl": "61825d136ef05c2ce828f1cc",
             "parentId": "d9acadc4feacc8174181acf8",
             "slotId": "mod_stock_001"
-        },
-        {
+        }, {
             "_id": "1c4aa0cbaca9cbf8fa029d87",
             "_tpl": "61825d24d3a39d50044c13af",
             "parentId": "d9acadc4feacc8174181acf8",
             "slotId": "mod_stock_002"
-        },
-        {
+        }, {
             "_id": "d9acadc4feacc8174181acf8",
             "_tpl": "61825d06d92c473c770215de",
             "parentId": "de85b4dc3eaa6fbe1aaade6c",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "5e2fade807f32ca69de7cf0d",
             "_tpl": "6181688c6c780c1e710c9b04",
             "parentId": "de85b4dc3eaa6fbe1aaade6c",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "f7253aa7fdb140fe0e3fb6d2",
             "_tpl": "5bb2475ed4351e00853264e3",
             "parentId": "hideout",
@@ -7021,74 +6270,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "243d9dec59a4a5f1dd0cc54a",
             "_tpl": "5bb20e0ed4351e3bac1212dc",
             "parentId": "f7253aa7fdb140fe0e3fb6d2",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "deabbfebfa52dcbadc12b536",
             "_tpl": "5c05413a0db834001c390617",
             "parentId": "f7253aa7fdb140fe0e3fb6d2",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "57daf879bc3ccf953effd911",
             "_tpl": "5bb20d53d4351e4502010a69",
             "parentId": "f7253aa7fdb140fe0e3fb6d2",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "c0cdecdbf6d2f3eb6510bf2f",
             "_tpl": "5bb20d9cd4351e00334c9d8a",
             "parentId": "57daf879bc3ccf953effd911",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "e1f5fefbe99beaa63c54aeee",
             "_tpl": "544a38634bdc2d58388b4568",
             "parentId": "c0cdecdbf6d2f3eb6510bf2f",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "eb3d49feefe5376d58d0ecfc",
             "_tpl": "5bb20dcad4351e3bac1212da",
             "parentId": "c0cdecdbf6d2f3eb6510bf2f",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "e37cb14fb68eb649dfef27ac",
             "_tpl": "5bb20de5d4351e0035629e59",
             "parentId": "57daf879bc3ccf953effd911",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "efc4ad22b724c09fa9cc042b",
             "_tpl": "5bb20e49d4351e3bac1212de",
             "parentId": "57daf879bc3ccf953effd911",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "5a2dbcac88998dfaf8dc00a7",
             "_tpl": "5bb20e58d4351e00320205d7",
             "parentId": "f7253aa7fdb140fe0e3fb6d2",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "05de64beebaaaf8fe4945de6",
             "_tpl": "5bb20e70d4351e0035629f8f",
             "parentId": "5a2dbcac88998dfaf8dc00a7",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "dd9fcaec1cecc216aebeade0",
             "_tpl": "5bb20dbcd4351e44f824c04e",
             "parentId": "f7253aa7fdb140fe0e3fb6d2",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "dab7c8f57398c5eba1a7a9cd",
             "_tpl": "5d43021ca4b9362eab4b5e25",
             "parentId": "hideout",
@@ -7099,86 +6336,72 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ccddf0323afedf07cc8dcfe4",
             "_tpl": "55802f5d4bdc2dac148b458f",
             "parentId": "dab7c8f57398c5eba1a7a9cd",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "983d6cd3a9af2cb3cd8bdb11",
             "_tpl": "5aaa5dfee5b5b000140293d3",
             "parentId": "dab7c8f57398c5eba1a7a9cd",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "67dccffc83fdda43eccb0c87",
             "_tpl": "5d4405aaa4b9361e6a4e6bd3",
             "parentId": "dab7c8f57398c5eba1a7a9cd",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "2f99782c32be7bcb45fddb3f",
             "_tpl": "5d440b93a4b9364276578d4b",
             "parentId": "67dccffc83fdda43eccb0c87",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "fa6ff043378b1ae9a7acbc7f",
             "_tpl": "5d440625a4b9361eec4ae6c5",
             "parentId": "2f99782c32be7bcb45fddb3f",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "2cf9d498cae36aa9b1bde47d",
             "_tpl": "5d44064fa4b9361e4f6eb8b5",
             "parentId": "fa6ff043378b1ae9a7acbc7f",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "f9c51042cdde5575cfd072ed",
             "_tpl": "56eabcd4d2720b66698b4574",
             "parentId": "2f99782c32be7bcb45fddb3f",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "fac924bdd9770e80cacba9a7",
             "_tpl": "5d4405f0a4b9361e6a4e6bd9",
             "parentId": "67dccffc83fdda43eccb0c87",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "8a45ebebcd50b6618f9ef77d",
             "_tpl": "5b7be47f5acfc400170e2dd2",
             "parentId": "fac924bdd9770e80cacba9a7",
             "slotId": "mod_mount_004"
-        },
-        {
+        }, {
             "_id": "7fb7281de8e1529cd6e473dd",
             "_tpl": "5b7be4895acfc400170e2dd5",
             "parentId": "fac924bdd9770e80cacba9a7",
             "slotId": "mod_foregrip"
-        },
-        {
+        }, {
             "_id": "dfdead0c9ba8e1cbceab2fb4",
             "_tpl": "5649be884bdc2d79388b4577",
             "parentId": "dab7c8f57398c5eba1a7a9cd",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "c0beda3565da358cadccd7ac",
             "_tpl": "5d4406a8a4b9361e4f6eb8b7",
             "parentId": "dfdead0c9ba8e1cbceab2fb4",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "af5faf7b42f2bc0feacaa6db",
             "_tpl": "5d44334ba4b9362b346d1948",
             "parentId": "dab7c8f57398c5eba1a7a9cd",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "bc3eee4fb6caeaef28b91a85",
             "_tpl": "5ac66d725acfc43b321d4b60",
             "parentId": "hideout",
@@ -7189,56 +6412,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "40f740faf3dfd6e9f0bd1a1c",
             "_tpl": "5648b1504bdc2d9d488b4584",
             "parentId": "eb5aaeecbffdc7eea5cc00b7",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "eb5aaeecbffdc7eea5cc00b7",
             "_tpl": "59c6633186f7740cf0493bb9",
             "parentId": "bc3eee4fb6caeaef28b91a85",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "63a49dcd12588e63ae0beb96",
             "_tpl": "5ac72e895acfc43b321d4bd5",
             "parentId": "bc3eee4fb6caeaef28b91a85",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "1f226e8f3b52cc1ca6a97822",
             "_tpl": "5649ade84bdc2d1b2b8b4587",
             "parentId": "bc3eee4fb6caeaef28b91a85",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "ef5bbacb229079cd165b757f",
             "_tpl": "5ac50da15acfc4001718d287",
             "parentId": "bc3eee4fb6caeaef28b91a85",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "ffe7f47caa8f6197cbcb1a50",
             "_tpl": "5ac733a45acfc400192630e2",
             "parentId": "bc3eee4fb6caeaef28b91a85",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "dc48d215c03adc0b0bd20aad",
             "_tpl": "5ac50c185acfc400163398d4",
             "parentId": "bc3eee4fb6caeaef28b91a85",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "efcd2658d6f33054ef9b0b09",
             "_tpl": "5ac66bea5acfc43b321d4aec",
             "parentId": "bc3eee4fb6caeaef28b91a85",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "eb9e0f0277f7b85f2c513e55",
             "_tpl": "5ac66d2e5acfc43b321d4b53",
             "parentId": "hideout",
@@ -7249,56 +6463,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "6a2a902cc7cec8a114928eca",
             "_tpl": "59c6633186f7740cf0493bb9",
             "parentId": "eb9e0f0277f7b85f2c513e55",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "ae1bd14eecb29dc2f63e021a",
             "_tpl": "5648b1504bdc2d9d488b4584",
             "parentId": "6a2a902cc7cec8a114928eca",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "7c22ea96eec8a56458df816d",
             "_tpl": "5ac72e7d5acfc40016339a02",
             "parentId": "eb9e0f0277f7b85f2c513e55",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "eafab33bb854cd919e6cb2a6",
             "_tpl": "5649ade84bdc2d1b2b8b4587",
             "parentId": "eb9e0f0277f7b85f2c513e55",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "df1fc3edff400de6d348af31",
             "_tpl": "5ac50da15acfc4001718d287",
             "parentId": "eb9e0f0277f7b85f2c513e55",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "66bca3c0dcfa55e72ee1adff",
             "_tpl": "5ac72e475acfc400180ae6fe",
             "parentId": "eb9e0f0277f7b85f2c513e55",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "bedbd42e0dafcc2e62cefce2",
             "_tpl": "5ac50c185acfc400163398d4",
             "parentId": "eb9e0f0277f7b85f2c513e55",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "a2fb6f18b4565e2153b10fae",
             "_tpl": "5ac66bea5acfc43b321d4aec",
             "parentId": "eb9e0f0277f7b85f2c513e55",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "ddacd746b270532e7c761c07",
             "_tpl": "606587252535c57a13424cfd",
             "parentId": "hideout",
@@ -7309,80 +6514,67 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "757ddfff07eea58ba8bf747d",
             "_tpl": "55802f5d4bdc2dac148b458f",
             "parentId": "ddacd746b270532e7c761c07",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "ddf05c0b4fe8cd9ab44bbefc",
             "_tpl": "59d6272486f77466146386ff",
             "parentId": "ddacd746b270532e7c761c07",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "c1f2c5f286ee30bcfeb8efaa",
             "_tpl": "606587a88900dc2d9a55b659",
             "parentId": "ddacd746b270532e7c761c07",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "bb4ce7e55fa9c81eaa72d3c8",
             "_tpl": "60658776f2cb2e02a42ace2b",
             "parentId": "c1f2c5f286ee30bcfeb8efaa",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "29002d9d9bd6b993b92e2693",
             "_tpl": "6065c6e7132d4d12c81fd8e1",
             "parentId": "bb4ce7e55fa9c81eaa72d3c8",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "e3f16d4ffd57244f232c9f1d",
             "_tpl": "6065dc8a132d4d12c81fd8e3",
             "parentId": "bb4ce7e55fa9c81eaa72d3c8",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "407c5b85d8093ea0fcde7638",
             "_tpl": "6065880c132d4d12c81fd8da",
             "parentId": "c1f2c5f286ee30bcfeb8efaa",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "6a396c014cbcab7c20e685fc",
             "_tpl": "5bc09a30d4351e00367fb7c8",
             "parentId": "407c5b85d8093ea0fcde7638",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "4c09bf5adcbbddf0a282fb00",
             "_tpl": "5bc09a18d4351e003562b68e",
             "parentId": "c1f2c5f286ee30bcfeb8efaa",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "d31fa5fbabafec64fd06bb7a",
             "_tpl": "606587e18900dc2d9a55b65f",
             "parentId": "ddacd746b270532e7c761c07",
             "slotId": "mod_stock_001"
-        },
-        {
+        }, {
             "_id": "e8d05e1bc48cfcf9babd055e",
             "_tpl": "606587d11246154cad35d635",
             "parentId": "d31fa5fbabafec64fd06bb7a",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "e8e5b6943e09fdce8dd8f1c4",
             "_tpl": "606587bd6d0bd7580617bacc",
             "parentId": "ddacd746b270532e7c761c07",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "2c2953acc3228daceef9f38d",
             "_tpl": "5c488a752e221602b412af63",
             "parentId": "hideout",
@@ -7393,38 +6585,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fce7da81adb196eba6f4ddca",
             "_tpl": "5c48a2c22e221602b313fb6c",
             "parentId": "2c2953acc3228daceef9f38d",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "bcb1a1fa7bdd11be7d93e3ef",
             "_tpl": "55802d5f4bdc2dac148b458e",
             "parentId": "2c2953acc3228daceef9f38d",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "d3fbebdd60c9dff5fe3df381",
             "_tpl": "5c48a14f2e2216152006edd7",
             "parentId": "2c2953acc3228daceef9f38d",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "a48e56fd81eaa23a91f2f276",
             "_tpl": "5c48a2852e221602b21d5923",
             "parentId": "2c2953acc3228daceef9f38d",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "61dbadc75cfeb3b7c76b23dd",
             "_tpl": "5c48a2a42e221602b66d1e07",
             "parentId": "a48e56fd81eaa23a91f2f276",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "cf3bc468503c7cfec45ebada",
             "_tpl": "5b0bbe4e5acfc40dc528a72d",
             "parentId": "hideout",
@@ -7435,74 +6621,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fdbaeba137ccdeabeb8afebd",
             "_tpl": "5b099b965acfc400186331e6",
             "parentId": "cf3bc468503c7cfec45ebada",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "27cc9c1bc9dd220a560c0fac",
             "_tpl": "5b099ac65acfc400186331e1",
             "parentId": "cf3bc468503c7cfec45ebada",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "c225e0bbc3acb2f1b57dfa9b",
             "_tpl": "5b099a9d5acfc47a8607efe7",
             "parentId": "cf3bc468503c7cfec45ebada",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "bbe083bf8e5f1a3e3790b6d2",
             "_tpl": "5b099b7d5acfc400186331e4",
             "parentId": "4b916979b58fefcfd3048052",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "4b916979b58fefcfd3048052",
             "_tpl": "5b099a765acfc47a8607efe3",
             "parentId": "cf3bc468503c7cfec45ebada",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "3aae1dac26c440ca5bbce33a",
             "_tpl": "5b0bc22d5acfc47a8607f085",
             "parentId": "cf3bc468503c7cfec45ebada",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "e6dbffe4348accfa46baea1c",
             "_tpl": "5b099bb25acfc400186331e8",
             "parentId": "cf3bc468503c7cfec45ebada",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "ba92afefa35a0bcbbad11ea2",
             "_tpl": "58d2912286f7744e27117493",
             "parentId": "b2bae93dbccc95574bdeb664",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "b2bae93dbccc95574bdeb664",
             "_tpl": "56eabf3bd2720b75698b4569",
             "parentId": "3a8ebc8388e55cdcd7eafbae",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "3a8ebc8388e55cdcd7eafbae",
             "_tpl": "5649be884bdc2d79388b4577",
             "parentId": "a4aabf903ecf754dfbbe6d9f",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "a4aabf903ecf754dfbbe6d9f",
             "_tpl": "5b099bf25acfc4001637e683",
             "parentId": "cf3bc468503c7cfec45ebada",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "16426ac6c6fede5eeb28e114",
             "_tpl": "6165ac306ef05c2ce828ef74",
             "parentId": "hideout",
@@ -7513,92 +6687,77 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "4e983fc17fafe7d6c3bcaa37",
             "_tpl": "571659bb2459771fb2755a12",
             "parentId": "16426ac6c6fede5eeb28e114",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "3dde80afcfcde8782132bba3",
             "_tpl": "6183d53f1cb55961fa0fdcda",
             "parentId": "16426ac6c6fede5eeb28e114",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "e7e956780ed793692a64cddc",
             "_tpl": "618178aa1cb55961fa0fdc80",
             "parentId": "0be8f624f6c180f17ee77b5e",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "ded5b968dfad67aecce4f203",
             "_tpl": "61816fcad92c473c770215cc",
             "parentId": "0be8f624f6c180f17ee77b5e",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "0be8f624f6c180f17ee77b5e",
             "_tpl": "6183b0711cb55961fa0fdcad",
             "parentId": "bc4c165efccbcfff56669e3d",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "9aebb3bff384eb43fbb2cd25",
             "_tpl": "61817865d3a39d50044c13a4",
             "parentId": "bc4c165efccbcfff56669e3d",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "8dfd3a45b700acde62897931",
             "_tpl": "61816df1d3a39d50044c139e",
             "parentId": "bc4c165efccbcfff56669e3d",
             "slotId": "mod_mount_000"
-        },
-        {
+        }, {
             "_id": "a7fcb278cfa00cfdeb0ba338",
             "_tpl": "61816dfa6ef05c2ce828f1ad",
             "parentId": "bc4c165efccbcfff56669e3d",
             "slotId": "mod_mount_001"
-        },
-        {
+        }, {
             "_id": "bc4c165efccbcfff56669e3d",
             "_tpl": "6165aeedfaa1272e431521e3",
             "parentId": "16426ac6c6fede5eeb28e114",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "d42fc8ecdda4fad0d1f094f2",
             "_tpl": "618167616ef05c2ce828f1a8",
             "parentId": "5df48798ecd6dd4c10ab5e5c",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "5df48798ecd6dd4c10ab5e5c",
             "_tpl": "61825d136ef05c2ce828f1cc",
             "parentId": "b30c60f716bceb6abbd4f120",
             "slotId": "mod_stock_001"
-        },
-        {
+        }, {
             "_id": "c4bcd59efb3ac3532ec68adb",
             "_tpl": "61825d24d3a39d50044c13af",
             "parentId": "b30c60f716bceb6abbd4f120",
             "slotId": "mod_stock_002"
-        },
-        {
+        }, {
             "_id": "b30c60f716bceb6abbd4f120",
             "_tpl": "61825d06d92c473c770215de",
             "parentId": "16426ac6c6fede5eeb28e114",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "46caee1cad8fe55e143f0090",
             "_tpl": "6181688c6c780c1e710c9b04",
             "parentId": "16426ac6c6fede5eeb28e114",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "fa7a7b8c6abdad1f8a9d1eaa",
             "_tpl": "5dcbd56fdbd3d91b3e5468d5",
             "parentId": "hideout",
@@ -7609,38 +6768,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ffadfafc9badf07fdeb27d34",
             "_tpl": "5dcbd6dddbd3d91b3e5468de",
             "parentId": "fa7a7b8c6abdad1f8a9d1eaa",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "5afee0589b02ababbece187e",
             "_tpl": "5a3501acc4a282000d72293a",
             "parentId": "fa7a7b8c6abdad1f8a9d1eaa",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "a7deefed40ba414009f3d21a",
             "_tpl": "5dcbd6b46ec07c0c4347a564",
             "parentId": "fa7a7b8c6abdad1f8a9d1eaa",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "f4d8c039eba8cca7719a6dc6",
             "_tpl": "5dcbe9431e1f4616d354987e",
             "parentId": "fa7a7b8c6abdad1f8a9d1eaa",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "6fb37e228adbe9ed2b960b84",
             "_tpl": "5dcbe965e4ed22586443a79d",
             "parentId": "f4d8c039eba8cca7719a6dc6",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "19a87af0baebfa18bbecbfeb",
             "_tpl": "5cadfbf7ae92152ac412eeef",
             "parentId": "hideout",
@@ -7651,44 +6804,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "da673bfd35a5ba9973a7b1cb",
             "_tpl": "5caf17c9ae92150b30006be1",
             "parentId": "19a87af0baebfa18bbecbfeb",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "2beaef8fec0dcc4cf408c752",
             "_tpl": "5caf1041ae92157c28402e3f",
             "parentId": "19a87af0baebfa18bbecbfeb",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "bf830c9abd9d19ddc8181e4c",
             "_tpl": "5caf16a2ae92152ac412efbc",
             "parentId": "19a87af0baebfa18bbecbfeb",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "fffbff84fdfa4bd04930e43b",
             "_tpl": "5cdaa99dd7f00c002412d0b2",
             "parentId": "19a87af0baebfa18bbecbfeb",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "4c4c4cad668ccd5d5abdefdc",
             "_tpl": "5cda9bcfd7f00c0c0b53e900",
             "parentId": "fffbff84fdfa4bd04930e43b",
             "slotId": "mod_foregrip"
-        },
-        {
+        }, {
             "_id": "e72df0c78cb81b0ad61dab7a",
             "_tpl": "5caf1691ae92152ac412efb9",
             "parentId": "19a87af0baebfa18bbecbfeb",
             "slotId": "mod_scope"
-        },
-        {
+        }, {
             "_id": "dccbe2319a8d86bdafa1a8cc",
             "_tpl": "64b7af434b75259c590fa893",
             "parentId": "hideout",
@@ -7699,8 +6845,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "96ce24efde7f7fdb74b7cd72",
             "_tpl": "64b7af434b75259c590fa893",
             "parentId": "hideout",
@@ -7711,8 +6856,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7d33ea8e2eaaad24ada9a92c",
             "_tpl": "64b7af5a8532cf95ee0a0dbd",
             "parentId": "hideout",
@@ -7723,8 +6867,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "997dd0e96ce2ea6ffbb2bfae",
             "_tpl": "64b7af5a8532cf95ee0a0dbd",
             "parentId": "hideout",
@@ -7735,8 +6878,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f714e6fac3aa8ac5ab5e8b0b",
             "_tpl": "64b7af734b75259c590fa895",
             "parentId": "hideout",
@@ -7747,8 +6889,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "2acaff8c0e4dbaf8e84f5c4d",
             "_tpl": "64b7af734b75259c590fa895",
             "parentId": "hideout",
@@ -7759,8 +6900,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a9d7eabebf51477f7d615d66",
             "_tpl": "6529243824cbe3c74a05e5c1",
             "parentId": "hideout",
@@ -7771,8 +6911,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "1d966fc3c05c0cfbfb6db0bb",
             "_tpl": "6529243824cbe3c74a05e5c1",
             "parentId": "hideout",
@@ -7783,8 +6922,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bda2ff902bc93909425bf53f",
             "_tpl": "6529302b8c26af6326029fb7",
             "parentId": "hideout",
@@ -7795,8 +6933,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c7e1f40ffae087ecc96ceaaf",
             "_tpl": "6529302b8c26af6326029fb7",
             "parentId": "hideout",
@@ -7807,8 +6944,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d2ee8d41b52c9cdbc83cfd74",
             "_tpl": "6576f96220d53a5b8f3e395e",
             "parentId": "hideout",
@@ -7819,8 +6955,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "0ffccaa6b7cead2daeea355b",
             "_tpl": "6576f96220d53a5b8f3e395e",
             "parentId": "hideout",
@@ -7831,8 +6966,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "1ab4be0cf384fb2a35a00fdd",
             "_tpl": "65293c38fc460e50a509cb25",
             "parentId": "hideout",
@@ -7843,8 +6977,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d8542abf28bfc3e8358503bb",
             "_tpl": "65293c7a17e14363030ad308",
             "parentId": "hideout",
@@ -7855,8 +6988,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "dd2dda5ed65fa75cd9b5e0d4",
             "_tpl": "6183afd850224f204c1da514",
             "parentId": "hideout",
@@ -7867,92 +6999,77 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "4ee053ee2bb1ccda9bd25eda",
             "_tpl": "55d4b9964bdc2d1d4e8b456e",
             "parentId": "dd2dda5ed65fa75cd9b5e0d4",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "e64a7b1e8ebdea1e40b3b855",
             "_tpl": "618168dc8004cc50514c34fc",
             "parentId": "dd2dda5ed65fa75cd9b5e0d4",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "c4ec49550e3cfb82d2c35b8a",
             "_tpl": "6165adcdd3a39d50044c120f",
             "parentId": "dd2dda5ed65fa75cd9b5e0d4",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "4865b3fa2c0ab7e08b08cbd7",
             "_tpl": "61816dfa6ef05c2ce828f1ad",
             "parentId": "c4ec49550e3cfb82d2c35b8a",
             "slotId": "mod_mount_001"
-        },
-        {
+        }, {
             "_id": "a81f7a00b443b4aa4ede8690",
             "_tpl": "61816df1d3a39d50044c139e",
             "parentId": "c4ec49550e3cfb82d2c35b8a",
             "slotId": "mod_mount_000"
-        },
-        {
+        }, {
             "_id": "5ecee622ffb9a5f1710cfbe4",
             "_tpl": "61817865d3a39d50044c13a4",
             "parentId": "c4ec49550e3cfb82d2c35b8a",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "d5decbe4afa6bb5ccaa6c8be",
             "_tpl": "6183b084a112697a4b3a6e6c",
             "parentId": "c4ec49550e3cfb82d2c35b8a",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "394fb6b88110edddcda238a5",
             "_tpl": "61816fcad92c473c770215cc",
             "parentId": "d5decbe4afa6bb5ccaa6c8be",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "5f363dc0b8a21f911a8e83c3",
             "_tpl": "618178aa1cb55961fa0fdc80",
             "parentId": "d5decbe4afa6bb5ccaa6c8be",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "dbedc64e247aa0dfe0fa5f37",
             "_tpl": "61816734d8e3106d9806c1f3",
             "parentId": "dd2dda5ed65fa75cd9b5e0d4",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "6cda89ec7cadcd3ed2b77cdf",
             "_tpl": "618167441cb55961fa0fdc71",
             "parentId": "dbedc64e247aa0dfe0fa5f37",
             "slotId": "mod_stock_002"
-        },
-        {
+        }, {
             "_id": "6dac69fb7b13ca293888ceca",
             "_tpl": "618167528004cc50514c34f9",
             "parentId": "dbedc64e247aa0dfe0fa5f37",
             "slotId": "mod_stock_001"
-        },
-        {
+        }, {
             "_id": "ce776dc79aefff257834cacf",
             "_tpl": "618167616ef05c2ce828f1a8",
             "parentId": "6dac69fb7b13ca293888ceca",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "3f9dafa71e9aaabfcf8a0c21",
             "_tpl": "6181688c6c780c1e710c9b04",
             "parentId": "dd2dda5ed65fa75cd9b5e0d4",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "12e2cbbcd0fc1a2f9eef88d6",
             "_tpl": "623063e994fc3f7b302a9696",
             "parentId": "hideout",
@@ -7963,62 +7080,52 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "78dd6ebc2ed7a6f3f8ed8a9a",
             "_tpl": "62307b7b10d2321fa8741921",
             "parentId": "12e2cbbcd0fc1a2f9eef88d6",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "ee0b7f54fa9a5113a1ab11d0",
             "_tpl": "622f140da5958f63c67f1735",
             "parentId": "12e2cbbcd0fc1a2f9eef88d6",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "a0bdffc5ace5a0f57ff27259",
             "_tpl": "622b38c56762c718e457e246",
             "parentId": "12e2cbbcd0fc1a2f9eef88d6",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "0a313431edf09cf23f94053f",
             "_tpl": "622b327b267a1b13a44abea3",
             "parentId": "a0bdffc5ace5a0f57ff27259",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "c689c6fcca9a5cc85e259bd2",
             "_tpl": "622f128cec80d870d349b4e8",
             "parentId": "a0bdffc5ace5a0f57ff27259",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "605ead4693af6ce3cf0ff4cf",
             "_tpl": "6231654c71b5bc3baa1078e5",
             "parentId": "12e2cbbcd0fc1a2f9eef88d6",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "1809dee4d54ea2fa73869ae5",
             "_tpl": "622f02437762f55aaa68ac85",
             "parentId": "12e2cbbcd0fc1a2f9eef88d6",
             "slotId": "mod_mount"
-        },
-        {
+        }, {
             "_id": "6a0485e6f1427a56bedc12c1",
             "_tpl": "622b4d7df9cfc87d675d2ded",
             "parentId": "12e2cbbcd0fc1a2f9eef88d6",
             "slotId": "mod_scope"
-        },
-        {
+        }, {
             "_id": "ec02c81c21afedcabeaac058",
             "_tpl": "622efbcb99f4ea1a4d6c9a15",
             "parentId": "6a0485e6f1427a56bedc12c1",
             "slotId": "mod_scope"
-        },
-        {
+        }, {
             "_id": "ac0c9fbb17a1afe29a70903d",
             "_tpl": "62e7c4fba689e8c9c50dfc38",
             "parentId": "hideout",
@@ -8029,44 +7136,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "563f2a6be6bdfe73adbfa3c9",
             "_tpl": "62e7c98b550c8218d602cbb4",
             "parentId": "ac0c9fbb17a1afe29a70903d",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "ff3ccecbc890cb8edfdfbd8d",
             "_tpl": "62e7c880f68e7a0676050c7c",
             "parentId": "ac0c9fbb17a1afe29a70903d",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "c9ee43fd9504877bdca3b4c3",
             "_tpl": "62ea7c793043d74a0306e19f",
             "parentId": "ac0c9fbb17a1afe29a70903d",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "19e29ed0abfe83250d93ff38",
             "_tpl": "62e7c7f3c34ea971710c32fc",
             "parentId": "c9ee43fd9504877bdca3b4c3",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "405cabcf3db9bd7edb9f71b8",
             "_tpl": "634e61b0767cb15c4601a877",
             "parentId": "19e29ed0abfe83250d93ff38",
             "slotId": "mod_foregrip"
-        },
-        {
+        }, {
             "_id": "a2fe540ddc6dc14b3f4aa8ea",
             "_tpl": "630f2872911356c17d06abc5",
             "parentId": "19e29ed0abfe83250d93ff38",
             "slotId": "mod_muzzle_000"
-        },
-        {
+        }, {
             "_id": "ad8a5ee6aea053d6ba1e9949",
             "_tpl": "63171672192e68c5460cebc5",
             "parentId": "hideout",
@@ -8077,50 +7177,42 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c105a4b9cd02e3cfac60749e",
             "_tpl": "62e7c98b550c8218d602cbb4",
             "parentId": "ad8a5ee6aea053d6ba1e9949",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "5bc3de1aacd8edff4aaf253f",
             "_tpl": "62ebbc53e3c1e1ec7c02c44f",
             "parentId": "ad8a5ee6aea053d6ba1e9949",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "cb6edfade8997e810cea7eb9",
             "_tpl": "62e7c72df68e7a0676050c77",
             "parentId": "ad8a5ee6aea053d6ba1e9949",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "85effdfc60cf2ba6bdfcb523",
             "_tpl": "62ebd290c427473eff0baafb",
             "parentId": "cb6edfade8997e810cea7eb9",
             "slotId": "mod_mount"
-        },
-        {
+        }, {
             "_id": "b8afa3f0a0bbfeef18cc64ad",
             "_tpl": "62e7c7f3c34ea971710c32fc",
             "parentId": "cb6edfade8997e810cea7eb9",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "ce584fdac9cf8dae56d10603",
             "_tpl": "634e61b0767cb15c4601a877",
             "parentId": "b8afa3f0a0bbfeef18cc64ad",
             "slotId": "mod_foregrip"
-        },
-        {
+        }, {
             "_id": "bf461845cad15ce331c1c535",
             "_tpl": "630f28f0cadb1fe05e06f004",
             "parentId": "b8afa3f0a0bbfeef18cc64ad",
             "slotId": "mod_muzzle_000"
-        },
-        {
+        }, {
             "_id": "accce84b4fbbec3a50c3f0b9",
             "_tpl": "628a60ae6b1d481ff772e9c8",
             "parentId": "hideout",
@@ -8131,62 +7223,52 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "124ce8d8eecc799f3bd9cca8",
             "_tpl": "628a83c29179c324ed269508",
             "parentId": "accce84b4fbbec3a50c3f0b9",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "cbcbf4af24eccdfccdd8d924",
             "_tpl": "628a66b41d5e41750e314f34",
             "parentId": "accce84b4fbbec3a50c3f0b9",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "cf9b17cee6ecdd8aff8177fc",
             "_tpl": "628a664bccaab13006640e47",
             "parentId": "accce84b4fbbec3a50c3f0b9",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "cecacc7495bcccdbeb7be74c",
             "_tpl": "628a665a86cbd9750d2ff5e5",
             "parentId": "accce84b4fbbec3a50c3f0b9",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "17c0d9a1c4bbd97f824e9af1",
             "_tpl": "628a7b23b0f75035732dd565",
             "parentId": "accce84b4fbbec3a50c3f0b9",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "4ed4fdffce842f5be3c6fba1",
             "_tpl": "628a6678ccaab13006640e49",
             "parentId": "accce84b4fbbec3a50c3f0b9",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "a1b9bdfe05ec1a21cdfdf911",
             "_tpl": "5649be884bdc2d79388b4577",
             "parentId": "4ed4fdffce842f5be3c6fba1",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "ebedf5955ed95968b9bce1c9",
             "_tpl": "628a85ee6b1d481ff772e9d5",
             "parentId": "a1b9bdfe05ec1a21cdfdf911",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "bbfbce81898ceabc06f66b0e",
             "_tpl": "59d625f086f774661516605d",
             "parentId": "accce84b4fbbec3a50c3f0b9",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "19d9df7a326dbb28a8d4c0ee",
             "_tpl": "628b5638ad252a16da6dd245",
             "parentId": "hideout",
@@ -8197,62 +7279,52 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "96fbd2f3b0b0a00eb7b2d652",
             "_tpl": "628b8d83717774443b15e248",
             "parentId": "19d9df7a326dbb28a8d4c0ee",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "1fabd3fa6c808c3de1f8702a",
             "_tpl": "628b916469015a4e1711ed8d",
             "parentId": "96fbd2f3b0b0a00eb7b2d652",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "8b0666062f5eadffee0c6db1",
             "_tpl": "628b9be6cff66b70c002b14c",
             "parentId": "1fabd3fa6c808c3de1f8702a",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "6d9a9539e2697dab8a63baf5",
             "_tpl": "628b9471078f94059a4b9bfb",
             "parentId": "8b0666062f5eadffee0c6db1",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "6096f30e5bd6b239233cdef0",
             "_tpl": "5ac7655e5acfc40016339a19",
             "parentId": "19d9df7a326dbb28a8d4c0ee",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "794dcc7e77c9e9da4d50d294",
             "_tpl": "5cf50850d7f00c056e24104c",
             "parentId": "19d9df7a326dbb28a8d4c0ee",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "0ac98c6cef9bade98b0dac71",
             "_tpl": "628b9a40717774443b15e9f2",
             "parentId": "19d9df7a326dbb28a8d4c0ee",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "79d1dbdc53bd74878a7f14dd",
             "_tpl": "55d4ae6c4bdc2d8b2f8b456e",
             "parentId": "0ac98c6cef9bade98b0dac71",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "2db603115efcb87390b29ceb",
             "_tpl": "55d480c04bdc2d1d4e8b456a",
             "parentId": "19d9df7a326dbb28a8d4c0ee",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "1a5e752edad847aa77c3e4ad",
             "_tpl": "628b9c37a733087d0d7fe84b",
             "parentId": "hideout",
@@ -8263,62 +7335,52 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7d15c29bdaa09dbff4fe1384",
             "_tpl": "628b8d83717774443b15e248",
             "parentId": "1a5e752edad847aa77c3e4ad",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "ccc8ca856bddcaaebed24cff",
             "_tpl": "628b916469015a4e1711ed8d",
             "parentId": "7d15c29bdaa09dbff4fe1384",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "d60bfdf2de02e9329d1b7cdb",
             "_tpl": "628b9be6cff66b70c002b14c",
             "parentId": "ccc8ca856bddcaaebed24cff",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "c63fba3e4cb7aefe3a6cda2f",
             "_tpl": "628b9471078f94059a4b9bfb",
             "parentId": "d60bfdf2de02e9329d1b7cdb",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "e44a8fe9ce9c40dddbde8af3",
             "_tpl": "5943eeeb86f77412d6384f6b",
             "parentId": "1a5e752edad847aa77c3e4ad",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "3accd204f4bb1cde6caaf8ef",
             "_tpl": "5cf50850d7f00c056e24104c",
             "parentId": "1a5e752edad847aa77c3e4ad",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "8f321fecaa04cff40903a655",
             "_tpl": "628b9a40717774443b15e9f2",
             "parentId": "1a5e752edad847aa77c3e4ad",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "e4b3dbbec9b6d2ff1cbb2bcc",
             "_tpl": "55d4ae6c4bdc2d8b2f8b456e",
             "parentId": "8f321fecaa04cff40903a655",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "2b89e5c64621db6d6fb7d3cf",
             "_tpl": "55d480c04bdc2d1d4e8b456a",
             "parentId": "1a5e752edad847aa77c3e4ad",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "e7a17a4ff2bcd5f406f03da7",
             "_tpl": "6499849fc93611967b034949",
             "parentId": "hideout",
@@ -8329,74 +7391,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a3bee5bbd43fae8bfdfa48fc",
             "_tpl": "649ec107961514b22506b10c",
             "parentId": "e7a17a4ff2bcd5f406f03da7",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "9db55a0cc2aaf5ef85aa56d2",
             "_tpl": "5beec8ea0db834001a6f9dbf",
             "parentId": "e7a17a4ff2bcd5f406f03da7",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "95f2839eb5d4ad81ad5ddeba",
             "_tpl": "649ec127c93611967b034957",
             "parentId": "e7a17a4ff2bcd5f406f03da7",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "a7d1e35fbd85eeaf6dce26a5",
             "_tpl": "5beecbb80db834001d2c465e",
             "parentId": "95f2839eb5d4ad81ad5ddeba",
             "slotId": "mod_mount_001"
-        },
-        {
+        }, {
             "_id": "1ad58ddbd0602fdcdc31f8fa",
             "_tpl": "649ec2af961514b22506b10f",
             "parentId": "e7a17a4ff2bcd5f406f03da7",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "d72bc8bd80d7fbb9f0adaa3e",
             "_tpl": "649ec2f3961514b22506b111",
             "parentId": "e7a17a4ff2bcd5f406f03da7",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "62ef5bd30bcf0ccfe1bba72a",
             "_tpl": "649ec2da59cbb3c813042dca",
             "parentId": "d72bc8bd80d7fbb9f0adaa3e",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "2e4d3c0dcc32a3d4c30a8b7a",
             "_tpl": "649ec2cec93611967b03495e",
             "parentId": "62ef5bd30bcf0ccfe1bba72a",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "a5bacfc3f4faaa2a6b7bc898",
             "_tpl": "649ec30cb013f04a700e60fb",
             "parentId": "e7a17a4ff2bcd5f406f03da7",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "b7bafc6cbedaf621fa65ed9c",
             "_tpl": "649ec87d8007560a9001ab36",
             "parentId": "e7a17a4ff2bcd5f406f03da7",
             "slotId": "mod_stock_001"
-        },
-        {
+        }, {
             "_id": "cb7c7f95ef743aecafbf3e8e",
             "_tpl": "5beec8c20db834001d2c465c",
             "parentId": "b7bafc6cbedaf621fa65ed9c",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "13950de5b6675e5c3a833dde",
             "_tpl": "65290f395ae2ae97b80fdf2d",
             "parentId": "hideout",
@@ -8407,92 +7457,77 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "1e9fce7240b50eb7abf0b59a",
             "_tpl": "652911675ae2ae97b80fdf3c",
             "parentId": "13950de5b6675e5c3a833dde",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "3ccfc5b91349a7451fae8bba",
             "_tpl": "65293c38fc460e50a509cb25",
             "parentId": "13950de5b6675e5c3a833dde",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "b78d0a35bb55a0f1ae2a0da9",
             "_tpl": "6529119424cbe3c74a05e5bb",
             "parentId": "13950de5b6675e5c3a833dde",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "a9400beb6dfa5aa839cbb7c1",
             "_tpl": "652910ef50dc782999054b97",
             "parentId": "b78d0a35bb55a0f1ae2a0da9",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "f6599af9b05dbe0feb38e54d",
             "_tpl": "652910565ae2ae97b80fdf35",
             "parentId": "b78d0a35bb55a0f1ae2a0da9",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "e7a2f21fc0aaea792ebd24fa",
             "_tpl": "652910bc24cbe3c74a05e5b9",
             "parentId": "f6599af9b05dbe0feb38e54d",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "aa56aab5dc844a77b1957fd3",
             "_tpl": "6529113b5ae2ae97b80fdf39",
             "parentId": "f6599af9b05dbe0feb38e54d",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "4de68e3de4da4dc2bb0a1d89",
             "_tpl": "652911e650dc782999054b9d",
             "parentId": "aa56aab5dc844a77b1957fd3",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "4eebb010ebf7fcf9c2a4aded",
             "_tpl": "6567e751a715f85433025998",
             "parentId": "b78d0a35bb55a0f1ae2a0da9",
             "slotId": "mod_scope"
-        },
-        {
+        }, {
             "_id": "360af6c1faea3b4959ea740b",
             "_tpl": "6567e7681265c8a131069b0f",
             "parentId": "4eebb010ebf7fcf9c2a4aded",
             "slotId": "mod_scope"
-        },
-        {
+        }, {
             "_id": "e65c10fa79cafdedfea06e1f",
             "_tpl": "6529348224cbe3c74a05e5c4",
             "parentId": "13950de5b6675e5c3a833dde",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "d2e2cdf6b583ba90eba72cdc",
             "_tpl": "6529366450dc782999054ba0",
             "parentId": "e65c10fa79cafdedfea06e1f",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "c3051bffdcc537fe2eafcd0d",
             "_tpl": "6529370c405a5f51dd023db8",
             "parentId": "d2e2cdf6b583ba90eba72cdc",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "cae2adce4a7a8a09da22605c",
             "_tpl": "6529109524cbe3c74a05e5b7",
             "parentId": "13950de5b6675e5c3a833dde",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "0e9daeadadafdced379c78fc",
             "_tpl": "6183afd850224f204c1da514",
             "parentId": "hideout",
@@ -8503,92 +7538,77 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "2d214f16dabdea5e2d4a69db",
             "_tpl": "55d4b9964bdc2d1d4e8b456e",
             "parentId": "0e9daeadadafdced379c78fc",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "6e4b6da1e51ad9aea9034c46",
             "_tpl": "618168dc8004cc50514c34fc",
             "parentId": "0e9daeadadafdced379c78fc",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "502e9b39fdbcacc37ae734c0",
             "_tpl": "6165adcdd3a39d50044c120f",
             "parentId": "0e9daeadadafdced379c78fc",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "fb8923cdf99cf0e1bfee5897",
             "_tpl": "61816dfa6ef05c2ce828f1ad",
             "parentId": "502e9b39fdbcacc37ae734c0",
             "slotId": "mod_mount_001"
-        },
-        {
+        }, {
             "_id": "bb665c2c6274c686ec02c91f",
             "_tpl": "61816df1d3a39d50044c139e",
             "parentId": "502e9b39fdbcacc37ae734c0",
             "slotId": "mod_mount_000"
-        },
-        {
+        }, {
             "_id": "daa7c0d6bbc1ab7dd7edcb8e",
             "_tpl": "61817865d3a39d50044c13a4",
             "parentId": "502e9b39fdbcacc37ae734c0",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "b9fb17b919bb5fdee9ba14f4",
             "_tpl": "6183b084a112697a4b3a6e6c",
             "parentId": "502e9b39fdbcacc37ae734c0",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "2daea8a6dbc3d68cf866e885",
             "_tpl": "61816fcad92c473c770215cc",
             "parentId": "b9fb17b919bb5fdee9ba14f4",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "47be32c5915ac2da9510ffdc",
             "_tpl": "618178aa1cb55961fa0fdc80",
             "parentId": "b9fb17b919bb5fdee9ba14f4",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "f73703492ecbee16d533a1b3",
             "_tpl": "61816734d8e3106d9806c1f3",
             "parentId": "0e9daeadadafdced379c78fc",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "6b5c0f12ccb35aad75cba064",
             "_tpl": "618167441cb55961fa0fdc71",
             "parentId": "f73703492ecbee16d533a1b3",
             "slotId": "mod_stock_002"
-        },
-        {
+        }, {
             "_id": "8e6fdbab5bd6e3beb3beff6f",
             "_tpl": "618167528004cc50514c34f9",
             "parentId": "f73703492ecbee16d533a1b3",
             "slotId": "mod_stock_001"
-        },
-        {
+        }, {
             "_id": "c68d3dd7fbe7a1f34e9423d7",
             "_tpl": "618167616ef05c2ce828f1a8",
             "parentId": "8e6fdbab5bd6e3beb3beff6f",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "3df9c7f89bf598a04cd3f5ce",
             "_tpl": "6181688c6c780c1e710c9b04",
             "parentId": "0e9daeadadafdced379c78fc",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "2a2fcf4b17f8905fcbd18c02",
             "_tpl": "623063e994fc3f7b302a9696",
             "parentId": "hideout",
@@ -8599,62 +7619,52 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f266baab3afb1e5dbe5c4b4b",
             "_tpl": "62307b7b10d2321fa8741921",
             "parentId": "2a2fcf4b17f8905fcbd18c02",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "ee3b8ce9facf0356558c3e95",
             "_tpl": "622f140da5958f63c67f1735",
             "parentId": "2a2fcf4b17f8905fcbd18c02",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "47df8a1bf6dbf6153245a285",
             "_tpl": "622b38c56762c718e457e246",
             "parentId": "2a2fcf4b17f8905fcbd18c02",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "6eadccff3195cd95b0bdb6db",
             "_tpl": "622b327b267a1b13a44abea3",
             "parentId": "47df8a1bf6dbf6153245a285",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "aa6acfe6c4ba3b9dec23df56",
             "_tpl": "622f128cec80d870d349b4e8",
             "parentId": "47df8a1bf6dbf6153245a285",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "5e3516764de3193e18ffbfdd",
             "_tpl": "6231654c71b5bc3baa1078e5",
             "parentId": "2a2fcf4b17f8905fcbd18c02",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "1fdef3a0505fb2f0aaec0a71",
             "_tpl": "622f02437762f55aaa68ac85",
             "parentId": "2a2fcf4b17f8905fcbd18c02",
             "slotId": "mod_mount"
-        },
-        {
+        }, {
             "_id": "adae9d7ff57ceea9f08c8516",
             "_tpl": "622b4d7df9cfc87d675d2ded",
             "parentId": "2a2fcf4b17f8905fcbd18c02",
             "slotId": "mod_scope"
-        },
-        {
+        }, {
             "_id": "7bac56a64e802e047eb1b3a6",
             "_tpl": "622efbcb99f4ea1a4d6c9a15",
             "parentId": "adae9d7ff57ceea9f08c8516",
             "slotId": "mod_scope"
-        },
-        {
+        }, {
             "_id": "debdcc752ca60d8087a6df4d",
             "_tpl": "62e7c4fba689e8c9c50dfc38",
             "parentId": "hideout",
@@ -8665,44 +7675,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "9f6a6fba84ab4fe3bb9a95d2",
             "_tpl": "62e7c98b550c8218d602cbb4",
             "parentId": "debdcc752ca60d8087a6df4d",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "e881cac08ee9adbddeb2fb03",
             "_tpl": "62e7c880f68e7a0676050c7c",
             "parentId": "debdcc752ca60d8087a6df4d",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "e343a1464052b2d3f65b9abe",
             "_tpl": "62ea7c793043d74a0306e19f",
             "parentId": "debdcc752ca60d8087a6df4d",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "fc19f4bebeaf429bd506be5c",
             "_tpl": "62e7c7f3c34ea971710c32fc",
             "parentId": "e343a1464052b2d3f65b9abe",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "cdb9abf8c10bb66d9cbe2e28",
             "_tpl": "634e61b0767cb15c4601a877",
             "parentId": "fc19f4bebeaf429bd506be5c",
             "slotId": "mod_foregrip"
-        },
-        {
+        }, {
             "_id": "ad3693ce1991f94abc4ae7ce",
             "_tpl": "630f2872911356c17d06abc5",
             "parentId": "fc19f4bebeaf429bd506be5c",
             "slotId": "mod_muzzle_000"
-        },
-        {
+        }, {
             "_id": "bdfefe4ecb28f112e49eabdd",
             "_tpl": "63171672192e68c5460cebc5",
             "parentId": "hideout",
@@ -8713,50 +7716,42 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f6d9ddbaeaec28e67ea4ba21",
             "_tpl": "62e7c98b550c8218d602cbb4",
             "parentId": "bdfefe4ecb28f112e49eabdd",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "3dabf151dbb723cce48dcd4b",
             "_tpl": "62ebbc53e3c1e1ec7c02c44f",
             "parentId": "bdfefe4ecb28f112e49eabdd",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "bdd670eefeffc9a6e383cfe7",
             "_tpl": "62e7c72df68e7a0676050c77",
             "parentId": "bdfefe4ecb28f112e49eabdd",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "c7d2bd9905af9ede92aa3ab2",
             "_tpl": "62ebd290c427473eff0baafb",
             "parentId": "bdd670eefeffc9a6e383cfe7",
             "slotId": "mod_mount"
-        },
-        {
+        }, {
             "_id": "4dca32e186410c6c868f990c",
             "_tpl": "62e7c7f3c34ea971710c32fc",
             "parentId": "bdd670eefeffc9a6e383cfe7",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "f09fbeaf713b38127bfe6cef",
             "_tpl": "634e61b0767cb15c4601a877",
             "parentId": "4dca32e186410c6c868f990c",
             "slotId": "mod_foregrip"
-        },
-        {
+        }, {
             "_id": "7a3eb4e6eaff1a7dcad7f99b",
             "_tpl": "630f28f0cadb1fe05e06f004",
             "parentId": "4dca32e186410c6c868f990c",
             "slotId": "mod_muzzle_000"
-        },
-        {
+        }, {
             "_id": "1eebaa8b0df8b85864bd9dd1",
             "_tpl": "628a60ae6b1d481ff772e9c8",
             "parentId": "hideout",
@@ -8767,62 +7762,52 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c7de6ec7edee8cfefa7a3c7f",
             "_tpl": "628a83c29179c324ed269508",
             "parentId": "1eebaa8b0df8b85864bd9dd1",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "bff2beec4b28bea81cef3d65",
             "_tpl": "628a66b41d5e41750e314f34",
             "parentId": "1eebaa8b0df8b85864bd9dd1",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "bf8cd7b1efba8b3a06ffddda",
             "_tpl": "628a664bccaab13006640e47",
             "parentId": "1eebaa8b0df8b85864bd9dd1",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "5c1e04e17947bb9a8e99babb",
             "_tpl": "628a665a86cbd9750d2ff5e5",
             "parentId": "1eebaa8b0df8b85864bd9dd1",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "cbad8f20acff2cdf5ddbeea5",
             "_tpl": "628a7b23b0f75035732dd565",
             "parentId": "1eebaa8b0df8b85864bd9dd1",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "fef58ebb10f8f12df31adecc",
             "_tpl": "628a6678ccaab13006640e49",
             "parentId": "1eebaa8b0df8b85864bd9dd1",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "8b19d81de1448dbb1cecfb25",
             "_tpl": "5649be884bdc2d79388b4577",
             "parentId": "fef58ebb10f8f12df31adecc",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "2ab9ceec57615ad5e554c6ae",
             "_tpl": "628a85ee6b1d481ff772e9d5",
             "parentId": "8b19d81de1448dbb1cecfb25",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "6fa8d4a3bdd476c3e85c1d6d",
             "_tpl": "59d625f086f774661516605d",
             "parentId": "1eebaa8b0df8b85864bd9dd1",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "e06d1d5bd0bafc5daa43beab",
             "_tpl": "628b5638ad252a16da6dd245",
             "parentId": "hideout",
@@ -8833,62 +7818,52 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "6ea5de2acd2acdf2fcadd3a3",
             "_tpl": "628b8d83717774443b15e248",
             "parentId": "e06d1d5bd0bafc5daa43beab",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "bd28ba49bb7ca553f144e0ce",
             "_tpl": "628b916469015a4e1711ed8d",
             "parentId": "6ea5de2acd2acdf2fcadd3a3",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "a72a6cd7a70adc27e04f1a80",
             "_tpl": "628b9be6cff66b70c002b14c",
             "parentId": "bd28ba49bb7ca553f144e0ce",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "8fc5ce7aa3bad9ba83c63de5",
             "_tpl": "628b9471078f94059a4b9bfb",
             "parentId": "a72a6cd7a70adc27e04f1a80",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "3abc23fbb17be5d77ac23f73",
             "_tpl": "5ac7655e5acfc40016339a19",
             "parentId": "e06d1d5bd0bafc5daa43beab",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "ac5193c3a1ecb1ec5de75dbe",
             "_tpl": "5cf50850d7f00c056e24104c",
             "parentId": "e06d1d5bd0bafc5daa43beab",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "d2ef807d94ecef396ff26a54",
             "_tpl": "628b9a40717774443b15e9f2",
             "parentId": "e06d1d5bd0bafc5daa43beab",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "64c4aab6f8c9faf067e4f6ea",
             "_tpl": "55d4ae6c4bdc2d8b2f8b456e",
             "parentId": "d2ef807d94ecef396ff26a54",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "03596af173f8c68cfa2398d3",
             "_tpl": "55d480c04bdc2d1d4e8b456a",
             "parentId": "e06d1d5bd0bafc5daa43beab",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "3bb7bf8716b6edd9cfeb7c01",
             "_tpl": "628b9c37a733087d0d7fe84b",
             "parentId": "hideout",
@@ -8899,62 +7874,52 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ae79bf9312e63fe0aa0176c2",
             "_tpl": "628b8d83717774443b15e248",
             "parentId": "3bb7bf8716b6edd9cfeb7c01",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "f5babefbf369402b6ca25c5c",
             "_tpl": "628b916469015a4e1711ed8d",
             "parentId": "ae79bf9312e63fe0aa0176c2",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "f5e46c9272a5bd3c39b56b7c",
             "_tpl": "628b9be6cff66b70c002b14c",
             "parentId": "f5babefbf369402b6ca25c5c",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "4e5dafbdad3c9db2fbf8c8be",
             "_tpl": "628b9471078f94059a4b9bfb",
             "parentId": "f5e46c9272a5bd3c39b56b7c",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "64dcfa2e4d77c6bc7b86bc7d",
             "_tpl": "5943eeeb86f77412d6384f6b",
             "parentId": "3bb7bf8716b6edd9cfeb7c01",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "fba4d6bdfbffcb4943dab3f9",
             "_tpl": "5cf50850d7f00c056e24104c",
             "parentId": "3bb7bf8716b6edd9cfeb7c01",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "b31fafe4fafcb1fd88eb1e2d",
             "_tpl": "628b9a40717774443b15e9f2",
             "parentId": "3bb7bf8716b6edd9cfeb7c01",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "44cdc766b7eaf2afc904e9d1",
             "_tpl": "55d4ae6c4bdc2d8b2f8b456e",
             "parentId": "b31fafe4fafcb1fd88eb1e2d",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "630c03c22172eedfee12fd42",
             "_tpl": "55d480c04bdc2d1d4e8b456a",
             "parentId": "3bb7bf8716b6edd9cfeb7c01",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "a2f6071ed03fa6bba2d0d151",
             "_tpl": "6499849fc93611967b034949",
             "parentId": "hideout",
@@ -8965,74 +7930,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d05eb2cccaeb8ef69e0f97bc",
             "_tpl": "649ec107961514b22506b10c",
             "parentId": "a2f6071ed03fa6bba2d0d151",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "cf1f8bf3ce0fcf46d9fbf9f4",
             "_tpl": "5beec8ea0db834001a6f9dbf",
             "parentId": "a2f6071ed03fa6bba2d0d151",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "046e891c5f835caba7652558",
             "_tpl": "649ec127c93611967b034957",
             "parentId": "a2f6071ed03fa6bba2d0d151",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "c87becfcedfabc6a02dc135d",
             "_tpl": "5beecbb80db834001d2c465e",
             "parentId": "046e891c5f835caba7652558",
             "slotId": "mod_mount_001"
-        },
-        {
+        }, {
             "_id": "af96c2f6abfa927d0b0a727b",
             "_tpl": "649ec2af961514b22506b10f",
             "parentId": "a2f6071ed03fa6bba2d0d151",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "541ee4f7619eb413eecedee8",
             "_tpl": "649ec2f3961514b22506b111",
             "parentId": "a2f6071ed03fa6bba2d0d151",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "831a5e2ccefcaff29fada6a0",
             "_tpl": "649ec2da59cbb3c813042dca",
             "parentId": "541ee4f7619eb413eecedee8",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "35fa030abceea2fe7e1ea678",
             "_tpl": "649ec2cec93611967b03495e",
             "parentId": "831a5e2ccefcaff29fada6a0",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "8deda7fefaab2545e49a1aaa",
             "_tpl": "649ec30cb013f04a700e60fb",
             "parentId": "a2f6071ed03fa6bba2d0d151",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "cecc14afcbfcf510324bd1d1",
             "_tpl": "649ec87d8007560a9001ab36",
             "parentId": "a2f6071ed03fa6bba2d0d151",
             "slotId": "mod_stock_001"
-        },
-        {
+        }, {
             "_id": "8a2723a28b317bf6cc2de1a3",
             "_tpl": "5beec8c20db834001d2c465c",
             "parentId": "cecc14afcbfcf510324bd1d1",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "aaf6d69efa9cacf60adc7f8e",
             "_tpl": "65290f395ae2ae97b80fdf2d",
             "parentId": "hideout",
@@ -9043,92 +7996,77 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "cc659acaacbb1c3d11e1be2c",
             "_tpl": "652911675ae2ae97b80fdf3c",
             "parentId": "aaf6d69efa9cacf60adc7f8e",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "bbc4dba2cbf0da5f50cb90a7",
             "_tpl": "65293c38fc460e50a509cb25",
             "parentId": "aaf6d69efa9cacf60adc7f8e",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "2b59ddcddfe94a9a9b840fef",
             "_tpl": "6529119424cbe3c74a05e5bb",
             "parentId": "aaf6d69efa9cacf60adc7f8e",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "800b32bbe6abcaeedf9d3b67",
             "_tpl": "652910ef50dc782999054b97",
             "parentId": "2b59ddcddfe94a9a9b840fef",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "56710e8acdf16de24bf0eacb",
             "_tpl": "652910565ae2ae97b80fdf35",
             "parentId": "2b59ddcddfe94a9a9b840fef",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "27ccceeac258b7fb2c5ba0eb",
             "_tpl": "652910bc24cbe3c74a05e5b9",
             "parentId": "56710e8acdf16de24bf0eacb",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "282e1688caac5ec37cc3dce3",
             "_tpl": "6529113b5ae2ae97b80fdf39",
             "parentId": "56710e8acdf16de24bf0eacb",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "e932e7ef224ac79aa1ef00fc",
             "_tpl": "652911e650dc782999054b9d",
             "parentId": "282e1688caac5ec37cc3dce3",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "7bdd1b5f1acbe09ba3e99ae0",
             "_tpl": "6567e751a715f85433025998",
             "parentId": "2b59ddcddfe94a9a9b840fef",
             "slotId": "mod_scope"
-        },
-        {
+        }, {
             "_id": "db9f5a3cfa608befaa14e6fe",
             "_tpl": "6567e7681265c8a131069b0f",
             "parentId": "7bdd1b5f1acbe09ba3e99ae0",
             "slotId": "mod_scope"
-        },
-        {
+        }, {
             "_id": "0193df8c68fbfe91a6cdd5ba",
             "_tpl": "6529348224cbe3c74a05e5c4",
             "parentId": "aaf6d69efa9cacf60adc7f8e",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "f6a5e745c3c63f64713ed5eb",
             "_tpl": "6529366450dc782999054ba0",
             "parentId": "0193df8c68fbfe91a6cdd5ba",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "ac56bbe327fc9aadbcb0a0d0",
             "_tpl": "6529370c405a5f51dd023db8",
             "parentId": "f6a5e745c3c63f64713ed5eb",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "559a771fa1dc1b49acca8827",
             "_tpl": "6529109524cbe3c74a05e5b7",
             "parentId": "aaf6d69efa9cacf60adc7f8e",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "d98ab051c5da92d456bcdc1f",
             "_tpl": "62307b7b10d2321fa8741921",
             "parentId": "hideout",
@@ -9139,8 +8077,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ae52b4abba99e7fd158401bd",
             "_tpl": "630e1adbbd357927e4007c09",
             "parentId": "hideout",
@@ -9151,8 +8088,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "eacecba5bed5b258dddf2eaf",
             "_tpl": "62e7c98b550c8218d602cbb4",
             "parentId": "hideout",
@@ -9163,8 +8099,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "edf9df344ec677aacbb52f9f",
             "_tpl": "630e295c984633f1fb0e7c30",
             "parentId": "hideout",
@@ -9175,8 +8110,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e6a60edaacc44e043b69aad4",
             "_tpl": "649ec30cb013f04a700e60fb",
             "parentId": "hideout",
@@ -9187,8 +8121,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "667b4b8efce0ac366aed9eb7",
             "_tpl": "55d4887d4bdc2d962f8b4570",
             "parentId": "hideout",

--- a/db/traders/6765fbd20fdc7eb79b00000d/assort.json
+++ b/db/traders/6765fbd20fdc7eb79b00000d/assort.json
@@ -1,1497 +1,1712 @@
 {
     "barter_scheme": {
         "7aa3924d668adec0b4bdc172": [
-            [{
+            [
+                {
                     "_tpl": "59e366c186f7741778269d85",
                     "count": 5
                 }
             ]
         ],
         "e7dba0b556bbdedd48bb3efc": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 20000
                 }
             ]
         ],
         "4a05cab1ec3fcaecfd869ad7": [
-            [{
+            [
+                {
                     "_tpl": "5af0534a86f7743b6f354284",
                     "count": 1
                 }
             ]
         ],
         "3c9a94be9f1f085be6bf531a": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 88000
                 }
             ]
         ],
         "f2bffb9aadcdbc2965ce79d0": [
-            [{
+            [
+                {
                     "_tpl": "619cbfeb6b8a1b37a54eebfa",
                     "count": 1
                 }
             ]
         ],
         "9d5fc650ffb2dadbae0af289": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 8500
                 }
             ]
         ],
         "bbaa3cd4a5e92ef032f0cabf": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1900
                 }
             ]
         ],
         "4feaffc69b6ec20f7b7bdee5": [
-            [{
+            [
+                {
                     "_tpl": "56dff421d2720b5f5a8b4567",
                     "count": 2
                 }
             ]
         ],
         "e3667b22d92ed5aad0a07733": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24
                 }
             ]
         ],
         "87c445dab45bca03aa9eba6d": [
-            [{
+            [
+                {
                     "_tpl": "59e3577886f774176a362503",
                     "count": 5
                 }
             ]
         ],
         "c4cc139e00afaab6aaaedef0": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 38000
                 }
             ]
         ],
         "1dcacae3060cacdda409dd3b": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24000
                 }
             ]
         ],
         "7be6cf2fbddcdc064d19f3d8": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "a909df3fed26210f205d7bb7": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 450
                 }
             ]
         ],
         "e6f580eda46a6a5f308f785c": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1800
                 }
             ]
         ],
         "b4ab4f3fb9a1c8d3fe4be6db": [
-            [{
+            [
+                {
                     "_tpl": "5d1b2ffd86f77425243e8d17",
                     "count": 5
                 }
             ]
         ],
         "eedeeaa88d99b468cfe8c9db": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 20500
                 }
             ]
         ],
         "62baccaf0cb7a0dd6efbcff8": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1400
                 }
             ]
         ],
         "0cedd0be14cd798150806117": [
-            [{
+            [
+                {
                     "_tpl": "5d6e6772a4b936088465b17c",
                     "count": 3
                 }
             ]
         ],
         "beebe51d8451e5a660c7adda": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 46
                 }
             ]
         ],
         "8dbbeabc4cade94fc119bbca": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1500
                 }
             ]
         ],
         "aa0daf7dd10fafb6deb5aa68": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1000
                 }
             ]
         ],
         "14fcaf39a7b147e851f54ab8": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 800
                 }
             ]
         ],
         "815bdffbfefaefc1eb946042": [
-            [{
+            [
+                {
                     "_tpl": "57347baf24597738002c6178",
                     "count": 2
                 }
             ]
         ],
         "d0bf8b7df20d2d5e41d243dd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 20000
                 }
             ]
         ],
         "ab5ad43ae0c94f95adcce72c": [
-            [{
+            [
+                {
                     "_tpl": "5d6d2ef3a4b93618084f58bd",
                     "count": 4
                 }
             ]
         ],
         "5a8ae15552d7bab96f6deefc": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 40000
                 }
             ]
         ],
         "b5369dabebdaae9f0638690e": [
-            [{
+            [
+                {
                     "_tpl": "590a3cd386f77436f20848cb",
                     "count": 3
                 }
             ]
         ],
         "abf5d1323a7beedbedef4e7a": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 9000
                 }
             ]
         ],
         "b6e30b8cb2ccc9cb52c6dddf": [
-            [{
+            [
+                {
                     "_tpl": "56742c284bdc2d98058b456d",
                     "count": 3
                 }
             ]
         ],
         "2fcbee555002fa95add0cde5": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 6000
                 }
             ]
         ],
         "338fdbdb2c904cdbe5fc6bd1": [
-            [{
+            [
+                {
                     "_tpl": "5d6e695fa4b936359b35d852",
                     "count": 3
                 }
             ]
         ],
         "b5bbca063ce94dd3adeafe5e": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 20
                 }
             ]
         ],
         "b7cfaabbd60e5e1d40b5b23d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 900
                 }
             ]
         ],
         "3bec2fb9ecd6b8eceebda42d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 660
                 }
             ]
         ],
         "caff57e18ced0af048ead93b": [
-            [{
+            [
+                {
                     "_tpl": "5e2af22086f7746d3f3c33fa",
                     "count": 4
                 }
             ]
         ],
         "6e8a643bca8daa84dbacabbc": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 25000
                 }
             ]
         ],
         "81b87eca6e8eab6183ba05a6": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 750
                 }
             ]
         ],
         "2d028a9aad960b9be056eeba": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1500
                 }
             ]
         ],
         "607ef9471edab8965ed93c2c": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2200
                 }
             ]
         ],
         "14ebcc4a4d7cbde6e3da4a27": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3100
                 }
             ]
         ],
         "e8a0fe4dcca134dc37a7eb89": [
-            [{
+            [
+                {
                     "_tpl": "5e8f3423fd7471236e6e3b64",
                     "count": 4
                 }
             ]
         ],
         "9e0fb0dc0647ee412eccbfb7": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 35000
                 }
             ]
         ],
         "bebdbbf862ac9db6fe44c8a7": [
-            [{
+            [
+                {
                     "_tpl": "5d1b317c86f7742523398392",
                     "count": 1
                 }
             ]
         ],
         "28a2ceba0f658b7cde82e3db": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 80000
                 }
             ]
         ],
         "7f0cd7ce3de8f02a42ceb994": [
-            [{
+            [
+                {
                     "_tpl": "5e2aee0a86f774755a234b62",
                     "count": 3
                 }
             ]
         ],
         "8aab4bd4bc42f6dbde6f6e76": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 168000
                 }
             ]
         ],
         "abff9fd31e2addb58a449beb": [
-            [{
+            [
+                {
                     "_tpl": "5d6e6806a4b936088465b17e",
                     "count": 5
                 }
             ]
         ],
         "5a7da5bc3fc294f8abfaafa7": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 600
                 }
             ]
         ],
         "fd06898aad080db6836c43ee": [
-            [{
+            [
+                {
                     "_tpl": "5d1b2ffd86f77425243e8d17",
                     "count": 5
                 }
             ]
         ],
         "60dfff92fdfddbb41fe52ebb": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 42000
                 }
             ]
         ],
         "127beb33b5eb51fd2e70207a": [
-            [{
+            [
+                {
                     "_tpl": "5d1b304286f774253763a528",
                     "count": 3
                 }
             ]
         ],
         "a3ef1d5febe5abf65dcedcb8": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 42000
                 }
             ]
         ],
         "1bc8eec0b9c5df19e4b9cd9d": [
-            [{
+            [
+                {
                     "_tpl": "590a3c0a86f774385a33c450",
                     "count": 4
                 }
             ]
         ],
         "7936d525b99ffb703cd8ea29": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 38000
                 }
             ]
         ],
         "a8cd694ebdfe692520edfac7": [
-            [{
+            [
+                {
                     "_tpl": "5d403f9186f7743cac3f229b",
                     "count": 3
                 }
             ]
         ],
         "bcaabb55ecbd2dcaf2401b6b": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 65000
                 }
             ]
         ],
         "06a26faa77eee1fe7557532a": [
-            [{
+            [
+                {
                     "_tpl": "590c645c86f77412b01304d9",
                     "count": 3
                 }
             ]
         ],
         "2a6b7cf8c5ca055c1b6dc4fa": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 75000
                 }
             ]
         ],
         "5ccae3762dbff05bd55bf93a": [
-            [{
+            [
+                {
                     "_tpl": "5d1c774f86f7746d6620f8db",
                     "count": 3
                 }
             ]
         ],
         "cfe8a8bde180b1eaec91ed90": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 27000
                 }
             ]
         ],
         "0a5bcceac2bf91793d8f10dc": [
-            [{
+            [
+                {
                     "_tpl": "5d1b3f2d86f774253763b735",
                     "count": 2
                 }
             ]
         ],
         "7b1af22abd0e2e0619fa4af7": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1200
                 }
             ]
         ],
         "02b2d5d2c2a0ccecae56cccc": [
-            [{
+            [
+                {
                     "_tpl": "5d1b39a386f774252339976f",
                     "count": 3
                 }
             ]
         ],
         "6985d7dca6cba924cab9f3ee": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 22500
                 }
             ]
         ],
         "9eb2dbad3ee5fe81dfd9f4dd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 21000
                 }
             ]
         ],
         "14f09c3dcc2f8dcfa5b66d1b": [
-            [{
+            [
+                {
                     "_tpl": "5d40419286f774318526545f",
                     "count": 2
                 }
             ]
         ],
         "e1e4be9eb2fb2c7f3dc2bc5c": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60000
                 }
             ]
         ],
         "6d4aa0fcc7cbf1deb09bd91e": [
-            [{
+            [
+                {
                     "_tpl": "59e35de086f7741778269d84",
                     "count": 1
                 }
             ]
         ],
         "bda6e7e5ff8a22da30aa8ea1": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 30000
                 }
             ]
         ],
         "7bcd28b4cbbf7a34d643dce9": [
-            [{
+            [
+                {
                     "_tpl": "590de71386f774347051a052",
                     "count": 2
                 }
             ]
         ],
         "9f1f6df81a9bab1a5f7bba6b": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 91000
                 }
             ]
         ],
         "f1a5934eaa76429ab1c7c4fc": [
-            [{
+            [
+                {
                     "_tpl": "5d1b309586f77425227d1676",
                     "count": 2
                 }
             ]
         ],
         "343f9a2592db24c7367d9bb0": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 9000
                 }
             ]
         ],
         "6b294de60ee4afbdf7eddf2e": [
-            [{
+            [
+                {
                     "_tpl": "560d5e524bdc2d25448b4571",
                     "count": 3
                 }
             ]
         ],
         "172e90dcba9ec5ae96ee01f2": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 30
                 }
             ]
         ],
         "25b829ade67aa93a8da0ba89": [
-            [{
+            [
+                {
                     "_tpl": "5d6e68d1a4b93622fe60e845",
                     "count": 4
                 }
             ]
         ],
         "7fe29efcd4b9cdc35f662aaf": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 36
                 }
             ]
         ],
         "5df6afccfdd9e3de38cf2daf": [
-            [{
+            [
+                {
                     "_tpl": "5d6e68b3a4b9361bca7e50b5",
                     "count": 3
                 }
             ]
         ],
         "8ed3f327c9a78ff4fae5c9fa": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 160
                 }
             ]
         ],
         "fc4ec0987d8a1083e94b6f1b": [
-            [{
+            [
+                {
                     "_tpl": "5d6e6891a4b9361bd473feea",
                     "count": 3
                 }
             ]
         ],
         "659857de5bd8bff8e39ebba1": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60
                 }
             ]
         ],
         "3adde9b6b3c48c173114eb81": [
-            [{
+            [
+                {
                     "_tpl": "58820d1224597753c90aeb13",
                     "count": 2
                 }
             ]
         ],
         "d95bf0a27ec8a5b8f4fce9fb": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 45
                 }
             ]
         ],
         "c9e724db43f279a4dc44565d": [
-            [{
+            [
+                {
                     "_tpl": "5d6e6869a4b9361c140bcfde",
                     "count": 3
                 }
             ]
         ],
         "1ff5b265a6e69e713fdafc7c": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60
                 }
             ]
         ],
         "f9d05eb5a0910dc0b41ecc4e": [
-            [{
+            [
+                {
                     "_tpl": "5d6e68c4a4b9361b93413f79",
                     "count": 2
                 }
             ]
         ],
         "8a0bd539dd47a5ff59938fee": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 840
                 }
             ]
         ],
         "002a7f22d6297fd004beb4ed": [
-            [{
+            [
+                {
                     "_tpl": "5d6e68e6a4b9361c140bcfe0",
                     "count": 3
                 }
             ]
         ],
         "209e3c91cf9ea1bd6aecabb2": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 75
                 }
             ]
         ],
         "64de2ab8bead299fb3b1fdfa": [
-            [{
+            [
+                {
                     "_tpl": "5c0d591486f7744c505b416f",
                     "count": 2
                 }
             ]
         ],
         "ea1b19ecaca8b4d7d2f9cd2e": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 360
                 }
             ]
         ],
         "bee7bb50c8942ae3e9b790e6": [
-            [{
+            [
+                {
                     "_tpl": "5d6e689ca4b9361bc8618956",
                     "count": 2
                 }
             ]
         ],
         "5a2c5d1f45fdcc509a0e509e": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 160
                 }
             ]
         ],
         "b2924c4ea4f0f27aadde6d4d": [
-            [{
+            [
+                {
                     "_tpl": "5d6e6911a4b9361bd5780d52",
                     "count": 3
                 }
             ]
         ],
         "e0bf522520d0ee8dcddcecfc": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60
                 }
             ]
         ],
         "d8cbffcb15be9ef00d1bc83c": [
-            [{
+            [
+                {
                     "_tpl": "5d6e68dea4b9361bcc29e659",
                     "count": 2
                 }
             ]
         ],
         "4dcacbf50d8f0b4b5e57c518": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 66
                 }
             ]
         ],
         "d0a91b2b9ecd370b27719adf": [
-            [{
+            [
+                {
                     "_tpl": "5d6e67fba4b9361bc73bc779",
                     "count": 3
                 }
             ]
         ],
         "96daf62f8cef314ce2ebcbe8": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 300
                 }
             ]
         ],
         "ebfdd56e54eac3afef0be4b7": [
-            [{
+            [
+                {
                     "_tpl": "560d5e524bdc2d25448b4571",
                     "count": 3
                 }
             ]
         ],
         "0fb70646328e94c05adb9371": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 18
                 }
             ]
         ],
         "f1ef72fcdade7bfedaf1fca1": [
-            [{
+            [
+                {
                     "_tpl": "5d6e6a53a4b9361bd473feec",
                     "count": 3
                 }
             ]
         ],
         "a6deabdf042b04703a69f32c": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24
                 }
             ]
         ],
         "c72ebf92e3bcdad20982c0c7": [
-            [{
+            [
+                {
                     "_tpl": "5d6e6a05a4b93618084f58d0",
                     "count": 4
                 }
             ]
         ],
         "8ed19a9fbd1ebeef15af8cbd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 33
                 }
             ]
         ],
         "ec3a10e74fd57d62bdf85d9a": [
-            [{
+            [
+                {
                     "_tpl": "5d6e6a42a4b9364f07165f52",
                     "count": 3
                 }
             ]
         ],
         "78073a728de6a5c9a6ed60d0": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 75
                 }
             ]
         ],
         "ab11bfb33bde45cef4aad3db": [
-            [{
+            [
+                {
                     "_tpl": "5d6e69b9a4b9361bc8618958",
                     "count": 3
                 }
             ]
         ],
         "7cbe0fb45c06fcdfc0fccee3": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60
                 }
             ]
         ],
         "1aee6bfdf419aaacb102028b": [
-            [{
+            [
+                {
                     "_tpl": "5a38ebd9c4a282000d722a5b",
                     "count": 3
                 }
             ]
         ],
         "be72bf3becb06875108179cb": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 45
                 }
             ]
         ],
         "abefc4eece1bec9ddd29db7f": [
-            [{
+            [
+                {
                     "_tpl": "5d6e69c7a4b9360b6c0d54e4",
                     "count": 3
                 }
             ]
         ],
         "7a9ed9ece005b3e2ca2e7915": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 150
                 }
             ]
         ],
         "ba8ca88daafaf9594ae540e5": [
-            [{
+            [
+                {
                     "_tpl": "5bc9c29cd4351e003562b8a3",
                     "count": 6
                 }
             ]
         ],
         "0ff1bc2be0ac63ee6cabfce9": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 41000
                 }
             ]
         ],
         "a5f649bf8d44b1893d4fd69b": [
-            [{
+            [
+                {
                     "_tpl": "57347cd0245977445a2d6ff1",
                     "count": 4
                 }
             ]
         ],
         "c5194f82e7a5f0cfd41d0e45": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 9500
                 }
             ]
         ],
         "0df43ca5ffe3fc1ec51dccea": [
-            [{
+            [
+                {
                     "_tpl": "5d1b3a5d86f774252167ba22",
                     "count": 4
                 }
             ]
         ],
         "1a97bc5decbca0f037a80aff": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 17000
                 }
             ]
         ],
         "b5ec3d0cd03cc5ed7f9e5abc": [
-            [{
+            [
+                {
                     "_tpl": "59faff1d86f7746c51718c9c",
                     "count": 1
                 }
             ]
         ],
         "bb33afb00f72bfb3cefc91d7": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 190000
                 }
             ]
         ],
         "0644e04adbb0df7b7e1adfe8": [
-            [{
+            [
+                {
                     "_tpl": "5d1c774f86f7746d6620f8db",
                     "count": 6
                 }
             ]
         ],
         "befe0e3d6b6187afc6bed13d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 40000
                 }
             ]
         ],
         "3db1ce73dda3d123aa1e5ca1": [
-            [{
+            [
+                {
                     "_tpl": "5f647f31b6238e5dd066e196",
                     "count": 3
                 }
             ]
         ],
         "c560e753a39628c459aa8e73": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 75
                 }
             ]
         ],
         "dfb203e62e2092c12584d01c": [
-            [{
+            [
+                {
                     "_tpl": "590a373286f774287540368b",
                     "count": 1
-                }, {
+                },
+                {
                     "_tpl": "5e2af37686f774755a234b65",
                     "count": 1
                 }
             ]
         ],
         "ae574cfa8c9edeffda91eeb3": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3000
                 }
             ]
         ],
         "9abc31afafd3af049cf1432d": [
-            [{
+            [
+                {
                     "_tpl": "5e85a9a6eacf8c039e4e2ac1",
                     "count": 4
                 }
             ]
         ],
         "dbd3aacd87e030cd2a76e6d7": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 225
                 }
             ]
         ],
         "5b3fbcdbec5daf6c8c94ae9d": [
-            [{
+            [
+                {
                     "_tpl": "590c35a486f774273531c822",
                     "count": 1
                 }
             ]
         ],
         "de565b1ba801acabcd28247d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 28000
                 }
             ]
         ],
         "e39a291deaefa46f7d9ea3d1": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1400
                 }
             ]
         ],
         "8be67fad35c2041d0ab894b3": [
-            [{
+            [
+                {
                     "_tpl": "573474f924597738002c6174",
                     "count": 5
                 }
             ]
         ],
         "ef6d7cedd2aa50ee8ac348c1": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 36000
                 }
             ]
         ],
         "f8d40ee84cf325dd1ea4f277": [
-            [{
+            [
+                {
                     "_tpl": "590a386e86f77429692b27ab",
                     "count": 4
                 }
             ]
         ],
         "acdf6c8f8ad9de7bdda3eb21": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 22000
                 }
             ]
         ],
         "a4b0cbb6ae80ca76a5ad2afa": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2000
                 }
             ]
         ],
         "b171a43daba1aafeacf82ef7": [
-            [{
+            [
+                {
                     "_tpl": "5d6e6a5fa4b93614ec501745",
                     "count": 3
                 }
             ]
         ],
         "bbaa0da51cc5cd3150187212": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 100
                 }
             ]
         ],
         "b4c3ad7f6315dab31c7def05": [
-            [{
+            [
+                {
                     "_tpl": "57347c5b245977448d35f6e1",
                     "count": 2
                 }
             ]
         ],
         "972beb8aeb39edac5fb66ab6": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3600
                 }
             ]
         ],
         "dd80a6c3f7d6deabac4abbfd": [
-            [{
+            [
+                {
                     "_tpl": "59e35cbb86f7741778269d83",
                     "count": 2
                 }
             ]
         ],
         "ac9a2aac2ecfcf9d6ab6fd08": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 28000
                 }
             ]
         ],
         "1af4cd84e135f08e84fd00b0": [
-            [{
+            [
+                {
                     "_tpl": "5751496424597720a27126da",
                     "count": 4
                 }
             ]
         ],
         "5fd0fa716e0cae2f43cfbdde": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24000
                 }
             ]
         ],
         "4f98a8eb9c3a3d351c4dc616": [
-            [{
+            [
+                {
                     "_tpl": "590c2b4386f77425357b6123",
                     "count": 5
                 }
             ]
         ],
         "4894ed01ee4ff84e2f01a9ad": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 9000
                 }
             ]
         ],
         "1f146f73bf81b60d52f79fdb": [
-            [{
+            [
+                {
                     "_tpl": "5734773724597737fd047c14",
                     "count": 3
                 }
             ]
         ],
         "c2dd6ddbf2ee14dd90b20e2b": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 28000
                 }
             ]
         ],
         "bcfb7e5df21c3beeacec529e": [
-            [{
+            [
+                {
                     "_tpl": "590a373286f774287540368b",
                     "count": 3
                 }
             ]
         ],
         "fd4b6e085dacd9ded83fc8f6": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 27000
                 }
             ]
         ],
         "bf57c5de5dfc6329e0ed29c4": [
-            [{
+            [
+                {
                     "_tpl": "5e2aee0a86f774755a234b62",
                     "count": 5
                 }
             ]
         ],
         "5ca0dee49bced1007ebd9fca": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 161000
                 }
             ]
         ],
         "8107aeabab56728bdbe6181f": [
-            [{
+            [
+                {
                     "_tpl": "60391afc25aff57af81f7085",
                     "count": 2
                 }
             ]
         ],
         "bcedb51bce8ca8cec38dbe98": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 78000
                 }
             ]
         ],
         "0720d68e9bdc9fbfcec106c3": [
-            [{
+            [
+                {
                     "_tpl": "56742c2e4bdc2d95058b456d",
                     "count": 5
                 }
             ]
         ],
         "65d3c74ebed719cd2e7e9eaf": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 30000
                 }
             ]
         ],
         "f4a96de7cbf7e245cab905ad": [
-            [{
+            [
+                {
                     "_tpl": "61bf83814088ec1a363d7097",
                     "count": 1
                 }
             ]
         ],
         "b60d3d77d62c4408f924a38c": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 19000
                 }
             ]
         ],
         "0bdd95825aed498d5edc3fb2": [
-            [{
+            [
+                {
                     "_tpl": "61bf83814088ec1a363d7097",
                     "count": 3
                 }
             ]
         ],
         "6ca566b8cfead979b1a041e1": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 64000
                 }
             ]
         ],
         "3b8b75b42dff1b2b96cd1243": [
-            [{
+            [
+                {
                     "_tpl": "619cbfccbedcde2f5b3f7bdd",
                     "count": 1
-                }, {
+                },
+                {
                     "_tpl": "5d1b3a5d86f774252167ba22",
                     "count": 1
                 }
             ]
         ],
         "b503dddf3900caaca0e6cc7b": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 66000
                 }
             ]
         ],
         "aecaeaaa617a6a05bb821bbd": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "087717cededfbc19aeff9c37": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 190
                 }
             ]
         ],
         "623aa1c90154a75c100edff9": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "89fc36ba93333ceddffbbde8": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3900
                 }
             ]
         ],
         "eff24cfec6c89e39dfacfddb": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "56b4fdb5172ed0f32bcdfea3": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3900
                 }
             ]
         ],
         "fdafbace8bbf37ceedd73095": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "afac1b2faff7b091519bcb09": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 4600
                 }
             ]
         ],
         "af9861dc3f89985ecf89a4a9": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "a81c21e4ef358ce073b64b61": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 8500
                 }
             ]
         ],
         "4ffda1ff3ccba63e3f39ebad": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "3ce1e4fd4a2ca2fddaf1ef24": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 46000
                 }
             ]
         ],
         "956afc80c1f135f7d0c0cbe9": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "e99ecee55633440e3feff2d0": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 27000
                 }
             ]
         ],
         "aef1470bcf2378f3f32bcfb6": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "f1b2f521bd8dfbbbae294d20": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 26000
                 }
             ]
         ],
         "7cb4be3b3adb4f7617eb8a4a": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "d57fd8b6bbd1def2a9939aff": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 58000
                 }
             ]
         ],
         "acebc7ca3a8ac16ce17df0aa": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "e3a7b67a679103cbc4cb9c00": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 31000
                 }
             ]
         ],
         "db976b5c10f48fd4b0caccba": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "ddd1dbe15b4468ac443df650": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 27000
                 }
             ]
         ],
         "2c73afd9cdfbc0562e5f4115": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "55b1c789d288f78e634ca086": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 72000
                 }
             ]
         ],
         "7afc02b5923ad5c054bd79b6": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "77dde8e2fff0ccb2aa60bb12": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 66000
                 }
             ]
         ],
         "a08fca03a1dfd7a1f5bdddfb": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "cf6fbdaf8bcabe38b62d180a": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 253000
                 }
             ]
         ],
         "dd05d9eaa23f4dbca40fdf08": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "81f94b456a68be8f28d2de69": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 253000
                 }
             ]
         ],
         "6fffc98890b7cfb0580eb651": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "9e0da78f93fcd9bcd11c93ee": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 272000
                 }
             ]
         ],
         "dab0b75515263367b57489fe": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "4cfc5b3d8ab89f4d2ac8f4aa": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 250000
                 }
             ]
         ],
         "acdc3fe76a21feaad0c7e2f0": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "d6fdaeeee9e64b5cd68624e9": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 200000
                 }
             ]
         ],
         "d2ee21b623e2fcfeea03b359": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "d710d13c10a0ed5e1dbf1cfe": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 45000
                 }
             ]
         ],
         "39f40cb623d2f57f165eeb8c": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 9000
                 }
             ]
         ],
         "f0a75666e2cf7d2ff9eef1ce": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "c5b9dc5b10f8ab52f6a0a3c0": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 37000
                 }
             ]
         ],
         "cd18bd455119eafb5bdfb605": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "8a1f6ebbaacd2c8ebbc8452d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 15000
                 }
             ]
         ],
         "7b351e290bfc09b0cf879dce": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1300
                 }
             ]
         ],
         "facee397e8b3cdfcac07c3ca": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2000
                 }
             ]
         ],
         "6ccccc393cde0a66d0bc68a7": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2200
                 }
             ]
         ],
         "2c36d4e2f9534d1db9cdb37b": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3300
                 }
             ]
         ],
         "e14d2ef0f42a294e7a52ff9d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 4500
                 }
             ]
         ]
     },
-    "items": [{
+    "items": [
+        {
             "_id": "4feaffc69b6ec20f7b7bdee5",
             "_tpl": "560d5e524bdc2d25448b4571",
             "parentId": "hideout",
@@ -1502,7 +1717,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "6b294de60ee4afbdf7eddf2e",
             "_tpl": "5d6e6772a4b936088465b17c",
             "parentId": "hideout",
@@ -1513,7 +1729,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "0cedd0be14cd798150806117",
             "_tpl": "58820d1224597753c90aeb13",
             "parentId": "hideout",
@@ -1524,7 +1741,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "3adde9b6b3c48c173114eb81",
             "_tpl": "5d6e6891a4b9361bd473feea",
             "parentId": "hideout",
@@ -1535,7 +1753,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "aa0daf7dd10fafb6deb5aa68",
             "_tpl": "5882163824597757561aa922",
             "parentId": "hideout",
@@ -1546,7 +1765,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fc4ec0987d8a1083e94b6f1b",
             "_tpl": "5d6e6869a4b9361c140bcfde",
             "parentId": "hideout",
@@ -1557,7 +1777,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c9e724db43f279a4dc44565d",
             "_tpl": "5d6e689ca4b9361bc8618956",
             "parentId": "hideout",
@@ -1568,7 +1789,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bee7bb50c8942ae3e9b790e6",
             "_tpl": "5d6e68d1a4b93622fe60e845",
             "parentId": "hideout",
@@ -1579,7 +1801,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "2d028a9aad960b9be056eeba",
             "_tpl": "5a78830bc5856700137e4c90",
             "parentId": "hideout",
@@ -1590,7 +1813,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "25b829ade67aa93a8da0ba89",
             "_tpl": "5d6e67fba4b9361bc73bc779",
             "parentId": "hideout",
@@ -1601,7 +1825,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "8dbbeabc4cade94fc119bbca",
             "_tpl": "5882163224597757561aa920",
             "parentId": "hideout",
@@ -1612,7 +1837,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d0a91b2b9ecd370b27719adf",
             "_tpl": "5d6e6911a4b9361bd5780d52",
             "parentId": "hideout",
@@ -1623,7 +1849,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "14ebcc4a4d7cbde6e3da4a27",
             "_tpl": "5a966f51a2750c00156aacf6",
             "parentId": "hideout",
@@ -1634,7 +1861,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b2924c4ea4f0f27aadde6d4d",
             "_tpl": "5d6e68dea4b9361bcc29e659",
             "parentId": "hideout",
@@ -1645,7 +1873,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d8cbffcb15be9ef00d1bc83c",
             "_tpl": "5d6e68e6a4b9361c140bcfe0",
             "parentId": "hideout",
@@ -1656,7 +1885,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "002a7f22d6297fd004beb4ed",
             "_tpl": "5d6e68b3a4b9361bca7e50b5",
             "parentId": "hideout",
@@ -1667,7 +1897,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bbaa3cd4a5e92ef032f0cabf",
             "_tpl": "55d485804bdc2d8c2f8b456b",
             "parentId": "hideout",
@@ -1678,7 +1909,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e6f580eda46a6a5f308f785c",
             "_tpl": "56deeefcd2720bc8328b4568",
             "parentId": "hideout",
@@ -1689,7 +1921,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "5df6afccfdd9e3de38cf2daf",
             "_tpl": "5d6e6806a4b936088465b17e",
             "parentId": "hideout",
@@ -1700,7 +1933,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "abff9fd31e2addb58a449beb",
             "_tpl": "5c0d591486f7744c505b416f",
             "parentId": "hideout",
@@ -1711,7 +1945,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "0a5bcceac2bf91793d8f10dc",
             "_tpl": "5c1127d0d174af29be75cf68",
             "parentId": "hideout",
@@ -1722,7 +1957,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a0ec9da1ec10eda3a8533f1c",
             "_tpl": "5c0d591486f7744c505b416f",
             "parentId": "0a5bcceac2bf91793d8f10dc",
@@ -1731,7 +1967,8 @@
             "upd": {
                 "StackObjectsCount": 5
             }
-        }, {
+        },
+        {
             "_id": "607ef9471edab8965ed93c2c",
             "_tpl": "5a78832ec5856700155a6ca3",
             "parentId": "hideout",
@@ -1742,7 +1979,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "64de2ab8bead299fb3b1fdfa",
             "_tpl": "5d6e68c4a4b9361b93413f79",
             "parentId": "hideout",
@@ -1753,7 +1991,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f9d05eb5a0910dc0b41ecc4e",
             "_tpl": "5d6e68a8a4b9360b6c0d54e2",
             "parentId": "hideout",
@@ -1764,7 +2003,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "9eb2dbad3ee5fe81dfd9f4dd",
             "_tpl": "5cf8f3b0d7f00c00217872ef",
             "parentId": "hideout",
@@ -1775,7 +2015,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e3667b22d92ed5aad0a07733",
             "_tpl": "560d5e524bdc2d25448b4571",
             "parentId": "hideout",
@@ -1786,7 +2027,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "172e90dcba9ec5ae96ee01f2",
             "_tpl": "5d6e6772a4b936088465b17c",
             "parentId": "hideout",
@@ -1797,7 +2039,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "beebe51d8451e5a660c7adda",
             "_tpl": "58820d1224597753c90aeb13",
             "parentId": "hideout",
@@ -1808,7 +2051,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d95bf0a27ec8a5b8f4fce9fb",
             "_tpl": "5d6e6891a4b9361bd473feea",
             "parentId": "hideout",
@@ -1819,7 +2063,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "659857de5bd8bff8e39ebba1",
             "_tpl": "5d6e6869a4b9361c140bcfde",
             "parentId": "hideout",
@@ -1830,7 +2075,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "1ff5b265a6e69e713fdafc7c",
             "_tpl": "5d6e689ca4b9361bc8618956",
             "parentId": "hideout",
@@ -1841,7 +2087,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "5a2c5d1f45fdcc509a0e509e",
             "_tpl": "5d6e68d1a4b93622fe60e845",
             "parentId": "hideout",
@@ -1852,7 +2099,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7fe29efcd4b9cdc35f662aaf",
             "_tpl": "5d6e67fba4b9361bc73bc779",
             "parentId": "hideout",
@@ -1863,7 +2111,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "96daf62f8cef314ce2ebcbe8",
             "_tpl": "5d6e6911a4b9361bd5780d52",
             "parentId": "hideout",
@@ -1874,7 +2123,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e0bf522520d0ee8dcddcecfc",
             "_tpl": "5d6e68dea4b9361bcc29e659",
             "parentId": "hideout",
@@ -1885,7 +2135,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "4dcacbf50d8f0b4b5e57c518",
             "_tpl": "5d6e68e6a4b9361c140bcfe0",
             "parentId": "hideout",
@@ -1896,7 +2147,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "209e3c91cf9ea1bd6aecabb2",
             "_tpl": "5d6e68b3a4b9361bca7e50b5",
             "parentId": "hideout",
@@ -1907,7 +2159,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "8ed3f327c9a78ff4fae5c9fa",
             "_tpl": "5d6e6806a4b936088465b17e",
             "parentId": "hideout",
@@ -1918,7 +2171,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "5a7da5bc3fc294f8abfaafa7",
             "_tpl": "5c0d591486f7744c505b416f",
             "parentId": "hideout",
@@ -1929,7 +2183,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ea1b19ecaca8b4d7d2f9cd2e",
             "_tpl": "5d6e68c4a4b9361b93413f79",
             "parentId": "hideout",
@@ -1940,7 +2195,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "8a0bd539dd47a5ff59938fee",
             "_tpl": "5d6e68a8a4b9360b6c0d54e2",
             "parentId": "hideout",
@@ -1951,7 +2207,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ebfdd56e54eac3afef0be4b7",
             "_tpl": "5d6e695fa4b936359b35d852",
             "parentId": "hideout",
@@ -1962,7 +2219,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "338fdbdb2c904cdbe5fc6bd1",
             "_tpl": "5a38ebd9c4a282000d722a5b",
             "parentId": "hideout",
@@ -1973,7 +2231,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "1aee6bfdf419aaacb102028b",
             "_tpl": "5d6e6a53a4b9361bd473feec",
             "parentId": "hideout",
@@ -1984,7 +2243,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b7cfaabbd60e5e1d40b5b23d",
             "_tpl": "5a38ed75c4a28232996e40c6",
             "parentId": "hideout",
@@ -1995,7 +2255,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f1ef72fcdade7bfedaf1fca1",
             "_tpl": "5d6e69b9a4b9361bc8618958",
             "parentId": "hideout",
@@ -2006,7 +2267,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ab11bfb33bde45cef4aad3db",
             "_tpl": "5d6e6a42a4b9364f07165f52",
             "parentId": "hideout",
@@ -2017,7 +2279,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ec3a10e74fd57d62bdf85d9a",
             "_tpl": "5d6e6a05a4b93618084f58d0",
             "parentId": "hideout",
@@ -2028,7 +2291,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7b1af22abd0e2e0619fa4af7",
             "_tpl": "5c6161fb2e221600113fbde5",
             "parentId": "hideout",
@@ -2039,7 +2303,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c72ebf92e3bcdad20982c0c7",
             "_tpl": "5d6e69c7a4b9360b6c0d54e4",
             "parentId": "hideout",
@@ -2050,7 +2315,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "abefc4eece1bec9ddd29db7f",
             "_tpl": "5d6e6a5fa4b93614ec501745",
             "parentId": "hideout",
@@ -2061,7 +2327,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "0fb70646328e94c05adb9371",
             "_tpl": "5d6e695fa4b936359b35d852",
             "parentId": "hideout",
@@ -2072,7 +2339,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b5bbca063ce94dd3adeafe5e",
             "_tpl": "5a38ebd9c4a282000d722a5b",
             "parentId": "hideout",
@@ -2083,7 +2351,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "be72bf3becb06875108179cb",
             "_tpl": "5d6e6a53a4b9361bd473feec",
             "parentId": "hideout",
@@ -2094,7 +2363,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a6deabdf042b04703a69f32c",
             "_tpl": "5d6e69b9a4b9361bc8618958",
             "parentId": "hideout",
@@ -2105,7 +2375,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7cbe0fb45c06fcdfc0fccee3",
             "_tpl": "5d6e6a42a4b9364f07165f52",
             "parentId": "hideout",
@@ -2116,7 +2387,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "78073a728de6a5c9a6ed60d0",
             "_tpl": "5d6e6a05a4b93618084f58d0",
             "parentId": "hideout",
@@ -2127,7 +2399,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "8ed19a9fbd1ebeef15af8cbd",
             "_tpl": "5d6e69c7a4b9360b6c0d54e4",
             "parentId": "hideout",
@@ -2138,7 +2411,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7a9ed9ece005b3e2ca2e7915",
             "_tpl": "5d6e6a5fa4b93614ec501745",
             "parentId": "hideout",
@@ -2149,7 +2423,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "dfb203e62e2092c12584d01c",
             "_tpl": "5e85a9f4add9fe03027d9bf1",
             "parentId": "hideout",
@@ -2160,7 +2435,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b171a43daba1aafeacf82ef7",
             "_tpl": "5f647f31b6238e5dd066e196",
             "parentId": "hideout",
@@ -2171,7 +2447,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "3db1ce73dda3d123aa1e5ca1",
             "_tpl": "5e85a9a6eacf8c039e4e2ac1",
             "parentId": "hideout",
@@ -2182,7 +2459,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "9abc31afafd3af049cf1432d",
             "_tpl": "5e85aa1a988a8701445df1f5",
             "parentId": "hideout",
@@ -2193,7 +2471,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ae574cfa8c9edeffda91eeb3",
             "_tpl": "5e85a9f4add9fe03027d9bf1",
             "parentId": "hideout",
@@ -2204,7 +2483,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bbaa0da51cc5cd3150187212",
             "_tpl": "5f647f31b6238e5dd066e196",
             "parentId": "hideout",
@@ -2215,7 +2495,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c560e753a39628c459aa8e73",
             "_tpl": "5e85a9a6eacf8c039e4e2ac1",
             "parentId": "hideout",
@@ -2226,7 +2507,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "dbd3aacd87e030cd2a76e6d7",
             "_tpl": "5e85aa1a988a8701445df1f5",
             "parentId": "hideout",
@@ -2237,7 +2519,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b4c3ad7f6315dab31c7def05",
             "_tpl": "5fd4c5477a8d854fa0105061",
             "parentId": "hideout",
@@ -2248,7 +2531,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a5f649bf8d44b1893d4fd69b",
             "_tpl": "5e4abc1f86f774069619fbaa",
             "parentId": "hideout",
@@ -2259,7 +2543,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f1a5934eaa76429ab1c7c4fc",
             "_tpl": "5d5d8ca986f7742798716522",
             "parentId": "hideout",
@@ -2270,7 +2555,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "4f98a8eb9c3a3d351c4dc616",
             "_tpl": "6034d0230ca681766b6a0fb5",
             "parentId": "hideout",
@@ -2281,7 +2567,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b5369dabebdaae9f0638690e",
             "_tpl": "59e7643b86f7742cbf2c109a",
             "parentId": "hideout",
@@ -2292,7 +2579,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fd06898aad080db6836c43ee",
             "_tpl": "5c0e3eb886f7742015526062",
             "parentId": "hideout",
@@ -2303,27 +2591,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c02",
             "_tpl": "65764a4cd8537eb26a0355ee",
             "parentId": "fd06898aad080db6836c43ee",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c03",
             "_tpl": "65764bc22bc38ef78e076485",
             "parentId": "fd06898aad080db6836c43ee",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c04",
             "_tpl": "65764c39526e320fbe035777",
             "parentId": "fd06898aad080db6836c43ee",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c05",
             "_tpl": "65764c6b526e320fbe03577b",
             "parentId": "fd06898aad080db6836c43ee",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "815bdffbfefaefc1eb946042",
             "_tpl": "5929a2a086f7744f4b234d43",
             "parentId": "hideout",
@@ -2334,7 +2627,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "0df43ca5ffe3fc1ec51dccea",
             "_tpl": "5e4abfed86f77406a2713cf7",
             "parentId": "hideout",
@@ -2345,7 +2639,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "1af4cd84e135f08e84fd00b0",
             "_tpl": "6034cf5fffd42c541047f72e",
             "parentId": "hideout",
@@ -2356,7 +2651,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "5ccae3762dbff05bd55bf93a",
             "_tpl": "5c0e9f2c86f77432297fe0a3",
             "parentId": "hideout",
@@ -2367,7 +2663,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "02b2d5d2c2a0ccecae56cccc",
             "_tpl": "5ca20abf86f77418567a43f2",
             "parentId": "hideout",
@@ -2378,7 +2675,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "1bc8eec0b9c5df19e4b9cd9d",
             "_tpl": "5c0e6a1586f77404597b4965",
             "parentId": "hideout",
@@ -2389,7 +2687,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "127beb33b5eb51fd2e70207a",
             "_tpl": "5c0e446786f7742013381639",
             "parentId": "hideout",
@@ -2400,27 +2699,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c06",
             "_tpl": "657087577f6d4590ac0d2109",
             "parentId": "127beb33b5eb51fd2e70207a",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c07",
             "_tpl": "6570880f4a747dbb63005ee5",
             "parentId": "127beb33b5eb51fd2e70207a",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c08",
             "_tpl": "65708afe4a747dbb63005eee",
             "parentId": "127beb33b5eb51fd2e70207a",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c09",
             "_tpl": "65708b4c4a747dbb63005ef3",
             "parentId": "127beb33b5eb51fd2e70207a",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "dd80a6c3f7d6deabac4abbfd",
             "_tpl": "5fd4c60f875c30179f5d04c2",
             "parentId": "hideout",
@@ -2431,7 +2735,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "6d4aa0fcc7cbf1deb09bd91e",
             "_tpl": "5d5d85c586f774279a21cbdb",
             "parentId": "hideout",
@@ -2442,7 +2747,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f8d40ee84cf325dd1ea4f277",
             "_tpl": "5f5f41f56760b4138443b352",
             "parentId": "hideout",
@@ -2453,7 +2759,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "0720d68e9bdc9fbfcec106c3",
             "_tpl": "60a6220e953894617404b00a",
             "parentId": "hideout",
@@ -2464,7 +2771,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "14f09c3dcc2f8dcfa5b66d1b",
             "_tpl": "5d5d646386f7742797261fd9",
             "parentId": "hideout",
@@ -2475,27 +2783,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c0a",
             "_tpl": "65764e1e2bc38ef78e076489",
             "parentId": "14f09c3dcc2f8dcfa5b66d1b",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c0b",
             "_tpl": "65764fae2bc38ef78e07648d",
             "parentId": "14f09c3dcc2f8dcfa5b66d1b",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c0c",
             "_tpl": "6576504b526e320fbe035783",
             "parentId": "14f09c3dcc2f8dcfa5b66d1b",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c0d",
             "_tpl": "6576500f526e320fbe03577f",
             "parentId": "14f09c3dcc2f8dcfa5b66d1b",
             "slotId": "Groin_back"
-        }, {
+        },
+        {
             "_id": "0bdd95825aed498d5edc3fb2",
             "_tpl": "61bc85697113f767765c7fe7",
             "parentId": "hideout",
@@ -2506,37 +2819,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c0e",
             "_tpl": "6572fc809a866b80ab07eb59",
             "parentId": "0bdd95825aed498d5edc3fb2",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c0f",
             "_tpl": "6572fc8c9a866b80ab07eb5d",
             "parentId": "0bdd95825aed498d5edc3fb2",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c10",
             "_tpl": "6572fc989a866b80ab07eb61",
             "parentId": "0bdd95825aed498d5edc3fb2",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c11",
             "_tpl": "6572fca39a866b80ab07eb65",
             "parentId": "0bdd95825aed498d5edc3fb2",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c12",
             "_tpl": "656fad8c498d1b7e3e071da0",
             "parentId": "0bdd95825aed498d5edc3fb2",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c13",
             "_tpl": "656fad8c498d1b7e3e071da0",
             "parentId": "0bdd95825aed498d5edc3fb2",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "e8a0fe4dcca134dc37a7eb89",
             "_tpl": "5ab8dab586f77441cd04f2a2",
             "parentId": "hideout",
@@ -2547,7 +2867,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "1f146f73bf81b60d52f79fdb",
             "_tpl": "603648ff5a45383c122086ac",
             "parentId": "hideout",
@@ -2558,7 +2879,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "87c445dab45bca03aa9eba6d",
             "_tpl": "5648a69d4bdc2ded0b8b457b",
             "parentId": "hideout",
@@ -2569,7 +2891,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "3b8b75b42dff1b2b96cd1243",
             "_tpl": "61bcc89aef0f505f0c6cd0fc",
             "parentId": "hideout",
@@ -2580,42 +2903,50 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c14",
             "_tpl": "6572eb0e55beba16bc04079f",
             "parentId": "3b8b75b42dff1b2b96cd1243",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c15",
             "_tpl": "6572eb1b04ee6483ef039882",
             "parentId": "3b8b75b42dff1b2b96cd1243",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c16",
             "_tpl": "6572eb3004ee6483ef039886",
             "parentId": "3b8b75b42dff1b2b96cd1243",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c17",
             "_tpl": "6572eb3b04ee6483ef03988a",
             "parentId": "3b8b75b42dff1b2b96cd1243",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c18",
             "_tpl": "6572eb865b5eac12f10a03ee",
             "parentId": "3b8b75b42dff1b2b96cd1243",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c19",
             "_tpl": "656fb21fa0dce000a2020f7c",
             "parentId": "3b8b75b42dff1b2b96cd1243",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c1a",
             "_tpl": "656fb21fa0dce000a2020f7c",
             "parentId": "3b8b75b42dff1b2b96cd1243",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "bebdbbf862ac9db6fe44c8a7",
             "_tpl": "5ab8dced86f774646209ec87",
             "parentId": "hideout",
@@ -2626,37 +2957,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c1b",
             "_tpl": "6570f6e774d84423df065f21",
             "parentId": "bebdbbf862ac9db6fe44c8a7",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c1c",
             "_tpl": "6570f71dd67d0309980a7af8",
             "parentId": "bebdbbf862ac9db6fe44c8a7",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c1d",
             "_tpl": "6570f74774d84423df065f25",
             "parentId": "bebdbbf862ac9db6fe44c8a7",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c1e",
             "_tpl": "6570f79c4c65ab77a6015121",
             "parentId": "bebdbbf862ac9db6fe44c8a7",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c1f",
             "_tpl": "656fa25e94b480b8a500c0e0",
             "parentId": "bebdbbf862ac9db6fe44c8a7",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c20",
             "_tpl": "656fa25e94b480b8a500c0e0",
             "parentId": "bebdbbf862ac9db6fe44c8a7",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "ab5ad43ae0c94f95adcce72c",
             "_tpl": "592c2d1a86f7746dbe2af32a",
             "parentId": "hideout",
@@ -2667,7 +3005,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ba8ca88daafaf9594ae540e5",
             "_tpl": "5df8a42886f77412640e2e75",
             "parentId": "hideout",
@@ -2678,7 +3017,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "8be67fad35c2041d0ab894b3",
             "_tpl": "5e9db13186f7742f845ee9d3",
             "parentId": "hideout",
@@ -2689,7 +3029,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "4a05cab1ec3fcaecfd869ad7",
             "_tpl": "544a5caa4bdc2d1a388b4568",
             "parentId": "hideout",
@@ -2700,32 +3041,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c21",
             "_tpl": "6570e83223c1f638ef0b0ede",
             "parentId": "4a05cab1ec3fcaecfd869ad7",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c22",
             "_tpl": "6570e87c23c1f638ef0b0ee2",
             "parentId": "4a05cab1ec3fcaecfd869ad7",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c23",
             "_tpl": "6570e90b3a5689d85f08db97",
             "parentId": "4a05cab1ec3fcaecfd869ad7",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c24",
             "_tpl": "656f9fa0498d1b7e3e071d98",
             "parentId": "4a05cab1ec3fcaecfd869ad7",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c25",
             "_tpl": "656f9fa0498d1b7e3e071d98",
             "parentId": "4a05cab1ec3fcaecfd869ad7",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "a8cd694ebdfe692520edfac7",
             "_tpl": "5c0e722886f7740458316a57",
             "parentId": "hideout",
@@ -2736,37 +3083,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c26",
             "_tpl": "65730c0e292ecadbfa09ad49",
             "parentId": "a8cd694ebdfe692520edfac7",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c27",
             "_tpl": "65730c2213a2f660f60bea96",
             "parentId": "a8cd694ebdfe692520edfac7",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c28",
             "_tpl": "65730c2b292ecadbfa09ad50",
             "parentId": "a8cd694ebdfe692520edfac7",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c29",
             "_tpl": "65730c35292ecadbfa09ad54",
             "parentId": "a8cd694ebdfe692520edfac7",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c2a",
             "_tpl": "656fa0fb498d1b7e3e071d9c",
             "parentId": "a8cd694ebdfe692520edfac7",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c2b",
             "_tpl": "656fa0fb498d1b7e3e071d9c",
             "parentId": "a8cd694ebdfe692520edfac7",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "8107aeabab56728bdbe6181f",
             "_tpl": "60a3c70cde5f453f634816a3",
             "parentId": "hideout",
@@ -2777,52 +3131,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c2c",
             "_tpl": "6570fae34c65ab77a6015146",
             "parentId": "8107aeabab56728bdbe6181f",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c2d",
             "_tpl": "6570fa1f4c65ab77a601512f",
             "parentId": "8107aeabab56728bdbe6181f",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c2e",
             "_tpl": "6570fb22584a51c23e03251f",
             "parentId": "8107aeabab56728bdbe6181f",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c2f",
             "_tpl": "6570fb6ad3eefd23430f8c7c",
             "parentId": "8107aeabab56728bdbe6181f",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c30",
             "_tpl": "6570fb8f4c65ab77a601514d",
             "parentId": "8107aeabab56728bdbe6181f",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c31",
             "_tpl": "6570fbdd74d84423df065f60",
             "parentId": "8107aeabab56728bdbe6181f",
             "slotId": "Shoulder_l"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c32",
             "_tpl": "6570fc41d3eefd23430f8c83",
             "parentId": "8107aeabab56728bdbe6181f",
             "slotId": "Shoulder_r"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c33",
             "_tpl": "656fb21fa0dce000a2020f7c",
             "parentId": "8107aeabab56728bdbe6181f",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c34",
             "_tpl": "656fb21fa0dce000a2020f7c",
             "parentId": "8107aeabab56728bdbe6181f",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "06a26faa77eee1fe7557532a",
             "_tpl": "5c0e746986f7741453628fe5",
             "parentId": "hideout",
@@ -2833,27 +3197,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c35",
             "_tpl": "6570df294cc0d2ab1e05ed74",
             "parentId": "06a26faa77eee1fe7557532a",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c36",
             "_tpl": "6570df9c615f54368b04fca9",
             "parentId": "06a26faa77eee1fe7557532a",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c37",
             "_tpl": "656fa0fb498d1b7e3e071d9c",
             "parentId": "06a26faa77eee1fe7557532a",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c38",
             "_tpl": "656fa0fb498d1b7e3e071d9c",
             "parentId": "06a26faa77eee1fe7557532a",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "7bcd28b4cbbf7a34d643dce9",
             "_tpl": "5d5d87f786f77427997cfaef",
             "parentId": "hideout",
@@ -2864,37 +3233,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c39",
             "_tpl": "6570e5100b57c03ec90b970a",
             "parentId": "7bcd28b4cbbf7a34d643dce9",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c3a",
             "_tpl": "6570e479a6560e4ee50c2b02",
             "parentId": "7bcd28b4cbbf7a34d643dce9",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c3b",
             "_tpl": "6570e5674cc0d2ab1e05edbb",
             "parentId": "7bcd28b4cbbf7a34d643dce9",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c3c",
             "_tpl": "6570e59b0b57c03ec90b970e",
             "parentId": "7bcd28b4cbbf7a34d643dce9",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c3d",
             "_tpl": "656f9fa0498d1b7e3e071d98",
             "parentId": "7bcd28b4cbbf7a34d643dce9",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c3e",
             "_tpl": "656f9fa0498d1b7e3e071d98",
             "parentId": "7bcd28b4cbbf7a34d643dce9",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "7f0cd7ce3de8f02a42ceb994",
             "_tpl": "5b44cad286f77402a54ae7e5",
             "parentId": "hideout",
@@ -2905,27 +3281,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c3f",
             "_tpl": "6575bc88c6700bd6b40e8a57",
             "parentId": "7f0cd7ce3de8f02a42ceb994",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c40",
             "_tpl": "6575bca0dc9932aed601c5d7",
             "parentId": "7f0cd7ce3de8f02a42ceb994",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c41",
             "_tpl": "656fae5f7c2d57afe200c0d7",
             "parentId": "7f0cd7ce3de8f02a42ceb994",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c42",
             "_tpl": "656fae5f7c2d57afe200c0d7",
             "parentId": "7f0cd7ce3de8f02a42ceb994",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "bf57c5de5dfc6329e0ed29c4",
             "_tpl": "60a3c68c37ea821725773ef5",
             "parentId": "hideout",
@@ -2936,62 +3317,74 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c43",
             "_tpl": "65733312ca0ca984940a2d53",
             "parentId": "bf57c5de5dfc6329e0ed29c4",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c44",
             "_tpl": "657333232cc8dfad2c0a3d97",
             "parentId": "bf57c5de5dfc6329e0ed29c4",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c45",
             "_tpl": "657333302cc8dfad2c0a3d9b",
             "parentId": "bf57c5de5dfc6329e0ed29c4",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c46",
             "_tpl": "6573333eca0ca984940a2d57",
             "parentId": "bf57c5de5dfc6329e0ed29c4",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c47",
             "_tpl": "6573334aca0ca984940a2d5b",
             "parentId": "bf57c5de5dfc6329e0ed29c4",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c48",
             "_tpl": "65733375b7a8d286530e3dd7",
             "parentId": "bf57c5de5dfc6329e0ed29c4",
             "slotId": "Shoulder_l"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c49",
             "_tpl": "6573337f2cc8dfad2c0a3da7",
             "parentId": "bf57c5de5dfc6329e0ed29c4",
             "slotId": "Shoulder_r"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c4a",
             "_tpl": "656fa53d94b480b8a500c0e4",
             "parentId": "bf57c5de5dfc6329e0ed29c4",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c4b",
             "_tpl": "656fa53d94b480b8a500c0e4",
             "parentId": "bf57c5de5dfc6329e0ed29c4",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c4c",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "bf57c5de5dfc6329e0ed29c4",
             "slotId": "Left_side_plate"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c4d",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "bf57c5de5dfc6329e0ed29c4",
             "slotId": "Right_side_plate"
-        }, {
+        },
+        {
             "_id": "b5ec3d0cd03cc5ed7f9e5abc",
             "_tpl": "5e4ac41886f77406a511c9a8",
             "parentId": "hideout",
@@ -3002,47 +3395,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c4e",
             "_tpl": "6575ef599c7cad336508e453",
             "parentId": "b5ec3d0cd03cc5ed7f9e5abc",
             "slotId": "soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c4f",
             "_tpl": "6575ef6bf6a13a7b7100b093",
             "parentId": "b5ec3d0cd03cc5ed7f9e5abc",
             "slotId": "soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c50",
             "_tpl": "6575ef78da698a4e980677eb",
             "parentId": "b5ec3d0cd03cc5ed7f9e5abc",
             "slotId": "soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c51",
             "_tpl": "6575ef7f9c7cad336508e457",
             "parentId": "b5ec3d0cd03cc5ed7f9e5abc",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c52",
             "_tpl": "656fae5f7c2d57afe200c0d7",
             "parentId": "b5ec3d0cd03cc5ed7f9e5abc",
             "slotId": "front_plate"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c53",
             "_tpl": "656fae5f7c2d57afe200c0d7",
             "parentId": "b5ec3d0cd03cc5ed7f9e5abc",
             "slotId": "back_plate"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c54",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "b5ec3d0cd03cc5ed7f9e5abc",
             "slotId": "left_side_plate"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c55",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "b5ec3d0cd03cc5ed7f9e5abc",
             "slotId": "right_side_plate"
-        }, {
+        },
+        {
             "_id": "972beb8aeb39edac5fb66ab6",
             "_tpl": "5fd4c5477a8d854fa0105061",
             "parentId": "hideout",
@@ -3053,7 +3455,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c5194f82e7a5f0cfd41d0e45",
             "_tpl": "5e4abc1f86f774069619fbaa",
             "parentId": "hideout",
@@ -3064,7 +3467,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "343f9a2592db24c7367d9bb0",
             "_tpl": "5d5d8ca986f7742798716522",
             "parentId": "hideout",
@@ -3075,7 +3479,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "4894ed01ee4ff84e2f01a9ad",
             "_tpl": "6034d0230ca681766b6a0fb5",
             "parentId": "hideout",
@@ -3086,7 +3491,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "abf5d1323a7beedbedef4e7a",
             "_tpl": "59e7643b86f7742cbf2c109a",
             "parentId": "hideout",
@@ -3097,7 +3503,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "60dfff92fdfddbb41fe52ebb",
             "_tpl": "5c0e3eb886f7742015526062",
             "parentId": "hideout",
@@ -3108,27 +3515,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c56",
             "_tpl": "65764a4cd8537eb26a0355ee",
             "parentId": "60dfff92fdfddbb41fe52ebb",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c57",
             "_tpl": "65764bc22bc38ef78e076485",
             "parentId": "60dfff92fdfddbb41fe52ebb",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c58",
             "_tpl": "65764c39526e320fbe035777",
             "parentId": "60dfff92fdfddbb41fe52ebb",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c59",
             "_tpl": "65764c6b526e320fbe03577b",
             "parentId": "60dfff92fdfddbb41fe52ebb",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "d0bf8b7df20d2d5e41d243dd",
             "_tpl": "5929a2a086f7744f4b234d43",
             "parentId": "hideout",
@@ -3139,7 +3551,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "1a97bc5decbca0f037a80aff",
             "_tpl": "5e4abfed86f77406a2713cf7",
             "parentId": "hideout",
@@ -3150,7 +3563,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "5fd0fa716e0cae2f43cfbdde",
             "_tpl": "6034cf5fffd42c541047f72e",
             "parentId": "hideout",
@@ -3161,7 +3575,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "cfe8a8bde180b1eaec91ed90",
             "_tpl": "5c0e9f2c86f77432297fe0a3",
             "parentId": "hideout",
@@ -3172,7 +3587,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "6985d7dca6cba924cab9f3ee",
             "_tpl": "5ca20abf86f77418567a43f2",
             "parentId": "hideout",
@@ -3183,7 +3599,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7936d525b99ffb703cd8ea29",
             "_tpl": "5c0e6a1586f77404597b4965",
             "parentId": "hideout",
@@ -3194,7 +3611,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a3ef1d5febe5abf65dcedcb8",
             "_tpl": "5c0e446786f7742013381639",
             "parentId": "hideout",
@@ -3205,27 +3623,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c5a",
             "_tpl": "657087577f6d4590ac0d2109",
             "parentId": "a3ef1d5febe5abf65dcedcb8",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c5b",
             "_tpl": "6570880f4a747dbb63005ee5",
             "parentId": "a3ef1d5febe5abf65dcedcb8",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c5c",
             "_tpl": "65708afe4a747dbb63005eee",
             "parentId": "a3ef1d5febe5abf65dcedcb8",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c5d",
             "_tpl": "65708b4c4a747dbb63005ef3",
             "parentId": "a3ef1d5febe5abf65dcedcb8",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "ac9a2aac2ecfcf9d6ab6fd08",
             "_tpl": "5fd4c60f875c30179f5d04c2",
             "parentId": "hideout",
@@ -3236,7 +3659,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bda6e7e5ff8a22da30aa8ea1",
             "_tpl": "5d5d85c586f774279a21cbdb",
             "parentId": "hideout",
@@ -3247,7 +3671,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "acdf6c8f8ad9de7bdda3eb21",
             "_tpl": "5f5f41f56760b4138443b352",
             "parentId": "hideout",
@@ -3258,7 +3683,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "65d3c74ebed719cd2e7e9eaf",
             "_tpl": "60a6220e953894617404b00a",
             "parentId": "hideout",
@@ -3269,7 +3695,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e1e4be9eb2fb2c7f3dc2bc5c",
             "_tpl": "5d5d646386f7742797261fd9",
             "parentId": "hideout",
@@ -3280,27 +3707,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c5e",
             "_tpl": "65764e1e2bc38ef78e076489",
             "parentId": "e1e4be9eb2fb2c7f3dc2bc5c",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c5f",
             "_tpl": "65764fae2bc38ef78e07648d",
             "parentId": "e1e4be9eb2fb2c7f3dc2bc5c",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c60",
             "_tpl": "6576504b526e320fbe035783",
             "parentId": "e1e4be9eb2fb2c7f3dc2bc5c",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c61",
             "_tpl": "6576500f526e320fbe03577f",
             "parentId": "e1e4be9eb2fb2c7f3dc2bc5c",
             "slotId": "Groin_back"
-        }, {
+        },
+        {
             "_id": "6ca566b8cfead979b1a041e1",
             "_tpl": "61bc85697113f767765c7fe7",
             "parentId": "hideout",
@@ -3311,37 +3743,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c62",
             "_tpl": "6572fc809a866b80ab07eb59",
             "parentId": "6ca566b8cfead979b1a041e1",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c63",
             "_tpl": "6572fc8c9a866b80ab07eb5d",
             "parentId": "6ca566b8cfead979b1a041e1",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c64",
             "_tpl": "6572fc989a866b80ab07eb61",
             "parentId": "6ca566b8cfead979b1a041e1",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c65",
             "_tpl": "6572fca39a866b80ab07eb65",
             "parentId": "6ca566b8cfead979b1a041e1",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c66",
             "_tpl": "656fad8c498d1b7e3e071da0",
             "parentId": "6ca566b8cfead979b1a041e1",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c67",
             "_tpl": "656fad8c498d1b7e3e071da0",
             "parentId": "6ca566b8cfead979b1a041e1",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "9e0fb0dc0647ee412eccbfb7",
             "_tpl": "5ab8dab586f77441cd04f2a2",
             "parentId": "hideout",
@@ -3352,7 +3791,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c2dd6ddbf2ee14dd90b20e2b",
             "_tpl": "603648ff5a45383c122086ac",
             "parentId": "hideout",
@@ -3363,7 +3803,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c4cc139e00afaab6aaaedef0",
             "_tpl": "5648a69d4bdc2ded0b8b457b",
             "parentId": "hideout",
@@ -3374,7 +3815,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b503dddf3900caaca0e6cc7b",
             "_tpl": "61bcc89aef0f505f0c6cd0fc",
             "parentId": "hideout",
@@ -3385,42 +3827,50 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c68",
             "_tpl": "6572eb0e55beba16bc04079f",
             "parentId": "b503dddf3900caaca0e6cc7b",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c69",
             "_tpl": "6572eb1b04ee6483ef039882",
             "parentId": "b503dddf3900caaca0e6cc7b",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c6a",
             "_tpl": "6572eb3004ee6483ef039886",
             "parentId": "b503dddf3900caaca0e6cc7b",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c6b",
             "_tpl": "6572eb3b04ee6483ef03988a",
             "parentId": "b503dddf3900caaca0e6cc7b",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c6c",
             "_tpl": "6572eb865b5eac12f10a03ee",
             "parentId": "b503dddf3900caaca0e6cc7b",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c6d",
             "_tpl": "656fb21fa0dce000a2020f7c",
             "parentId": "b503dddf3900caaca0e6cc7b",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c6e",
             "_tpl": "656fb21fa0dce000a2020f7c",
             "parentId": "b503dddf3900caaca0e6cc7b",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "28a2ceba0f658b7cde82e3db",
             "_tpl": "5ab8dced86f774646209ec87",
             "parentId": "hideout",
@@ -3431,37 +3881,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c6f",
             "_tpl": "6570f6e774d84423df065f21",
             "parentId": "28a2ceba0f658b7cde82e3db",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c70",
             "_tpl": "6570f71dd67d0309980a7af8",
             "parentId": "28a2ceba0f658b7cde82e3db",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c71",
             "_tpl": "6570f74774d84423df065f25",
             "parentId": "28a2ceba0f658b7cde82e3db",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c72",
             "_tpl": "6570f79c4c65ab77a6015121",
             "parentId": "28a2ceba0f658b7cde82e3db",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c73",
             "_tpl": "656fa25e94b480b8a500c0e0",
             "parentId": "28a2ceba0f658b7cde82e3db",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c74",
             "_tpl": "656fa25e94b480b8a500c0e0",
             "parentId": "28a2ceba0f658b7cde82e3db",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "5a8ae15552d7bab96f6deefc",
             "_tpl": "592c2d1a86f7746dbe2af32a",
             "parentId": "hideout",
@@ -3472,7 +3929,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "0ff1bc2be0ac63ee6cabfce9",
             "_tpl": "5df8a42886f77412640e2e75",
             "parentId": "hideout",
@@ -3483,7 +3941,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ef6d7cedd2aa50ee8ac348c1",
             "_tpl": "5e9db13186f7742f845ee9d3",
             "parentId": "hideout",
@@ -3494,7 +3953,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "3c9a94be9f1f085be6bf531a",
             "_tpl": "544a5caa4bdc2d1a388b4568",
             "parentId": "hideout",
@@ -3505,32 +3965,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c75",
             "_tpl": "6570e83223c1f638ef0b0ede",
             "parentId": "3c9a94be9f1f085be6bf531a",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c76",
             "_tpl": "6570e87c23c1f638ef0b0ee2",
             "parentId": "3c9a94be9f1f085be6bf531a",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c77",
             "_tpl": "6570e90b3a5689d85f08db97",
             "parentId": "3c9a94be9f1f085be6bf531a",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c78",
             "_tpl": "656f9fa0498d1b7e3e071d98",
             "parentId": "3c9a94be9f1f085be6bf531a",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c79",
             "_tpl": "656f9fa0498d1b7e3e071d98",
             "parentId": "3c9a94be9f1f085be6bf531a",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "bcaabb55ecbd2dcaf2401b6b",
             "_tpl": "5c0e722886f7740458316a57",
             "parentId": "hideout",
@@ -3541,37 +4007,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c7a",
             "_tpl": "65730c0e292ecadbfa09ad49",
             "parentId": "bcaabb55ecbd2dcaf2401b6b",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c7b",
             "_tpl": "65730c2213a2f660f60bea96",
             "parentId": "bcaabb55ecbd2dcaf2401b6b",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c7c",
             "_tpl": "65730c2b292ecadbfa09ad50",
             "parentId": "bcaabb55ecbd2dcaf2401b6b",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c7d",
             "_tpl": "65730c35292ecadbfa09ad54",
             "parentId": "bcaabb55ecbd2dcaf2401b6b",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c7e",
             "_tpl": "656fa0fb498d1b7e3e071d9c",
             "parentId": "bcaabb55ecbd2dcaf2401b6b",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c7f",
             "_tpl": "656fa0fb498d1b7e3e071d9c",
             "parentId": "bcaabb55ecbd2dcaf2401b6b",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "bcedb51bce8ca8cec38dbe98",
             "_tpl": "60a3c70cde5f453f634816a3",
             "parentId": "hideout",
@@ -3582,52 +4055,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c80",
             "_tpl": "6570fae34c65ab77a6015146",
             "parentId": "bcedb51bce8ca8cec38dbe98",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c81",
             "_tpl": "6570fa1f4c65ab77a601512f",
             "parentId": "bcedb51bce8ca8cec38dbe98",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c82",
             "_tpl": "6570fb22584a51c23e03251f",
             "parentId": "bcedb51bce8ca8cec38dbe98",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c83",
             "_tpl": "6570fb6ad3eefd23430f8c7c",
             "parentId": "bcedb51bce8ca8cec38dbe98",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c84",
             "_tpl": "6570fb8f4c65ab77a601514d",
             "parentId": "bcedb51bce8ca8cec38dbe98",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c85",
             "_tpl": "6570fbdd74d84423df065f60",
             "parentId": "bcedb51bce8ca8cec38dbe98",
             "slotId": "Shoulder_l"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c86",
             "_tpl": "6570fc41d3eefd23430f8c83",
             "parentId": "bcedb51bce8ca8cec38dbe98",
             "slotId": "Shoulder_r"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c87",
             "_tpl": "656fb21fa0dce000a2020f7c",
             "parentId": "bcedb51bce8ca8cec38dbe98",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c88",
             "_tpl": "656fb21fa0dce000a2020f7c",
             "parentId": "bcedb51bce8ca8cec38dbe98",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "2a6b7cf8c5ca055c1b6dc4fa",
             "_tpl": "5c0e746986f7741453628fe5",
             "parentId": "hideout",
@@ -3638,27 +4121,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c89",
             "_tpl": "6570df294cc0d2ab1e05ed74",
             "parentId": "2a6b7cf8c5ca055c1b6dc4fa",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c8a",
             "_tpl": "6570df9c615f54368b04fca9",
             "parentId": "2a6b7cf8c5ca055c1b6dc4fa",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c8b",
             "_tpl": "656fa0fb498d1b7e3e071d9c",
             "parentId": "2a6b7cf8c5ca055c1b6dc4fa",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c8c",
             "_tpl": "656fa0fb498d1b7e3e071d9c",
             "parentId": "2a6b7cf8c5ca055c1b6dc4fa",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "9f1f6df81a9bab1a5f7bba6b",
             "_tpl": "5d5d87f786f77427997cfaef",
             "parentId": "hideout",
@@ -3669,37 +4157,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c8d",
             "_tpl": "6570e5100b57c03ec90b970a",
             "parentId": "9f1f6df81a9bab1a5f7bba6b",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c8e",
             "_tpl": "6570e479a6560e4ee50c2b02",
             "parentId": "9f1f6df81a9bab1a5f7bba6b",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c8f",
             "_tpl": "6570e5674cc0d2ab1e05edbb",
             "parentId": "9f1f6df81a9bab1a5f7bba6b",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c90",
             "_tpl": "6570e59b0b57c03ec90b970e",
             "parentId": "9f1f6df81a9bab1a5f7bba6b",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c91",
             "_tpl": "656f9fa0498d1b7e3e071d98",
             "parentId": "9f1f6df81a9bab1a5f7bba6b",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c92",
             "_tpl": "656f9fa0498d1b7e3e071d98",
             "parentId": "9f1f6df81a9bab1a5f7bba6b",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "8aab4bd4bc42f6dbde6f6e76",
             "_tpl": "5b44cad286f77402a54ae7e5",
             "parentId": "hideout",
@@ -3710,27 +4205,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c93",
             "_tpl": "6575bc88c6700bd6b40e8a57",
             "parentId": "8aab4bd4bc42f6dbde6f6e76",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c94",
             "_tpl": "6575bca0dc9932aed601c5d7",
             "parentId": "8aab4bd4bc42f6dbde6f6e76",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c95",
             "_tpl": "656fae5f7c2d57afe200c0d7",
             "parentId": "8aab4bd4bc42f6dbde6f6e76",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c96",
             "_tpl": "656fae5f7c2d57afe200c0d7",
             "parentId": "8aab4bd4bc42f6dbde6f6e76",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "5ca0dee49bced1007ebd9fca",
             "_tpl": "60a3c68c37ea821725773ef5",
             "parentId": "hideout",
@@ -3741,62 +4241,74 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c97",
             "_tpl": "65733312ca0ca984940a2d53",
             "parentId": "5ca0dee49bced1007ebd9fca",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c98",
             "_tpl": "657333232cc8dfad2c0a3d97",
             "parentId": "5ca0dee49bced1007ebd9fca",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c99",
             "_tpl": "657333302cc8dfad2c0a3d9b",
             "parentId": "5ca0dee49bced1007ebd9fca",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c9a",
             "_tpl": "6573333eca0ca984940a2d57",
             "parentId": "5ca0dee49bced1007ebd9fca",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c9b",
             "_tpl": "6573334aca0ca984940a2d5b",
             "parentId": "5ca0dee49bced1007ebd9fca",
             "slotId": "Collar"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c9c",
             "_tpl": "65733375b7a8d286530e3dd7",
             "parentId": "5ca0dee49bced1007ebd9fca",
             "slotId": "Shoulder_l"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c9d",
             "_tpl": "6573337f2cc8dfad2c0a3da7",
             "parentId": "5ca0dee49bced1007ebd9fca",
             "slotId": "Shoulder_r"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c9e",
             "_tpl": "656fa53d94b480b8a500c0e4",
             "parentId": "5ca0dee49bced1007ebd9fca",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002c9f",
             "_tpl": "656fa53d94b480b8a500c0e4",
             "parentId": "5ca0dee49bced1007ebd9fca",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002ca0",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "5ca0dee49bced1007ebd9fca",
             "slotId": "Left_side_plate"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002ca1",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "5ca0dee49bced1007ebd9fca",
             "slotId": "Right_side_plate"
-        }, {
+        },
+        {
             "_id": "bb33afb00f72bfb3cefc91d7",
             "_tpl": "5e4ac41886f77406a511c9a8",
             "parentId": "hideout",
@@ -3807,47 +4319,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002ca2",
             "_tpl": "6575ef599c7cad336508e453",
             "parentId": "bb33afb00f72bfb3cefc91d7",
             "slotId": "soft_armor_front"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002ca3",
             "_tpl": "6575ef6bf6a13a7b7100b093",
             "parentId": "bb33afb00f72bfb3cefc91d7",
             "slotId": "soft_armor_back"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002ca4",
             "_tpl": "6575ef78da698a4e980677eb",
             "parentId": "bb33afb00f72bfb3cefc91d7",
             "slotId": "soft_armor_left"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002ca5",
             "_tpl": "6575ef7f9c7cad336508e457",
             "parentId": "bb33afb00f72bfb3cefc91d7",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002ca6",
             "_tpl": "656fae5f7c2d57afe200c0d7",
             "parentId": "bb33afb00f72bfb3cefc91d7",
             "slotId": "front_plate"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002ca7",
             "_tpl": "656fae5f7c2d57afe200c0d7",
             "parentId": "bb33afb00f72bfb3cefc91d7",
             "slotId": "back_plate"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002ca8",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "bb33afb00f72bfb3cefc91d7",
             "slotId": "left_side_plate"
-        }, {
+        },
+        {
             "_id": "666fbf8a05a4eac710002ca9",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "bb33afb00f72bfb3cefc91d7",
             "slotId": "right_side_plate"
-        }, {
+        },
+        {
             "_id": "f2bffb9aadcdbc2965ce79d0",
             "_tpl": "5580223e4bdc2d1c128b457f",
             "parentId": "hideout",
@@ -3858,17 +4379,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "3feddf18587ed753a51eab13",
             "_tpl": "55d447bb4bdc2d892f8b456f",
             "parentId": "f2bffb9aadcdbc2965ce79d0",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "22ddcefaf86c1d1fb0eebbda",
             "_tpl": "611a31ce5b7ffe001b4649d1",
             "parentId": "f2bffb9aadcdbc2965ce79d0",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "f4a96de7cbf7e245cab905ad",
             "_tpl": "60db29ce99594040e04c4a27",
             "parentId": "hideout",
@@ -3879,32 +4403,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f56ef24e9fb62d7669d4ecd0",
             "_tpl": "60dc519adf4c47305f6d410d",
             "parentId": "f4a96de7cbf7e245cab905ad",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "5f76cd7e337c6e8b80ee3dcd",
             "_tpl": "612368f58b401f4f51239b33",
             "parentId": "f4a96de7cbf7e245cab905ad",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "e87ef2cef7fb294aacd4ce38",
             "_tpl": "619d36da53b4d42ee724fae4",
             "parentId": "5f76cd7e337c6e8b80ee3dcd",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "7c7d3072bffdfeb39da7e5a9",
             "_tpl": "612781056f3d944a17348d60",
             "parentId": "f4a96de7cbf7e245cab905ad",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "e6cfefba91a8f1d0b2a83ce7",
             "_tpl": "6123649463849f3d843da7c4",
             "parentId": "f4a96de7cbf7e245cab905ad",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "b6e30b8cb2ccc9cb52c6dddf",
             "_tpl": "5a38e6bac4a2826c6e06d79b",
             "parentId": "hideout",
@@ -3915,22 +4445,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d5916c7bfeb92e715ae951f5",
             "_tpl": "5a38ee51c4a282000c5a955c",
             "parentId": "b6e30b8cb2ccc9cb52c6dddf",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "2fa78acff0ff0bf6fa70d3e6",
             "_tpl": "5a38ef1fc4a282000b1521f6",
             "parentId": "b6e30b8cb2ccc9cb52c6dddf",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "df2ccb23ebf1a0047bce0cab",
             "_tpl": "5a38eecdc4a282329a73b512",
             "parentId": "2fa78acff0ff0bf6fa70d3e6",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "3bec2fb9ecd6b8eceebda42d",
             "_tpl": "5a38ee51c4a282000c5a955c",
             "parentId": "hideout",
@@ -3941,7 +4475,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7aa3924d668adec0b4bdc172",
             "_tpl": "54491c4f4bdc2db1078b4568",
             "parentId": "hideout",
@@ -3952,27 +4487,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "3b44ec0dc6ba433d0847a588",
             "_tpl": "55d4491a4bdc2d882f8b456e",
             "parentId": "7aa3924d668adec0b4bdc172",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "4bfcda05bcfca0226cddab95",
             "_tpl": "55d45d3f4bdc2d972f8b456c",
             "parentId": "7aa3924d668adec0b4bdc172",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "ea409e59708e45cce4b0a8d2",
             "_tpl": "55d484b44bdc2d1d4e8b456d",
             "parentId": "7aa3924d668adec0b4bdc172",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "ddacc1788bffca8baa91bbdb",
             "_tpl": "56083cba4bdc2de22e8b456f",
             "parentId": "7aa3924d668adec0b4bdc172",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "5b3fbcdbec5daf6c8c94ae9d",
             "_tpl": "5e870397991fd70db46995c8",
             "parentId": "hideout",
@@ -3983,37 +4523,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f1dfccf8323ac261c33d5bf1",
             "_tpl": "5e87071478f43e51ca2de5e1",
             "parentId": "5b3fbcdbec5daf6c8c94ae9d",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "2f233fecb9fbc1b02aac1d3c",
             "_tpl": "5e8708d4ae379e67d22e0102",
             "parentId": "f1dfccf8323ac261c33d5bf1",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "5ceee5ccd1325abc0a1ea8f7",
             "_tpl": "5e87076ce2db31558c75a11d",
             "parentId": "5b3fbcdbec5daf6c8c94ae9d",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "057b9f3cb75efe177f13ea5c",
             "_tpl": "5e87080c81c4ed43e83cefda",
             "parentId": "5b3fbcdbec5daf6c8c94ae9d",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "c0ed5aa80aa1e66dceeaae7f",
             "_tpl": "5e87116b81c4ed43e83cefdd",
             "parentId": "5b3fbcdbec5daf6c8c94ae9d",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "9cfefb1e5b0bf23f5cedce04",
             "_tpl": "5e87114fe2db31558c75a120",
             "parentId": "5b3fbcdbec5daf6c8c94ae9d",
             "slotId": "mod_mount"
-        }, {
+        },
+        {
             "_id": "e39a291deaefa46f7d9ea3d1",
             "_tpl": "5e87080c81c4ed43e83cefda",
             "parentId": "hideout",
@@ -4024,7 +4571,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a909df3fed26210f205d7bb7",
             "_tpl": "56deee15d2720bee328b4567",
             "parentId": "hideout",
@@ -4035,7 +4583,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "caff57e18ced0af048ead93b",
             "_tpl": "5a7828548dc32e5a9c28b516",
             "parentId": "hideout",
@@ -4046,27 +4595,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "0bd5d921d4046b9def2dcf60",
             "_tpl": "5a787f7ac5856700177af660",
             "parentId": "caff57e18ced0af048ead93b",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "46f63b2ceeacebc0c55506ea",
             "_tpl": "5a788089c5856700142fdd9c",
             "parentId": "caff57e18ced0af048ead93b",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "d280fa52cf3852dfdda7d4fb",
             "_tpl": "5a7882dcc5856700177af662",
             "parentId": "caff57e18ced0af048ead93b",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "35ad945bcc2eb72d46f2ac86",
             "_tpl": "5a7880d0c5856700142fdd9d",
             "parentId": "caff57e18ced0af048ead93b",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "bcfb7e5df21c3beeacec529e",
             "_tpl": "606dae0ab0e443224b421bb7",
             "parentId": "hideout",
@@ -4077,27 +4631,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "81ce71c2e5e648cc467ed0b9",
             "_tpl": "6076c1b9f2cb2e02a42acedc",
             "parentId": "bcfb7e5df21c3beeacec529e",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "16cb631be5b64b8cdfd31146",
             "_tpl": "607d5aa50494a626335e12ed",
             "parentId": "bcfb7e5df21c3beeacec529e",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "86b18ee26d220b3c10a41ffe",
             "_tpl": "6076c87f232e5a31c233d50e",
             "parentId": "bcfb7e5df21c3beeacec529e",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "9bba1adab0c87276730ae979",
             "_tpl": "607d5a891246154cad35d6aa",
             "parentId": "bcfb7e5df21c3beeacec529e",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "81b87eca6e8eab6183ba05a6",
             "_tpl": "5a7882dcc5856700177af662",
             "parentId": "hideout",
@@ -4108,7 +4667,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "14fcaf39a7b147e851f54ab8",
             "_tpl": "5882163e24597758206fee8c",
             "parentId": "hideout",
@@ -4119,7 +4679,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b4ab4f3fb9a1c8d3fe4be6db",
             "_tpl": "576165642459773c7a400233",
             "parentId": "hideout",
@@ -4130,42 +4691,50 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e31e5bd424af092afaeca4b7",
             "_tpl": "576169e62459773c69055191",
             "parentId": "b4ab4f3fb9a1c8d3fe4be6db",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "5d92d5d3fec47a3d3f749dfc",
             "_tpl": "576167ab2459773cad038c43",
             "parentId": "b4ab4f3fb9a1c8d3fe4be6db",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "fdf6d063eda6d5fdf09eabe4",
             "_tpl": "5649ade84bdc2d1b2b8b4587",
             "parentId": "b4ab4f3fb9a1c8d3fe4be6db",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "09f09efe153ebd5bc0210fee",
             "_tpl": "57616c112459773cce774d66",
             "parentId": "b4ab4f3fb9a1c8d3fe4be6db",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "28586bc289cfcf8f82bff67e",
             "_tpl": "57a9b9ce2459770ee926038d",
             "parentId": "b4ab4f3fb9a1c8d3fe4be6db",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "2f1bcabcdecdd03afa34dbb3",
             "_tpl": "57616ca52459773c69055192",
             "parentId": "b4ab4f3fb9a1c8d3fe4be6db",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "2a4dc5ca7dcd9dca51f5be58",
             "_tpl": "57616a9e2459773c7a400234",
             "parentId": "b4ab4f3fb9a1c8d3fe4be6db",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "0644e04adbb0df7b7e1adfe8",
             "_tpl": "5e848cc2988a8701445df1e8",
             "parentId": "hideout",
@@ -4176,32 +4745,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e9cf91afe02a616bb4fa0852",
             "_tpl": "5e848d1c264f7c180b5e35a9",
             "parentId": "0644e04adbb0df7b7e1adfe8",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "aafacdb7fe33fab16dac92dd",
             "_tpl": "5e848d51e4dbc5266a4ec63b",
             "parentId": "0644e04adbb0df7b7e1adfe8",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "aeaecba25ce6cf21aec7e2d8",
             "_tpl": "5f647d9f8499b57dc40ddb93",
             "parentId": "0644e04adbb0df7b7e1adfe8",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "f3dfc2a74fff9d50f04274ab",
             "_tpl": "5e848d99865c0f329958c83b",
             "parentId": "0644e04adbb0df7b7e1adfe8",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "21c9471c9cebbba8d3dd48de",
             "_tpl": "5e848dc4e4dbc5266a4ec63d",
             "parentId": "f3dfc2a74fff9d50f04274ab",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "62baccaf0cb7a0dd6efbcff8",
             "_tpl": "57616a9e2459773c7a400234",
             "parentId": "hideout",
@@ -4212,7 +4787,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a4b0cbb6ae80ca76a5ad2afa",
             "_tpl": "5f647d9f8499b57dc40ddb93",
             "parentId": "hideout",
@@ -4223,7 +4799,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "9d5fc650ffb2dadbae0af289",
             "_tpl": "5580223e4bdc2d1c128b457f",
             "parentId": "hideout",
@@ -4234,17 +4811,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c309c77e2def5eaaa0856acc",
             "_tpl": "55d447bb4bdc2d892f8b456f",
             "parentId": "9d5fc650ffb2dadbae0af289",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "e9a08ed00efeafb6ce2f0b19",
             "_tpl": "611a31ce5b7ffe001b4649d1",
             "parentId": "9d5fc650ffb2dadbae0af289",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "b60d3d77d62c4408f924a38c",
             "_tpl": "60db29ce99594040e04c4a27",
             "parentId": "hideout",
@@ -4255,32 +4835,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e684da084edcdcd9581aeefd",
             "_tpl": "60dc519adf4c47305f6d410d",
             "parentId": "b60d3d77d62c4408f924a38c",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "bfc4b7e63da74eedfbad6059",
             "_tpl": "612368f58b401f4f51239b33",
             "parentId": "b60d3d77d62c4408f924a38c",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "41f1fe2509a43aec084be2fa",
             "_tpl": "619d36da53b4d42ee724fae4",
             "parentId": "bfc4b7e63da74eedfbad6059",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "e8f04ff0b08da3dcee8cceed",
             "_tpl": "612781056f3d944a17348d60",
             "parentId": "b60d3d77d62c4408f924a38c",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "d98feeeeabe1b83b3ddef8c5",
             "_tpl": "6123649463849f3d843da7c4",
             "parentId": "b60d3d77d62c4408f924a38c",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "2fcbee555002fa95add0cde5",
             "_tpl": "5a38e6bac4a2826c6e06d79b",
             "parentId": "hideout",
@@ -4291,22 +4877,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7922127aaff765502147ae4d",
             "_tpl": "5a38ee51c4a282000c5a955c",
             "parentId": "2fcbee555002fa95add0cde5",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "d05412fda9f305dae51ae4af",
             "_tpl": "5a38ef1fc4a282000b1521f6",
             "parentId": "2fcbee555002fa95add0cde5",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "b73c9bebda7547e4fab3a1ec",
             "_tpl": "5a38eecdc4a282329a73b512",
             "parentId": "d05412fda9f305dae51ae4af",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "e7dba0b556bbdedd48bb3efc",
             "_tpl": "54491c4f4bdc2db1078b4568",
             "parentId": "hideout",
@@ -4317,27 +4907,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c06aaafa8de0cae8a7a0eeee",
             "_tpl": "55d4491a4bdc2d882f8b456e",
             "parentId": "e7dba0b556bbdedd48bb3efc",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "b1bbda5a36ea5efffea1b518",
             "_tpl": "55d45d3f4bdc2d972f8b456c",
             "parentId": "e7dba0b556bbdedd48bb3efc",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "d4a98fe8ae6a3fcfcf6521fd",
             "_tpl": "55d484b44bdc2d1d4e8b456d",
             "parentId": "e7dba0b556bbdedd48bb3efc",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "9ae8eb0ac6e0e7eb7fb7aa39",
             "_tpl": "56083cba4bdc2de22e8b456f",
             "parentId": "e7dba0b556bbdedd48bb3efc",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "de565b1ba801acabcd28247d",
             "_tpl": "5e870397991fd70db46995c8",
             "parentId": "hideout",
@@ -4348,37 +4943,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d7eeb8aa9c13a2d5fbdca9cc",
             "_tpl": "5e87071478f43e51ca2de5e1",
             "parentId": "de565b1ba801acabcd28247d",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "dc4c2914646df7ec52baac11",
             "_tpl": "5e8708d4ae379e67d22e0102",
             "parentId": "d7eeb8aa9c13a2d5fbdca9cc",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "b1a1e6f2be5886a16b75d466",
             "_tpl": "5e87076ce2db31558c75a11d",
             "parentId": "de565b1ba801acabcd28247d",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "61c72cbe722bb4c54d4bef3e",
             "_tpl": "5e87080c81c4ed43e83cefda",
             "parentId": "de565b1ba801acabcd28247d",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "afcfe6acf6bfadfdefdcfbba",
             "_tpl": "5e87116b81c4ed43e83cefdd",
             "parentId": "de565b1ba801acabcd28247d",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "5efc8dd460e7431beb104bb5",
             "_tpl": "5e87114fe2db31558c75a120",
             "parentId": "de565b1ba801acabcd28247d",
             "slotId": "mod_mount"
-        }, {
+        },
+        {
             "_id": "6e8a643bca8daa84dbacabbc",
             "_tpl": "5a7828548dc32e5a9c28b516",
             "parentId": "hideout",
@@ -4389,27 +4991,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b2212ceb5fcf954cdaf69692",
             "_tpl": "5a787f7ac5856700177af660",
             "parentId": "6e8a643bca8daa84dbacabbc",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "502708aefb2a1ebdc974a7e3",
             "_tpl": "5a788089c5856700142fdd9c",
             "parentId": "6e8a643bca8daa84dbacabbc",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "0e47792501b1e939010a413e",
             "_tpl": "5a7882dcc5856700177af662",
             "parentId": "6e8a643bca8daa84dbacabbc",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "8bfbf3f47cbab29f76065c4d",
             "_tpl": "5a7880d0c5856700142fdd9d",
             "parentId": "6e8a643bca8daa84dbacabbc",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "fd4b6e085dacd9ded83fc8f6",
             "_tpl": "606dae0ab0e443224b421bb7",
             "parentId": "hideout",
@@ -4420,27 +5027,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "4c1532c5cf2b38934c4d245f",
             "_tpl": "6076c1b9f2cb2e02a42acedc",
             "parentId": "fd4b6e085dacd9ded83fc8f6",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "9afe77d390fd3d22ee8cf8dc",
             "_tpl": "607d5aa50494a626335e12ed",
             "parentId": "fd4b6e085dacd9ded83fc8f6",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "b5ae905b63360db1cca2db5b",
             "_tpl": "6076c87f232e5a31c233d50e",
             "parentId": "fd4b6e085dacd9ded83fc8f6",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "a261a3bb532adad0938bfa1e",
             "_tpl": "607d5a891246154cad35d6aa",
             "parentId": "fd4b6e085dacd9ded83fc8f6",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "1dcacae3060cacdda409dd3b",
             "_tpl": "56dee2bdd2720bc8328b4567",
             "parentId": "hideout",
@@ -4451,27 +5063,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e8461ccf7cedfe07f102e3d9",
             "_tpl": "56deec93d2720bec348b4568",
             "parentId": "1dcacae3060cacdda409dd3b",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "14eea5ae83dc29affeb02fae",
             "_tpl": "56deed6ed2720b4c698b4583",
             "parentId": "1dcacae3060cacdda409dd3b",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "422f184d852d6fdc6a7dacfc",
             "_tpl": "56deee15d2720bee328b4567",
             "parentId": "1dcacae3060cacdda409dd3b",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "0a2ff4f491adefe6f8aaea9f",
             "_tpl": "56083be64bdc2d20478b456f",
             "parentId": "1dcacae3060cacdda409dd3b",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "7be6cf2fbddcdc064d19f3d8",
             "_tpl": "56dee2bdd2720bc8328b4567",
             "parentId": "hideout",
@@ -4482,27 +5099,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "155fdb7f50962d93a87da484",
             "_tpl": "56deec93d2720bec348b4568",
             "parentId": "7be6cf2fbddcdc064d19f3d8",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "48c0acbaafc7debae5b0beee",
             "_tpl": "56deed6ed2720b4c698b4583",
             "parentId": "7be6cf2fbddcdc064d19f3d8",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "5fa742aeeb532d8079daa13f",
             "_tpl": "56deee15d2720bee328b4567",
             "parentId": "7be6cf2fbddcdc064d19f3d8",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "eed4bdf79dbb1c3dbb0cff39",
             "_tpl": "56083be64bdc2d20478b456f",
             "parentId": "7be6cf2fbddcdc064d19f3d8",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "eedeeaa88d99b468cfe8c9db",
             "_tpl": "576165642459773c7a400233",
             "parentId": "hideout",
@@ -4513,42 +5135,50 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ff85324997bd3f0cdc69ab1b",
             "_tpl": "576169e62459773c69055191",
             "parentId": "eedeeaa88d99b468cfe8c9db",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "0f987afbefdc9fe2effc3beb",
             "_tpl": "576167ab2459773cad038c43",
             "parentId": "eedeeaa88d99b468cfe8c9db",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "80d1f7093553667ccff7bf7d",
             "_tpl": "5649ade84bdc2d1b2b8b4587",
             "parentId": "eedeeaa88d99b468cfe8c9db",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "8fbfd7e3203054faffe91cbf",
             "_tpl": "57616c112459773cce774d66",
             "parentId": "eedeeaa88d99b468cfe8c9db",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "6a85d659e0fe3c722dba40ee",
             "_tpl": "57a9b9ce2459770ee926038d",
             "parentId": "eedeeaa88d99b468cfe8c9db",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "3b1fcc7c30b2c9cd4dd2d23f",
             "_tpl": "57616ca52459773c69055192",
             "parentId": "eedeeaa88d99b468cfe8c9db",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "b0d547eac182e1d1ce1ae9ae",
             "_tpl": "57616a9e2459773c7a400234",
             "parentId": "eedeeaa88d99b468cfe8c9db",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "befe0e3d6b6187afc6bed13d",
             "_tpl": "5e848cc2988a8701445df1e8",
             "parentId": "hideout",
@@ -4559,32 +5189,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fcce3f036f2b6b4bfb26045e",
             "_tpl": "5e848d1c264f7c180b5e35a9",
             "parentId": "befe0e3d6b6187afc6bed13d",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "ab5b5afdb3f18dcff8a00f9a",
             "_tpl": "5e848d51e4dbc5266a4ec63b",
             "parentId": "befe0e3d6b6187afc6bed13d",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "6b4ce9a3c0acbaed04141601",
             "_tpl": "5f647d9f8499b57dc40ddb93",
             "parentId": "befe0e3d6b6187afc6bed13d",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "2dbaeffbdaffdb97ecab14ad",
             "_tpl": "5e848d99865c0f329958c83b",
             "parentId": "befe0e3d6b6187afc6bed13d",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "62b2cc9c0fbe0ff25eef78d0",
             "_tpl": "5e848dc4e4dbc5266a4ec63d",
             "parentId": "2dbaeffbdaffdb97ecab14ad",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "aecaeaaa617a6a05bb821bbd",
             "_tpl": "64b8ee384b75259c590fa89b",
             "parentId": "hideout",
@@ -4595,7 +5231,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "087717cededfbc19aeff9c37",
             "_tpl": "64b8ee384b75259c590fa89b",
             "parentId": "hideout",
@@ -4606,7 +5243,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "623aa1c90154a75c100edff9",
             "_tpl": "572b7adb24597762ae139821",
             "parentId": "hideout",
@@ -4617,7 +5255,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "89fc36ba93333ceddffbbde8",
             "_tpl": "572b7adb24597762ae139821",
             "parentId": "hideout",
@@ -4628,7 +5267,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "eff24cfec6c89e39dfacfddb",
             "_tpl": "64be7095047e826eae02b0c1",
             "parentId": "hideout",
@@ -4639,7 +5279,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "56b4fdb5172ed0f32bcdfea3",
             "_tpl": "64be7095047e826eae02b0c1",
             "parentId": "hideout",
@@ -4650,7 +5291,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fdafbace8bbf37ceedd73095",
             "_tpl": "5fd4c4fa16cac650092f6771",
             "parentId": "hideout",
@@ -4661,7 +5303,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "afac1b2faff7b091519bcb09",
             "_tpl": "5fd4c4fa16cac650092f6771",
             "parentId": "hideout",
@@ -4672,7 +5315,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "af9861dc3f89985ecf89a4a9",
             "_tpl": "64be7110bf597ba84a0a41ea",
             "parentId": "hideout",
@@ -4683,7 +5327,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a81c21e4ef358ce073b64b61",
             "_tpl": "64be7110bf597ba84a0a41ea",
             "parentId": "hideout",
@@ -4694,7 +5339,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "4ffda1ff3ccba63e3f39ebad",
             "_tpl": "63611865ba5b90db0c0399d1",
             "parentId": "hideout",
@@ -4705,7 +5351,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "3ce1e4fd4a2ca2fddaf1ef24",
             "_tpl": "63611865ba5b90db0c0399d1",
             "parentId": "hideout",
@@ -4716,7 +5363,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "956afc80c1f135f7d0c0cbe9",
             "_tpl": "5b44c8ea86f7742d1627baf1",
             "parentId": "hideout",
@@ -4727,7 +5375,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e99ecee55633440e3feff2d0",
             "_tpl": "5b44c8ea86f7742d1627baf1",
             "parentId": "hideout",
@@ -4738,7 +5387,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "acebc7ca3a8ac16ce17df0aa",
             "_tpl": "60a621c49c197e4e8c4455e6",
             "parentId": "hideout",
@@ -4749,7 +5399,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e3a7b67a679103cbc4cb9c00",
             "_tpl": "60a621c49c197e4e8c4455e6",
             "parentId": "hideout",
@@ -4760,7 +5411,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "db976b5c10f48fd4b0caccba",
             "_tpl": "6040dd4ddcf9592f401632d2",
             "parentId": "hideout",
@@ -4771,7 +5423,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ddd1dbe15b4468ac443df650",
             "_tpl": "6040dd4ddcf9592f401632d2",
             "parentId": "hideout",
@@ -4782,7 +5435,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a08fca03a1dfd7a1f5bdddfb",
             "_tpl": "628cd624459354321c4b7fa2",
             "parentId": "hideout",
@@ -4793,17 +5447,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "10f1eeeca768e4e3c425a761",
             "_tpl": "64afdcb83efdfea28601d041",
             "parentId": "a08fca03a1dfd7a1f5bdddfb",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "eabbb3b2a82aabc44e957cdb",
             "_tpl": "64afdcb83efdfea28601d041",
             "parentId": "a08fca03a1dfd7a1f5bdddfb",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "dd05d9eaa23f4dbca40fdf08",
             "_tpl": "628d0618d1ba6e4fa07ce5a4",
             "parentId": "hideout",
@@ -4814,37 +5471,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ba6cfee85da734b61bd65ded",
             "_tpl": "64afdcb83efdfea28601d041",
             "parentId": "dd05d9eaa23f4dbca40fdf08",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "daa8b4c00ff13d2b3dbdf1fa",
             "_tpl": "657322a4cea9255e21023651",
             "parentId": "dd05d9eaa23f4dbca40fdf08",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "0f120bd83daaff5cfacbfdfd",
             "_tpl": "6570f3890b4ae5847f060dad",
             "parentId": "dd05d9eaa23f4dbca40fdf08",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "741026a3cee0bff8f8126031",
             "_tpl": "6570f3bb0b4ae5847f060db2",
             "parentId": "dd05d9eaa23f4dbca40fdf08",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "a3676b91e74eabd9aaddf46b",
             "_tpl": "656fb0bd7c2d57afe200c0dc",
             "parentId": "dd05d9eaa23f4dbca40fdf08",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "3dfff94da3d0663f957f2ba6",
             "_tpl": "656fb0bd7c2d57afe200c0dc",
             "parentId": "dd05d9eaa23f4dbca40fdf08",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "2c73afd9cdfbc0562e5f4115",
             "_tpl": "628dc750b910320f4c27a732",
             "parentId": "hideout",
@@ -4855,42 +5519,50 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d3d0ffc43220a8e8d0ebaa9c",
             "_tpl": "6572f1ca4c8d903cc60c874e",
             "parentId": "2c73afd9cdfbc0562e5f4115",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "4dee2d8dd1d243016d1e2e53",
             "_tpl": "6572f1d60103b4a3270332db",
             "parentId": "2c73afd9cdfbc0562e5f4115",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "01a90cadc60e86c7bbcafda2",
             "_tpl": "6572f1e10103b4a3270332df",
             "parentId": "2c73afd9cdfbc0562e5f4115",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "7cccd2f844aacd34e6e7a7be",
             "_tpl": "6572f1edea457732140ce875",
             "parentId": "2c73afd9cdfbc0562e5f4115",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "cfdb65868cf680a8b5ffaa9c",
             "_tpl": "656fa25e94b480b8a500c0e0",
             "parentId": "2c73afd9cdfbc0562e5f4115",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "02cbb1081ad726ec4aabc72b",
             "_tpl": "656fa25e94b480b8a500c0e0",
             "parentId": "2c73afd9cdfbc0562e5f4115",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "eafa8ad06defabb08dbe3eeb",
             "_tpl": "6572f1f7ea457732140ce879",
             "parentId": "2c73afd9cdfbc0562e5f4115",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "7afc02b5923ad5c054bd79b6",
             "_tpl": "639343fce101f4caa40a4ef3",
             "parentId": "hideout",
@@ -4901,37 +5573,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ff237fc0b56cf37e970c9c76",
             "_tpl": "6573101e292ecadbfa09b389",
             "parentId": "7afc02b5923ad5c054bd79b6",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "aa4e7e3ab4ae99f46bdb36ed",
             "_tpl": "6573102b292ecadbfa09b38d",
             "parentId": "7afc02b5923ad5c054bd79b6",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "5f37e53b4accb32855aeeaa2",
             "_tpl": "65731038292ecadbfa09b391",
             "parentId": "7afc02b5923ad5c054bd79b6",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "b248637adabb643ee17903e6",
             "_tpl": "65731045f31d5be00e08a75a",
             "parentId": "7afc02b5923ad5c054bd79b6",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "64e98a7cdfdfcb95f7362743",
             "_tpl": "656fad8c498d1b7e3e071da0",
             "parentId": "7afc02b5923ad5c054bd79b6",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "3b8f41d68d6a19dccaeaca8f",
             "_tpl": "656fad8c498d1b7e3e071da0",
             "parentId": "7afc02b5923ad5c054bd79b6",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "7cb4be3b3adb4f7617eb8a4a",
             "_tpl": "64a536392d2c4e6e970f4121",
             "parentId": "hideout",
@@ -4942,27 +5621,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "eeacff4a2abfe2abeb800bce",
             "_tpl": "6570653e89fd4926380b733e",
             "parentId": "7cb4be3b3adb4f7617eb8a4a",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "5a5a46ecb5cf14e3bf5103fd",
             "_tpl": "6570658a89fd4926380b7346",
             "parentId": "7cb4be3b3adb4f7617eb8a4a",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "b1f47abd609bcc06e11fda41",
             "_tpl": "656fac30c6baea13cd07e10c",
             "parentId": "7cb4be3b3adb4f7617eb8a4a",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "eef90133ab2e8ed39ac8e5cc",
             "_tpl": "656fac30c6baea13cd07e10c",
             "parentId": "7cb4be3b3adb4f7617eb8a4a",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "aef1470bcf2378f3f32bcfb6",
             "_tpl": "64a5366719bab53bd203bf33",
             "parentId": "hideout",
@@ -4973,17 +5657,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "1bec01fb60cad9afce61adc1",
             "_tpl": "656fac30c6baea13cd07e10c",
             "parentId": "aef1470bcf2378f3f32bcfb6",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "7d4c6c1bbbdb6f635c67d4fc",
             "_tpl": "656fac30c6baea13cd07e10c",
             "parentId": "aef1470bcf2378f3f32bcfb6",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "6fffc98890b7cfb0580eb651",
             "_tpl": "609e860ebd219504d8507525",
             "parentId": "hideout",
@@ -4994,27 +5681,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c112ee9b4bd48141645dad0a",
             "_tpl": "6575f5cbf6a13a7b7100b0bf",
             "parentId": "6fffc98890b7cfb0580eb651",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "abb1dfca41ccafba9e2ebfa8",
             "_tpl": "6575f5e1da698a4e98067869",
             "parentId": "6fffc98890b7cfb0580eb651",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "98c29eef43297d7b8123a8bd",
             "_tpl": "656fa99800d62bcd2e024088",
             "parentId": "6fffc98890b7cfb0580eb651",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "ea3df57899948aba9f367cd4",
             "_tpl": "656fa0fb498d1b7e3e071d9c",
             "parentId": "6fffc98890b7cfb0580eb651",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "dab0b75515263367b57489fe",
             "_tpl": "628b9784bcf6e2659e09b8a2",
             "parentId": "hideout",
@@ -5025,27 +5717,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "0f02ee226c9b7baa8d7ced75",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "dab0b75515263367b57489fe",
             "slotId": "Left_side_plate"
-        }, {
+        },
+        {
             "_id": "ed8ce46d813b69ebcaeba5ca",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "dab0b75515263367b57489fe",
             "slotId": "Right_side_plate"
-        }, {
+        },
+        {
             "_id": "aea2fdbfd62f9a9de29d3ae7",
             "_tpl": "656fae5f7c2d57afe200c0d7",
             "parentId": "dab0b75515263367b57489fe",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "9e4e2cae4ce148b9da52d16d",
             "_tpl": "656fae5f7c2d57afe200c0d7",
             "parentId": "dab0b75515263367b57489fe",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "acdc3fe76a21feaad0c7e2f0",
             "_tpl": "628b9c7d45122232a872358f",
             "parentId": "hideout",
@@ -5056,47 +5753,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "9a28b8dbabdaba98da863a57",
             "_tpl": "6575f24ff6a13a7b7100b09e",
             "parentId": "acdc3fe76a21feaad0c7e2f0",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "4ff9bfe9ddeca45cd12de61c",
             "_tpl": "6575f25ada698a4e98067836",
             "parentId": "acdc3fe76a21feaad0c7e2f0",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "1c32b1e4a461ecfba10e9a9c",
             "_tpl": "6575f2649cfdfe416f0399b8",
             "parentId": "acdc3fe76a21feaad0c7e2f0",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "e9b97e1f08bc9ba2d11e04e5",
             "_tpl": "6575f26d9c7cad336508e480",
             "parentId": "acdc3fe76a21feaad0c7e2f0",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "0db3a1fb8dbb65d9d5d9e27a",
             "_tpl": "656fa53d94b480b8a500c0e4",
             "parentId": "acdc3fe76a21feaad0c7e2f0",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "6a8da3591c5e034f28c66837",
             "_tpl": "656fa53d94b480b8a500c0e4",
             "parentId": "acdc3fe76a21feaad0c7e2f0",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "d8aa3a94af90c351c5afaa4d",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "acdc3fe76a21feaad0c7e2f0",
             "slotId": "Left_side_plate"
-        }, {
+        },
+        {
             "_id": "041ff10c6db7eead4de3bcaf",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "acdc3fe76a21feaad0c7e2f0",
             "slotId": "Right_side_plate"
-        }, {
+        },
+        {
             "_id": "d2ee21b623e2fcfeea03b359",
             "_tpl": "628baf0b967de16aab5a4f36",
             "parentId": "hideout",
@@ -5107,7 +5813,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "cf6fbdaf8bcabe38b62d180a",
             "_tpl": "628cd624459354321c4b7fa2",
             "parentId": "hideout",
@@ -5118,17 +5825,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "5adeb8fbe53d45cec7509063",
             "_tpl": "64afdcb83efdfea28601d041",
             "parentId": "cf6fbdaf8bcabe38b62d180a",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "adaab1aa9a45ad2790904eab",
             "_tpl": "64afdcb83efdfea28601d041",
             "parentId": "cf6fbdaf8bcabe38b62d180a",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "81f94b456a68be8f28d2de69",
             "_tpl": "628d0618d1ba6e4fa07ce5a4",
             "parentId": "hideout",
@@ -5139,37 +5849,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "af4d30bd645965810f618b7c",
             "_tpl": "64afdcb83efdfea28601d041",
             "parentId": "81f94b456a68be8f28d2de69",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "bdd6d8f9867c2287dacd2f77",
             "_tpl": "657322a4cea9255e21023651",
             "parentId": "81f94b456a68be8f28d2de69",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "a2d6e0bde0d6b387f7c16663",
             "_tpl": "6570f3890b4ae5847f060dad",
             "parentId": "81f94b456a68be8f28d2de69",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "fe404f0ce7f7b7dc5ecc8468",
             "_tpl": "6570f3bb0b4ae5847f060db2",
             "parentId": "81f94b456a68be8f28d2de69",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "edcbfbff7e968cf65d6bac2e",
             "_tpl": "656fb0bd7c2d57afe200c0dc",
             "parentId": "81f94b456a68be8f28d2de69",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "1f7aeae53beafeb16ce2f60a",
             "_tpl": "656fb0bd7c2d57afe200c0dc",
             "parentId": "81f94b456a68be8f28d2de69",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "55b1c789d288f78e634ca086",
             "_tpl": "628dc750b910320f4c27a732",
             "parentId": "hideout",
@@ -5180,42 +5897,50 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "df7d194fc2f98e0bcbfaeacc",
             "_tpl": "6572f1ca4c8d903cc60c874e",
             "parentId": "55b1c789d288f78e634ca086",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "9b4baa746d9500deaebbdd87",
             "_tpl": "6572f1d60103b4a3270332db",
             "parentId": "55b1c789d288f78e634ca086",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "0d5f30370cfeed4ffce2c5d6",
             "_tpl": "6572f1e10103b4a3270332df",
             "parentId": "55b1c789d288f78e634ca086",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "369fdc5aeefcfd8ff20337ef",
             "_tpl": "6572f1edea457732140ce875",
             "parentId": "55b1c789d288f78e634ca086",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "cbccbaada4aa4ea3bdbbefec",
             "_tpl": "656fa25e94b480b8a500c0e0",
             "parentId": "55b1c789d288f78e634ca086",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "cd38af0a0fddb56eb9cebe0b",
             "_tpl": "656fa25e94b480b8a500c0e0",
             "parentId": "55b1c789d288f78e634ca086",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "c0d096e57b6f5b97ad2becde",
             "_tpl": "6572f1f7ea457732140ce879",
             "parentId": "55b1c789d288f78e634ca086",
             "slotId": "Groin"
-        }, {
+        },
+        {
             "_id": "77dde8e2fff0ccb2aa60bb12",
             "_tpl": "639343fce101f4caa40a4ef3",
             "parentId": "hideout",
@@ -5226,37 +5951,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "905e7ea97547f60a770e2c91",
             "_tpl": "6573101e292ecadbfa09b389",
             "parentId": "77dde8e2fff0ccb2aa60bb12",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "b9e4f3bb19fe9a6cff5b0b2e",
             "_tpl": "6573102b292ecadbfa09b38d",
             "parentId": "77dde8e2fff0ccb2aa60bb12",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "92b4a5feaf0dbfc09b43ce69",
             "_tpl": "65731038292ecadbfa09b391",
             "parentId": "77dde8e2fff0ccb2aa60bb12",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "f39ffe2b3ba1cc858cb2cb6b",
             "_tpl": "65731045f31d5be00e08a75a",
             "parentId": "77dde8e2fff0ccb2aa60bb12",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "e029a9ece1ff0dd38925e3fe",
             "_tpl": "656fad8c498d1b7e3e071da0",
             "parentId": "77dde8e2fff0ccb2aa60bb12",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "ed7747dd573cf700c3ad321b",
             "_tpl": "656fad8c498d1b7e3e071da0",
             "parentId": "77dde8e2fff0ccb2aa60bb12",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "d57fd8b6bbd1def2a9939aff",
             "_tpl": "64a536392d2c4e6e970f4121",
             "parentId": "hideout",
@@ -5267,27 +5999,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "cecedea8c20c3aee3358d0c4",
             "_tpl": "6570653e89fd4926380b733e",
             "parentId": "d57fd8b6bbd1def2a9939aff",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "cdca4e601aad0f546d37ae41",
             "_tpl": "6570658a89fd4926380b7346",
             "parentId": "d57fd8b6bbd1def2a9939aff",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "7c6d5cbddf32044b610fd424",
             "_tpl": "656fac30c6baea13cd07e10c",
             "parentId": "d57fd8b6bbd1def2a9939aff",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "ccd82f887c64fad6a50af7b5",
             "_tpl": "656fac30c6baea13cd07e10c",
             "parentId": "d57fd8b6bbd1def2a9939aff",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "f1b2f521bd8dfbbbae294d20",
             "_tpl": "64a5366719bab53bd203bf33",
             "parentId": "hideout",
@@ -5298,17 +6035,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "3fbca21e6c312f8fdefe0032",
             "_tpl": "656fac30c6baea13cd07e10c",
             "parentId": "f1b2f521bd8dfbbbae294d20",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "4bfe8941fab33f3cde0bc3a4",
             "_tpl": "656fac30c6baea13cd07e10c",
             "parentId": "f1b2f521bd8dfbbbae294d20",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "9e0da78f93fcd9bcd11c93ee",
             "_tpl": "609e860ebd219504d8507525",
             "parentId": "hideout",
@@ -5319,27 +6059,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "acf9ed07bb5d2aa7cbabaa9d",
             "_tpl": "6575f5cbf6a13a7b7100b0bf",
             "parentId": "9e0da78f93fcd9bcd11c93ee",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "f95065b21f7b25ad978006f2",
             "_tpl": "6575f5e1da698a4e98067869",
             "parentId": "9e0da78f93fcd9bcd11c93ee",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "cedaac58becd81fa7fabafab",
             "_tpl": "656fa99800d62bcd2e024088",
             "parentId": "9e0da78f93fcd9bcd11c93ee",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "cbee0a1bba16ddc47d69d608",
             "_tpl": "656fa0fb498d1b7e3e071d9c",
             "parentId": "9e0da78f93fcd9bcd11c93ee",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "4cfc5b3d8ab89f4d2ac8f4aa",
             "_tpl": "628b9784bcf6e2659e09b8a2",
             "parentId": "hideout",
@@ -5350,27 +6095,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ac0cc9c4ba7913fbb54402bb",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "4cfc5b3d8ab89f4d2ac8f4aa",
             "slotId": "Left_side_plate"
-        }, {
+        },
+        {
             "_id": "fe4adce9f1eeec17abbddb6f",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "4cfc5b3d8ab89f4d2ac8f4aa",
             "slotId": "Right_side_plate"
-        }, {
+        },
+        {
             "_id": "991c22001ddf2ebcdffcb777",
             "_tpl": "656fae5f7c2d57afe200c0d7",
             "parentId": "4cfc5b3d8ab89f4d2ac8f4aa",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "68addc550be25026a96b253d",
             "_tpl": "656fae5f7c2d57afe200c0d7",
             "parentId": "4cfc5b3d8ab89f4d2ac8f4aa",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "d6fdaeeee9e64b5cd68624e9",
             "_tpl": "628b9c7d45122232a872358f",
             "parentId": "hideout",
@@ -5381,47 +6131,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "5ddd374d1ba0c2254edc1c8b",
             "_tpl": "6575f24ff6a13a7b7100b09e",
             "parentId": "d6fdaeeee9e64b5cd68624e9",
             "slotId": "Soft_armor_front"
-        }, {
+        },
+        {
             "_id": "fcf7a7c065bd99d6e08ce735",
             "_tpl": "6575f25ada698a4e98067836",
             "parentId": "d6fdaeeee9e64b5cd68624e9",
             "slotId": "Soft_armor_back"
-        }, {
+        },
+        {
             "_id": "e7c3877fb4fd0591bd0a7b81",
             "_tpl": "6575f2649cfdfe416f0399b8",
             "parentId": "d6fdaeeee9e64b5cd68624e9",
             "slotId": "Soft_armor_left"
-        }, {
+        },
+        {
             "_id": "d6785a3d33952d0cdbeb1c34",
             "_tpl": "6575f26d9c7cad336508e480",
             "parentId": "d6fdaeeee9e64b5cd68624e9",
             "slotId": "soft_armor_right"
-        }, {
+        },
+        {
             "_id": "c9dc588f43fc1c9bbb1cf8d0",
             "_tpl": "656fa53d94b480b8a500c0e4",
             "parentId": "d6fdaeeee9e64b5cd68624e9",
             "slotId": "Front_plate"
-        }, {
+        },
+        {
             "_id": "6fc783883d0fd4c65ace030a",
             "_tpl": "656fa53d94b480b8a500c0e4",
             "parentId": "d6fdaeeee9e64b5cd68624e9",
             "slotId": "Back_plate"
-        }, {
+        },
+        {
             "_id": "e566cc74ddf5cf5faf1bfca6",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "d6fdaeeee9e64b5cd68624e9",
             "slotId": "Left_side_plate"
-        }, {
+        },
+        {
             "_id": "d2ae9a9e46bc88afceac7ea1",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "d6fdaeeee9e64b5cd68624e9",
             "slotId": "Right_side_plate"
-        }, {
+        },
+        {
             "_id": "d710d13c10a0ed5e1dbf1cfe",
             "_tpl": "628baf0b967de16aab5a4f36",
             "parentId": "hideout",
@@ -5432,7 +6191,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "39f40cb623d2f57f165eeb8c",
             "_tpl": "64748cb8de82c85eaf0a273a",
             "parentId": "hideout",
@@ -5443,12 +6203,14 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b78afad0ef9deee7fd935f67",
             "_tpl": "64748d02d1c009260702b526",
             "parentId": "39f40cb623d2f57f165eeb8c",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "8a1f6ebbaacd2c8ebbc8452d",
             "_tpl": "61f7c9e189e6fb1a5e3ea78d",
             "parentId": "hideout",
@@ -5459,22 +6221,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fefa63e6f9d9666e4bb3a779",
             "_tpl": "61f4012adfc9f01a816adda1",
             "parentId": "8a1f6ebbaacd2c8ebbc8452d",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "59f4c06eb5b2bdeeaeeddcf3",
             "_tpl": "61f7b85367ddd414173fdb36",
             "parentId": "fefa63e6f9d9666e4bb3a779",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "d3c9774c228caf44d98d2a0e",
             "_tpl": "61f7b234ea4ab34f2f59c3ec",
             "parentId": "8a1f6ebbaacd2c8ebbc8452d",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "c5b9dc5b10f8ab52f6a0a3c0",
             "_tpl": "6259b864ebedf17603599e88",
             "parentId": "hideout",
@@ -5485,47 +6251,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "aecdff8ad0ac9b2bc5e68ece",
             "_tpl": "6259c2c1d714855d182bad85",
             "parentId": "c5b9dc5b10f8ab52f6a0a3c0",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "b276cc9debfa28bc7debfbc4",
             "_tpl": "6259c3387d6aab70bc23a18d",
             "parentId": "c5b9dc5b10f8ab52f6a0a3c0",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "7dbc8cde54c359299981fb04",
             "_tpl": "6259c3d8012d6678ec38eeb8",
             "parentId": "b276cc9debfa28bc7debfbc4",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "bd2ce48a771be207ab9baee9",
             "_tpl": "6259c4347d6aab70bc23a190",
             "parentId": "c5b9dc5b10f8ab52f6a0a3c0",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "fab81cacbcf008a5eaa98e27",
             "_tpl": "625ff2ccb8c587128c1a01dd",
             "parentId": "c5b9dc5b10f8ab52f6a0a3c0",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "8f6ce766f698cc55caeda0af",
             "_tpl": "625ebcef6f53af4aa66b44dc",
             "parentId": "c5b9dc5b10f8ab52f6a0a3c0",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "efed4b6ffe75cdb2bca3e27b",
             "_tpl": "625ed7c64d9b6612df732146",
             "parentId": "c5b9dc5b10f8ab52f6a0a3c0",
             "slotId": "mod_mount"
-        }, {
+        },
+        {
             "_id": "fa1d1f35fef27cc3bfead0db",
             "_tpl": "625ec45bb14d7326ac20f572",
             "parentId": "c5b9dc5b10f8ab52f6a0a3c0",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "cd18bd455119eafb5bdfb605",
             "_tpl": "61f7c9e189e6fb1a5e3ea78d",
             "parentId": "hideout",
@@ -5536,22 +6311,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "716d5bc84c8fded4e2f4ced8",
             "_tpl": "61f4012adfc9f01a816adda1",
             "parentId": "cd18bd455119eafb5bdfb605",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "e771db28d4bc7f2afd7a40d9",
             "_tpl": "61f7b85367ddd414173fdb36",
             "parentId": "716d5bc84c8fded4e2f4ced8",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "cd552ad6d5769e9a12d4d7f3",
             "_tpl": "61f7b234ea4ab34f2f59c3ec",
             "parentId": "cd18bd455119eafb5bdfb605",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "f0a75666e2cf7d2ff9eef1ce",
             "_tpl": "6259b864ebedf17603599e88",
             "parentId": "hideout",
@@ -5562,47 +6341,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "0af4eedeb6e9c6f0cc4fd58b",
             "_tpl": "6259c2c1d714855d182bad85",
             "parentId": "f0a75666e2cf7d2ff9eef1ce",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "b3fe86eecd01fb855bcc5dff",
             "_tpl": "6259c3387d6aab70bc23a18d",
             "parentId": "f0a75666e2cf7d2ff9eef1ce",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "91bfb7c71dc5d9f61d07f8ac",
             "_tpl": "6259c3d8012d6678ec38eeb8",
             "parentId": "b3fe86eecd01fb855bcc5dff",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "7aedcdb5ade0edbececf0dae",
             "_tpl": "6259c4347d6aab70bc23a190",
             "parentId": "f0a75666e2cf7d2ff9eef1ce",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "d5f23ddeaa3df8bed88a5bd5",
             "_tpl": "625ff2ccb8c587128c1a01dd",
             "parentId": "f0a75666e2cf7d2ff9eef1ce",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "59be8fdc6fecb8b1177beb7e",
             "_tpl": "625ebcef6f53af4aa66b44dc",
             "parentId": "f0a75666e2cf7d2ff9eef1ce",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "ece024cda377dda43dcfd45a",
             "_tpl": "625ed7c64d9b6612df732146",
             "parentId": "f0a75666e2cf7d2ff9eef1ce",
             "slotId": "mod_mount"
-        }, {
+        },
+        {
             "_id": "aa3c70c12fe4857f5f2d8c78",
             "_tpl": "625ec45bb14d7326ac20f572",
             "parentId": "f0a75666e2cf7d2ff9eef1ce",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "7b351e290bfc09b0cf879dce",
             "_tpl": "625ff2ccb8c587128c1a01dd",
             "parentId": "hideout",
@@ -5613,7 +6401,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "facee397e8b3cdfcac07c3ca",
             "_tpl": "6259bdcabd28e4721447a2aa",
             "parentId": "hideout",
@@ -5624,7 +6413,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "6ccccc393cde0a66d0bc68a7",
             "_tpl": "625ff2eb9f5537057932257d",
             "parentId": "hideout",
@@ -5635,7 +6425,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "2c36d4e2f9534d1db9cdb37b",
             "_tpl": "625ff3046d721f05d93bf2ee",
             "parentId": "hideout",
@@ -5646,7 +6437,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e14d2ef0f42a294e7a52ff9d",
             "_tpl": "625ff31daaaa8c1130599f64",
             "parentId": "hideout",

--- a/db/traders/6765fbd20fdc7eb79b00000d/assort.json
+++ b/db/traders/6765fbd20fdc7eb79b00000d/assort.json
@@ -1,1712 +1,1497 @@
 {
     "barter_scheme": {
         "7aa3924d668adec0b4bdc172": [
-            [
-                {
+            [{
                     "_tpl": "59e366c186f7741778269d85",
                     "count": 5
                 }
             ]
         ],
         "e7dba0b556bbdedd48bb3efc": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 20000
                 }
             ]
         ],
         "4a05cab1ec3fcaecfd869ad7": [
-            [
-                {
+            [{
                     "_tpl": "5af0534a86f7743b6f354284",
                     "count": 1
                 }
             ]
         ],
         "3c9a94be9f1f085be6bf531a": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 88000
                 }
             ]
         ],
         "f2bffb9aadcdbc2965ce79d0": [
-            [
-                {
+            [{
                     "_tpl": "619cbfeb6b8a1b37a54eebfa",
                     "count": 1
                 }
             ]
         ],
         "9d5fc650ffb2dadbae0af289": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 8500
                 }
             ]
         ],
         "bbaa3cd4a5e92ef032f0cabf": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1900
                 }
             ]
         ],
         "4feaffc69b6ec20f7b7bdee5": [
-            [
-                {
+            [{
                     "_tpl": "56dff421d2720b5f5a8b4567",
                     "count": 2
                 }
             ]
         ],
         "e3667b22d92ed5aad0a07733": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24
                 }
             ]
         ],
         "87c445dab45bca03aa9eba6d": [
-            [
-                {
+            [{
                     "_tpl": "59e3577886f774176a362503",
                     "count": 5
                 }
             ]
         ],
         "c4cc139e00afaab6aaaedef0": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 38000
                 }
             ]
         ],
         "1dcacae3060cacdda409dd3b": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24000
                 }
             ]
         ],
         "7be6cf2fbddcdc064d19f3d8": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "a909df3fed26210f205d7bb7": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 450
                 }
             ]
         ],
         "e6f580eda46a6a5f308f785c": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1800
                 }
             ]
         ],
         "b4ab4f3fb9a1c8d3fe4be6db": [
-            [
-                {
+            [{
                     "_tpl": "5d1b2ffd86f77425243e8d17",
                     "count": 5
                 }
             ]
         ],
         "eedeeaa88d99b468cfe8c9db": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 20500
                 }
             ]
         ],
         "62baccaf0cb7a0dd6efbcff8": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1400
                 }
             ]
         ],
         "0cedd0be14cd798150806117": [
-            [
-                {
+            [{
                     "_tpl": "5d6e6772a4b936088465b17c",
                     "count": 3
                 }
             ]
         ],
         "beebe51d8451e5a660c7adda": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 46
                 }
             ]
         ],
         "8dbbeabc4cade94fc119bbca": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1500
                 }
             ]
         ],
         "aa0daf7dd10fafb6deb5aa68": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1000
                 }
             ]
         ],
         "14fcaf39a7b147e851f54ab8": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 800
                 }
             ]
         ],
         "815bdffbfefaefc1eb946042": [
-            [
-                {
+            [{
                     "_tpl": "57347baf24597738002c6178",
                     "count": 2
                 }
             ]
         ],
         "d0bf8b7df20d2d5e41d243dd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 20000
                 }
             ]
         ],
         "ab5ad43ae0c94f95adcce72c": [
-            [
-                {
+            [{
                     "_tpl": "5d6d2ef3a4b93618084f58bd",
                     "count": 4
                 }
             ]
         ],
         "5a8ae15552d7bab96f6deefc": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 40000
                 }
             ]
         ],
         "b5369dabebdaae9f0638690e": [
-            [
-                {
+            [{
                     "_tpl": "590a3cd386f77436f20848cb",
                     "count": 3
                 }
             ]
         ],
         "abf5d1323a7beedbedef4e7a": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 9000
                 }
             ]
         ],
         "b6e30b8cb2ccc9cb52c6dddf": [
-            [
-                {
+            [{
                     "_tpl": "56742c284bdc2d98058b456d",
                     "count": 3
                 }
             ]
         ],
         "2fcbee555002fa95add0cde5": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 6000
                 }
             ]
         ],
         "338fdbdb2c904cdbe5fc6bd1": [
-            [
-                {
+            [{
                     "_tpl": "5d6e695fa4b936359b35d852",
                     "count": 3
                 }
             ]
         ],
         "b5bbca063ce94dd3adeafe5e": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 20
                 }
             ]
         ],
         "b7cfaabbd60e5e1d40b5b23d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 900
                 }
             ]
         ],
         "3bec2fb9ecd6b8eceebda42d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 660
                 }
             ]
         ],
         "caff57e18ced0af048ead93b": [
-            [
-                {
+            [{
                     "_tpl": "5e2af22086f7746d3f3c33fa",
                     "count": 4
                 }
             ]
         ],
         "6e8a643bca8daa84dbacabbc": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 25000
                 }
             ]
         ],
         "81b87eca6e8eab6183ba05a6": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 750
                 }
             ]
         ],
         "2d028a9aad960b9be056eeba": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1500
                 }
             ]
         ],
         "607ef9471edab8965ed93c2c": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2200
                 }
             ]
         ],
         "14ebcc4a4d7cbde6e3da4a27": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3100
                 }
             ]
         ],
         "e8a0fe4dcca134dc37a7eb89": [
-            [
-                {
+            [{
                     "_tpl": "5e8f3423fd7471236e6e3b64",
                     "count": 4
                 }
             ]
         ],
         "9e0fb0dc0647ee412eccbfb7": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 35000
                 }
             ]
         ],
         "bebdbbf862ac9db6fe44c8a7": [
-            [
-                {
+            [{
                     "_tpl": "5d1b317c86f7742523398392",
                     "count": 1
                 }
             ]
         ],
         "28a2ceba0f658b7cde82e3db": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 80000
                 }
             ]
         ],
         "7f0cd7ce3de8f02a42ceb994": [
-            [
-                {
+            [{
                     "_tpl": "5e2aee0a86f774755a234b62",
                     "count": 3
                 }
             ]
         ],
         "8aab4bd4bc42f6dbde6f6e76": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 168000
                 }
             ]
         ],
         "abff9fd31e2addb58a449beb": [
-            [
-                {
+            [{
                     "_tpl": "5d6e6806a4b936088465b17e",
                     "count": 5
                 }
             ]
         ],
         "5a7da5bc3fc294f8abfaafa7": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 600
                 }
             ]
         ],
         "fd06898aad080db6836c43ee": [
-            [
-                {
+            [{
                     "_tpl": "5d1b2ffd86f77425243e8d17",
                     "count": 5
                 }
             ]
         ],
         "60dfff92fdfddbb41fe52ebb": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 42000
                 }
             ]
         ],
         "127beb33b5eb51fd2e70207a": [
-            [
-                {
+            [{
                     "_tpl": "5d1b304286f774253763a528",
                     "count": 3
                 }
             ]
         ],
         "a3ef1d5febe5abf65dcedcb8": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 42000
                 }
             ]
         ],
         "1bc8eec0b9c5df19e4b9cd9d": [
-            [
-                {
+            [{
                     "_tpl": "590a3c0a86f774385a33c450",
                     "count": 4
                 }
             ]
         ],
         "7936d525b99ffb703cd8ea29": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 38000
                 }
             ]
         ],
         "a8cd694ebdfe692520edfac7": [
-            [
-                {
+            [{
                     "_tpl": "5d403f9186f7743cac3f229b",
                     "count": 3
                 }
             ]
         ],
         "bcaabb55ecbd2dcaf2401b6b": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 65000
                 }
             ]
         ],
         "06a26faa77eee1fe7557532a": [
-            [
-                {
+            [{
                     "_tpl": "590c645c86f77412b01304d9",
                     "count": 3
                 }
             ]
         ],
         "2a6b7cf8c5ca055c1b6dc4fa": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 75000
                 }
             ]
         ],
         "5ccae3762dbff05bd55bf93a": [
-            [
-                {
+            [{
                     "_tpl": "5d1c774f86f7746d6620f8db",
                     "count": 3
                 }
             ]
         ],
         "cfe8a8bde180b1eaec91ed90": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 27000
                 }
             ]
         ],
         "0a5bcceac2bf91793d8f10dc": [
-            [
-                {
+            [{
                     "_tpl": "5d1b3f2d86f774253763b735",
                     "count": 2
                 }
             ]
         ],
         "7b1af22abd0e2e0619fa4af7": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1200
                 }
             ]
         ],
         "02b2d5d2c2a0ccecae56cccc": [
-            [
-                {
+            [{
                     "_tpl": "5d1b39a386f774252339976f",
                     "count": 3
                 }
             ]
         ],
         "6985d7dca6cba924cab9f3ee": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 22500
                 }
             ]
         ],
         "9eb2dbad3ee5fe81dfd9f4dd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 21000
                 }
             ]
         ],
         "14f09c3dcc2f8dcfa5b66d1b": [
-            [
-                {
+            [{
                     "_tpl": "5d40419286f774318526545f",
                     "count": 2
                 }
             ]
         ],
         "e1e4be9eb2fb2c7f3dc2bc5c": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60000
                 }
             ]
         ],
         "6d4aa0fcc7cbf1deb09bd91e": [
-            [
-                {
+            [{
                     "_tpl": "59e35de086f7741778269d84",
                     "count": 1
                 }
             ]
         ],
         "bda6e7e5ff8a22da30aa8ea1": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 30000
                 }
             ]
         ],
         "7bcd28b4cbbf7a34d643dce9": [
-            [
-                {
+            [{
                     "_tpl": "590de71386f774347051a052",
                     "count": 2
                 }
             ]
         ],
         "9f1f6df81a9bab1a5f7bba6b": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 91000
                 }
             ]
         ],
         "f1a5934eaa76429ab1c7c4fc": [
-            [
-                {
+            [{
                     "_tpl": "5d1b309586f77425227d1676",
                     "count": 2
                 }
             ]
         ],
         "343f9a2592db24c7367d9bb0": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 9000
                 }
             ]
         ],
         "6b294de60ee4afbdf7eddf2e": [
-            [
-                {
+            [{
                     "_tpl": "560d5e524bdc2d25448b4571",
                     "count": 3
                 }
             ]
         ],
         "172e90dcba9ec5ae96ee01f2": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 30
                 }
             ]
         ],
         "25b829ade67aa93a8da0ba89": [
-            [
-                {
+            [{
                     "_tpl": "5d6e68d1a4b93622fe60e845",
                     "count": 4
                 }
             ]
         ],
         "7fe29efcd4b9cdc35f662aaf": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 36
                 }
             ]
         ],
         "5df6afccfdd9e3de38cf2daf": [
-            [
-                {
+            [{
                     "_tpl": "5d6e68b3a4b9361bca7e50b5",
                     "count": 3
                 }
             ]
         ],
         "8ed3f327c9a78ff4fae5c9fa": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 160
                 }
             ]
         ],
         "fc4ec0987d8a1083e94b6f1b": [
-            [
-                {
+            [{
                     "_tpl": "5d6e6891a4b9361bd473feea",
                     "count": 3
                 }
             ]
         ],
         "659857de5bd8bff8e39ebba1": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60
                 }
             ]
         ],
         "3adde9b6b3c48c173114eb81": [
-            [
-                {
+            [{
                     "_tpl": "58820d1224597753c90aeb13",
                     "count": 2
                 }
             ]
         ],
         "d95bf0a27ec8a5b8f4fce9fb": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 45
                 }
             ]
         ],
         "c9e724db43f279a4dc44565d": [
-            [
-                {
+            [{
                     "_tpl": "5d6e6869a4b9361c140bcfde",
                     "count": 3
                 }
             ]
         ],
         "1ff5b265a6e69e713fdafc7c": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60
                 }
             ]
         ],
         "f9d05eb5a0910dc0b41ecc4e": [
-            [
-                {
+            [{
                     "_tpl": "5d6e68c4a4b9361b93413f79",
                     "count": 2
                 }
             ]
         ],
         "8a0bd539dd47a5ff59938fee": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 840
                 }
             ]
         ],
         "002a7f22d6297fd004beb4ed": [
-            [
-                {
+            [{
                     "_tpl": "5d6e68e6a4b9361c140bcfe0",
                     "count": 3
                 }
             ]
         ],
         "209e3c91cf9ea1bd6aecabb2": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 75
                 }
             ]
         ],
         "64de2ab8bead299fb3b1fdfa": [
-            [
-                {
+            [{
                     "_tpl": "5c0d591486f7744c505b416f",
                     "count": 2
                 }
             ]
         ],
         "ea1b19ecaca8b4d7d2f9cd2e": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 360
                 }
             ]
         ],
         "bee7bb50c8942ae3e9b790e6": [
-            [
-                {
+            [{
                     "_tpl": "5d6e689ca4b9361bc8618956",
                     "count": 2
                 }
             ]
         ],
         "5a2c5d1f45fdcc509a0e509e": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 160
                 }
             ]
         ],
         "b2924c4ea4f0f27aadde6d4d": [
-            [
-                {
+            [{
                     "_tpl": "5d6e6911a4b9361bd5780d52",
                     "count": 3
                 }
             ]
         ],
         "e0bf522520d0ee8dcddcecfc": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60
                 }
             ]
         ],
         "d8cbffcb15be9ef00d1bc83c": [
-            [
-                {
+            [{
                     "_tpl": "5d6e68dea4b9361bcc29e659",
                     "count": 2
                 }
             ]
         ],
         "4dcacbf50d8f0b4b5e57c518": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 66
                 }
             ]
         ],
         "d0a91b2b9ecd370b27719adf": [
-            [
-                {
+            [{
                     "_tpl": "5d6e67fba4b9361bc73bc779",
                     "count": 3
                 }
             ]
         ],
         "96daf62f8cef314ce2ebcbe8": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 300
                 }
             ]
         ],
         "ebfdd56e54eac3afef0be4b7": [
-            [
-                {
+            [{
                     "_tpl": "560d5e524bdc2d25448b4571",
                     "count": 3
                 }
             ]
         ],
         "0fb70646328e94c05adb9371": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 18
                 }
             ]
         ],
         "f1ef72fcdade7bfedaf1fca1": [
-            [
-                {
+            [{
                     "_tpl": "5d6e6a53a4b9361bd473feec",
                     "count": 3
                 }
             ]
         ],
         "a6deabdf042b04703a69f32c": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24
                 }
             ]
         ],
         "c72ebf92e3bcdad20982c0c7": [
-            [
-                {
+            [{
                     "_tpl": "5d6e6a05a4b93618084f58d0",
                     "count": 4
                 }
             ]
         ],
         "8ed19a9fbd1ebeef15af8cbd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 33
                 }
             ]
         ],
         "ec3a10e74fd57d62bdf85d9a": [
-            [
-                {
+            [{
                     "_tpl": "5d6e6a42a4b9364f07165f52",
                     "count": 3
                 }
             ]
         ],
         "78073a728de6a5c9a6ed60d0": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 75
                 }
             ]
         ],
         "ab11bfb33bde45cef4aad3db": [
-            [
-                {
+            [{
                     "_tpl": "5d6e69b9a4b9361bc8618958",
                     "count": 3
                 }
             ]
         ],
         "7cbe0fb45c06fcdfc0fccee3": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60
                 }
             ]
         ],
         "1aee6bfdf419aaacb102028b": [
-            [
-                {
+            [{
                     "_tpl": "5a38ebd9c4a282000d722a5b",
                     "count": 3
                 }
             ]
         ],
         "be72bf3becb06875108179cb": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 45
                 }
             ]
         ],
         "abefc4eece1bec9ddd29db7f": [
-            [
-                {
+            [{
                     "_tpl": "5d6e69c7a4b9360b6c0d54e4",
                     "count": 3
                 }
             ]
         ],
         "7a9ed9ece005b3e2ca2e7915": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 150
                 }
             ]
         ],
         "ba8ca88daafaf9594ae540e5": [
-            [
-                {
+            [{
                     "_tpl": "5bc9c29cd4351e003562b8a3",
                     "count": 6
                 }
             ]
         ],
         "0ff1bc2be0ac63ee6cabfce9": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 41000
                 }
             ]
         ],
         "a5f649bf8d44b1893d4fd69b": [
-            [
-                {
+            [{
                     "_tpl": "57347cd0245977445a2d6ff1",
                     "count": 4
                 }
             ]
         ],
         "c5194f82e7a5f0cfd41d0e45": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 9500
                 }
             ]
         ],
         "0df43ca5ffe3fc1ec51dccea": [
-            [
-                {
+            [{
                     "_tpl": "5d1b3a5d86f774252167ba22",
                     "count": 4
                 }
             ]
         ],
         "1a97bc5decbca0f037a80aff": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 17000
                 }
             ]
         ],
         "b5ec3d0cd03cc5ed7f9e5abc": [
-            [
-                {
+            [{
                     "_tpl": "59faff1d86f7746c51718c9c",
                     "count": 1
                 }
             ]
         ],
         "bb33afb00f72bfb3cefc91d7": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 190000
                 }
             ]
         ],
         "0644e04adbb0df7b7e1adfe8": [
-            [
-                {
+            [{
                     "_tpl": "5d1c774f86f7746d6620f8db",
                     "count": 6
                 }
             ]
         ],
         "befe0e3d6b6187afc6bed13d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 40000
                 }
             ]
         ],
         "3db1ce73dda3d123aa1e5ca1": [
-            [
-                {
+            [{
                     "_tpl": "5f647f31b6238e5dd066e196",
                     "count": 3
                 }
             ]
         ],
         "c560e753a39628c459aa8e73": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 75
                 }
             ]
         ],
         "dfb203e62e2092c12584d01c": [
-            [
-                {
+            [{
                     "_tpl": "590a373286f774287540368b",
                     "count": 1
-                },
-                {
+                }, {
                     "_tpl": "5e2af37686f774755a234b65",
                     "count": 1
                 }
             ]
         ],
         "ae574cfa8c9edeffda91eeb3": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3000
                 }
             ]
         ],
         "9abc31afafd3af049cf1432d": [
-            [
-                {
+            [{
                     "_tpl": "5e85a9a6eacf8c039e4e2ac1",
                     "count": 4
                 }
             ]
         ],
         "dbd3aacd87e030cd2a76e6d7": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 225
                 }
             ]
         ],
         "5b3fbcdbec5daf6c8c94ae9d": [
-            [
-                {
+            [{
                     "_tpl": "590c35a486f774273531c822",
                     "count": 1
                 }
             ]
         ],
         "de565b1ba801acabcd28247d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 28000
                 }
             ]
         ],
         "e39a291deaefa46f7d9ea3d1": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1400
                 }
             ]
         ],
         "8be67fad35c2041d0ab894b3": [
-            [
-                {
+            [{
                     "_tpl": "573474f924597738002c6174",
                     "count": 5
                 }
             ]
         ],
         "ef6d7cedd2aa50ee8ac348c1": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 36000
                 }
             ]
         ],
         "f8d40ee84cf325dd1ea4f277": [
-            [
-                {
+            [{
                     "_tpl": "590a386e86f77429692b27ab",
                     "count": 4
                 }
             ]
         ],
         "acdf6c8f8ad9de7bdda3eb21": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 22000
                 }
             ]
         ],
         "a4b0cbb6ae80ca76a5ad2afa": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2000
                 }
             ]
         ],
         "b171a43daba1aafeacf82ef7": [
-            [
-                {
+            [{
                     "_tpl": "5d6e6a5fa4b93614ec501745",
                     "count": 3
                 }
             ]
         ],
         "bbaa0da51cc5cd3150187212": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 100
                 }
             ]
         ],
         "b4c3ad7f6315dab31c7def05": [
-            [
-                {
+            [{
                     "_tpl": "57347c5b245977448d35f6e1",
                     "count": 2
                 }
             ]
         ],
         "972beb8aeb39edac5fb66ab6": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3600
                 }
             ]
         ],
         "dd80a6c3f7d6deabac4abbfd": [
-            [
-                {
+            [{
                     "_tpl": "59e35cbb86f7741778269d83",
                     "count": 2
                 }
             ]
         ],
         "ac9a2aac2ecfcf9d6ab6fd08": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 28000
                 }
             ]
         ],
         "1af4cd84e135f08e84fd00b0": [
-            [
-                {
+            [{
                     "_tpl": "5751496424597720a27126da",
                     "count": 4
                 }
             ]
         ],
         "5fd0fa716e0cae2f43cfbdde": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24000
                 }
             ]
         ],
         "4f98a8eb9c3a3d351c4dc616": [
-            [
-                {
+            [{
                     "_tpl": "590c2b4386f77425357b6123",
                     "count": 5
                 }
             ]
         ],
         "4894ed01ee4ff84e2f01a9ad": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 9000
                 }
             ]
         ],
         "1f146f73bf81b60d52f79fdb": [
-            [
-                {
+            [{
                     "_tpl": "5734773724597737fd047c14",
                     "count": 3
                 }
             ]
         ],
         "c2dd6ddbf2ee14dd90b20e2b": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 28000
                 }
             ]
         ],
         "bcfb7e5df21c3beeacec529e": [
-            [
-                {
+            [{
                     "_tpl": "590a373286f774287540368b",
                     "count": 3
                 }
             ]
         ],
         "fd4b6e085dacd9ded83fc8f6": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 27000
                 }
             ]
         ],
         "bf57c5de5dfc6329e0ed29c4": [
-            [
-                {
+            [{
                     "_tpl": "5e2aee0a86f774755a234b62",
                     "count": 5
                 }
             ]
         ],
         "5ca0dee49bced1007ebd9fca": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 161000
                 }
             ]
         ],
         "8107aeabab56728bdbe6181f": [
-            [
-                {
+            [{
                     "_tpl": "60391afc25aff57af81f7085",
                     "count": 2
                 }
             ]
         ],
         "bcedb51bce8ca8cec38dbe98": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 78000
                 }
             ]
         ],
         "0720d68e9bdc9fbfcec106c3": [
-            [
-                {
+            [{
                     "_tpl": "56742c2e4bdc2d95058b456d",
                     "count": 5
                 }
             ]
         ],
         "65d3c74ebed719cd2e7e9eaf": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 30000
                 }
             ]
         ],
         "f4a96de7cbf7e245cab905ad": [
-            [
-                {
+            [{
                     "_tpl": "61bf83814088ec1a363d7097",
                     "count": 1
                 }
             ]
         ],
         "b60d3d77d62c4408f924a38c": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 19000
                 }
             ]
         ],
         "0bdd95825aed498d5edc3fb2": [
-            [
-                {
+            [{
                     "_tpl": "61bf83814088ec1a363d7097",
                     "count": 3
                 }
             ]
         ],
         "6ca566b8cfead979b1a041e1": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 64000
                 }
             ]
         ],
         "3b8b75b42dff1b2b96cd1243": [
-            [
-                {
+            [{
                     "_tpl": "619cbfccbedcde2f5b3f7bdd",
                     "count": 1
-                },
-                {
+                }, {
                     "_tpl": "5d1b3a5d86f774252167ba22",
                     "count": 1
                 }
             ]
         ],
         "b503dddf3900caaca0e6cc7b": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 66000
                 }
             ]
         ],
         "aecaeaaa617a6a05bb821bbd": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "087717cededfbc19aeff9c37": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 190
                 }
             ]
         ],
         "623aa1c90154a75c100edff9": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "89fc36ba93333ceddffbbde8": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3900
                 }
             ]
         ],
         "eff24cfec6c89e39dfacfddb": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "56b4fdb5172ed0f32bcdfea3": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3900
                 }
             ]
         ],
         "fdafbace8bbf37ceedd73095": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "afac1b2faff7b091519bcb09": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 4600
                 }
             ]
         ],
         "af9861dc3f89985ecf89a4a9": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "a81c21e4ef358ce073b64b61": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 8500
                 }
             ]
         ],
         "4ffda1ff3ccba63e3f39ebad": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "3ce1e4fd4a2ca2fddaf1ef24": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 46000
                 }
             ]
         ],
         "956afc80c1f135f7d0c0cbe9": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "e99ecee55633440e3feff2d0": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 27000
                 }
             ]
         ],
         "aef1470bcf2378f3f32bcfb6": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "f1b2f521bd8dfbbbae294d20": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 26000
                 }
             ]
         ],
         "7cb4be3b3adb4f7617eb8a4a": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "d57fd8b6bbd1def2a9939aff": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 58000
                 }
             ]
         ],
         "acebc7ca3a8ac16ce17df0aa": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "e3a7b67a679103cbc4cb9c00": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 31000
                 }
             ]
         ],
         "db976b5c10f48fd4b0caccba": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "ddd1dbe15b4468ac443df650": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 27000
                 }
             ]
         ],
         "2c73afd9cdfbc0562e5f4115": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "55b1c789d288f78e634ca086": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 72000
                 }
             ]
         ],
         "7afc02b5923ad5c054bd79b6": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "77dde8e2fff0ccb2aa60bb12": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 66000
                 }
             ]
         ],
         "a08fca03a1dfd7a1f5bdddfb": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "cf6fbdaf8bcabe38b62d180a": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 253000
                 }
             ]
         ],
         "dd05d9eaa23f4dbca40fdf08": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "81f94b456a68be8f28d2de69": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 253000
                 }
             ]
         ],
         "6fffc98890b7cfb0580eb651": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "9e0da78f93fcd9bcd11c93ee": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 272000
                 }
             ]
         ],
         "dab0b75515263367b57489fe": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "4cfc5b3d8ab89f4d2ac8f4aa": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 250000
                 }
             ]
         ],
         "acdc3fe76a21feaad0c7e2f0": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "d6fdaeeee9e64b5cd68624e9": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 200000
                 }
             ]
         ],
         "d2ee21b623e2fcfeea03b359": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "d710d13c10a0ed5e1dbf1cfe": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 45000
                 }
             ]
         ],
         "39f40cb623d2f57f165eeb8c": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 9000
                 }
             ]
         ],
         "f0a75666e2cf7d2ff9eef1ce": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "c5b9dc5b10f8ab52f6a0a3c0": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 37000
                 }
             ]
         ],
         "cd18bd455119eafb5bdfb605": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "8a1f6ebbaacd2c8ebbc8452d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 15000
                 }
             ]
         ],
         "7b351e290bfc09b0cf879dce": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1300
                 }
             ]
         ],
         "facee397e8b3cdfcac07c3ca": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2000
                 }
             ]
         ],
         "6ccccc393cde0a66d0bc68a7": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2200
                 }
             ]
         ],
         "2c36d4e2f9534d1db9cdb37b": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3300
                 }
             ]
         ],
         "e14d2ef0f42a294e7a52ff9d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 4500
                 }
             ]
         ]
     },
-    "items": [
-        {
+    "items": [{
             "_id": "4feaffc69b6ec20f7b7bdee5",
             "_tpl": "560d5e524bdc2d25448b4571",
             "parentId": "hideout",
@@ -1717,8 +1502,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "6b294de60ee4afbdf7eddf2e",
             "_tpl": "5d6e6772a4b936088465b17c",
             "parentId": "hideout",
@@ -1729,8 +1513,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "0cedd0be14cd798150806117",
             "_tpl": "58820d1224597753c90aeb13",
             "parentId": "hideout",
@@ -1741,8 +1524,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "3adde9b6b3c48c173114eb81",
             "_tpl": "5d6e6891a4b9361bd473feea",
             "parentId": "hideout",
@@ -1753,8 +1535,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "aa0daf7dd10fafb6deb5aa68",
             "_tpl": "5882163824597757561aa922",
             "parentId": "hideout",
@@ -1765,8 +1546,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fc4ec0987d8a1083e94b6f1b",
             "_tpl": "5d6e6869a4b9361c140bcfde",
             "parentId": "hideout",
@@ -1777,8 +1557,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c9e724db43f279a4dc44565d",
             "_tpl": "5d6e689ca4b9361bc8618956",
             "parentId": "hideout",
@@ -1789,8 +1568,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bee7bb50c8942ae3e9b790e6",
             "_tpl": "5d6e68d1a4b93622fe60e845",
             "parentId": "hideout",
@@ -1801,8 +1579,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "2d028a9aad960b9be056eeba",
             "_tpl": "5a78830bc5856700137e4c90",
             "parentId": "hideout",
@@ -1813,8 +1590,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "25b829ade67aa93a8da0ba89",
             "_tpl": "5d6e67fba4b9361bc73bc779",
             "parentId": "hideout",
@@ -1825,8 +1601,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "8dbbeabc4cade94fc119bbca",
             "_tpl": "5882163224597757561aa920",
             "parentId": "hideout",
@@ -1837,8 +1612,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d0a91b2b9ecd370b27719adf",
             "_tpl": "5d6e6911a4b9361bd5780d52",
             "parentId": "hideout",
@@ -1849,8 +1623,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "14ebcc4a4d7cbde6e3da4a27",
             "_tpl": "5a966f51a2750c00156aacf6",
             "parentId": "hideout",
@@ -1861,8 +1634,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b2924c4ea4f0f27aadde6d4d",
             "_tpl": "5d6e68dea4b9361bcc29e659",
             "parentId": "hideout",
@@ -1873,8 +1645,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d8cbffcb15be9ef00d1bc83c",
             "_tpl": "5d6e68e6a4b9361c140bcfe0",
             "parentId": "hideout",
@@ -1885,8 +1656,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "002a7f22d6297fd004beb4ed",
             "_tpl": "5d6e68b3a4b9361bca7e50b5",
             "parentId": "hideout",
@@ -1897,8 +1667,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bbaa3cd4a5e92ef032f0cabf",
             "_tpl": "55d485804bdc2d8c2f8b456b",
             "parentId": "hideout",
@@ -1909,8 +1678,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e6f580eda46a6a5f308f785c",
             "_tpl": "56deeefcd2720bc8328b4568",
             "parentId": "hideout",
@@ -1921,8 +1689,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "5df6afccfdd9e3de38cf2daf",
             "_tpl": "5d6e6806a4b936088465b17e",
             "parentId": "hideout",
@@ -1933,8 +1700,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "abff9fd31e2addb58a449beb",
             "_tpl": "5c0d591486f7744c505b416f",
             "parentId": "hideout",
@@ -1945,8 +1711,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "0a5bcceac2bf91793d8f10dc",
             "_tpl": "5c1127d0d174af29be75cf68",
             "parentId": "hideout",
@@ -1957,14 +1722,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a0ec9da1ec10eda3a8533f1c",
             "_tpl": "5c0d591486f7744c505b416f",
             "parentId": "0a5bcceac2bf91793d8f10dc",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 5
+            }
+        }, {
             "_id": "607ef9471edab8965ed93c2c",
             "_tpl": "5a78832ec5856700155a6ca3",
             "parentId": "hideout",
@@ -1975,8 +1742,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "64de2ab8bead299fb3b1fdfa",
             "_tpl": "5d6e68c4a4b9361b93413f79",
             "parentId": "hideout",
@@ -1987,8 +1753,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f9d05eb5a0910dc0b41ecc4e",
             "_tpl": "5d6e68a8a4b9360b6c0d54e2",
             "parentId": "hideout",
@@ -1999,8 +1764,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "9eb2dbad3ee5fe81dfd9f4dd",
             "_tpl": "5cf8f3b0d7f00c00217872ef",
             "parentId": "hideout",
@@ -2011,8 +1775,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e3667b22d92ed5aad0a07733",
             "_tpl": "560d5e524bdc2d25448b4571",
             "parentId": "hideout",
@@ -2023,8 +1786,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "172e90dcba9ec5ae96ee01f2",
             "_tpl": "5d6e6772a4b936088465b17c",
             "parentId": "hideout",
@@ -2035,8 +1797,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "beebe51d8451e5a660c7adda",
             "_tpl": "58820d1224597753c90aeb13",
             "parentId": "hideout",
@@ -2047,8 +1808,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d95bf0a27ec8a5b8f4fce9fb",
             "_tpl": "5d6e6891a4b9361bd473feea",
             "parentId": "hideout",
@@ -2059,8 +1819,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "659857de5bd8bff8e39ebba1",
             "_tpl": "5d6e6869a4b9361c140bcfde",
             "parentId": "hideout",
@@ -2071,8 +1830,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "1ff5b265a6e69e713fdafc7c",
             "_tpl": "5d6e689ca4b9361bc8618956",
             "parentId": "hideout",
@@ -2083,8 +1841,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "5a2c5d1f45fdcc509a0e509e",
             "_tpl": "5d6e68d1a4b93622fe60e845",
             "parentId": "hideout",
@@ -2095,8 +1852,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7fe29efcd4b9cdc35f662aaf",
             "_tpl": "5d6e67fba4b9361bc73bc779",
             "parentId": "hideout",
@@ -2107,8 +1863,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "96daf62f8cef314ce2ebcbe8",
             "_tpl": "5d6e6911a4b9361bd5780d52",
             "parentId": "hideout",
@@ -2119,8 +1874,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e0bf522520d0ee8dcddcecfc",
             "_tpl": "5d6e68dea4b9361bcc29e659",
             "parentId": "hideout",
@@ -2131,8 +1885,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "4dcacbf50d8f0b4b5e57c518",
             "_tpl": "5d6e68e6a4b9361c140bcfe0",
             "parentId": "hideout",
@@ -2143,8 +1896,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "209e3c91cf9ea1bd6aecabb2",
             "_tpl": "5d6e68b3a4b9361bca7e50b5",
             "parentId": "hideout",
@@ -2155,8 +1907,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "8ed3f327c9a78ff4fae5c9fa",
             "_tpl": "5d6e6806a4b936088465b17e",
             "parentId": "hideout",
@@ -2167,8 +1918,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "5a7da5bc3fc294f8abfaafa7",
             "_tpl": "5c0d591486f7744c505b416f",
             "parentId": "hideout",
@@ -2179,8 +1929,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ea1b19ecaca8b4d7d2f9cd2e",
             "_tpl": "5d6e68c4a4b9361b93413f79",
             "parentId": "hideout",
@@ -2191,8 +1940,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "8a0bd539dd47a5ff59938fee",
             "_tpl": "5d6e68a8a4b9360b6c0d54e2",
             "parentId": "hideout",
@@ -2203,8 +1951,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ebfdd56e54eac3afef0be4b7",
             "_tpl": "5d6e695fa4b936359b35d852",
             "parentId": "hideout",
@@ -2215,8 +1962,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "338fdbdb2c904cdbe5fc6bd1",
             "_tpl": "5a38ebd9c4a282000d722a5b",
             "parentId": "hideout",
@@ -2227,8 +1973,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "1aee6bfdf419aaacb102028b",
             "_tpl": "5d6e6a53a4b9361bd473feec",
             "parentId": "hideout",
@@ -2239,8 +1984,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b7cfaabbd60e5e1d40b5b23d",
             "_tpl": "5a38ed75c4a28232996e40c6",
             "parentId": "hideout",
@@ -2251,8 +1995,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f1ef72fcdade7bfedaf1fca1",
             "_tpl": "5d6e69b9a4b9361bc8618958",
             "parentId": "hideout",
@@ -2263,8 +2006,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ab11bfb33bde45cef4aad3db",
             "_tpl": "5d6e6a42a4b9364f07165f52",
             "parentId": "hideout",
@@ -2275,8 +2017,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ec3a10e74fd57d62bdf85d9a",
             "_tpl": "5d6e6a05a4b93618084f58d0",
             "parentId": "hideout",
@@ -2287,8 +2028,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7b1af22abd0e2e0619fa4af7",
             "_tpl": "5c6161fb2e221600113fbde5",
             "parentId": "hideout",
@@ -2299,8 +2039,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c72ebf92e3bcdad20982c0c7",
             "_tpl": "5d6e69c7a4b9360b6c0d54e4",
             "parentId": "hideout",
@@ -2311,8 +2050,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "abefc4eece1bec9ddd29db7f",
             "_tpl": "5d6e6a5fa4b93614ec501745",
             "parentId": "hideout",
@@ -2323,8 +2061,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "0fb70646328e94c05adb9371",
             "_tpl": "5d6e695fa4b936359b35d852",
             "parentId": "hideout",
@@ -2335,8 +2072,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b5bbca063ce94dd3adeafe5e",
             "_tpl": "5a38ebd9c4a282000d722a5b",
             "parentId": "hideout",
@@ -2347,8 +2083,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "be72bf3becb06875108179cb",
             "_tpl": "5d6e6a53a4b9361bd473feec",
             "parentId": "hideout",
@@ -2359,8 +2094,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a6deabdf042b04703a69f32c",
             "_tpl": "5d6e69b9a4b9361bc8618958",
             "parentId": "hideout",
@@ -2371,8 +2105,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7cbe0fb45c06fcdfc0fccee3",
             "_tpl": "5d6e6a42a4b9364f07165f52",
             "parentId": "hideout",
@@ -2383,8 +2116,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "78073a728de6a5c9a6ed60d0",
             "_tpl": "5d6e6a05a4b93618084f58d0",
             "parentId": "hideout",
@@ -2395,8 +2127,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "8ed19a9fbd1ebeef15af8cbd",
             "_tpl": "5d6e69c7a4b9360b6c0d54e4",
             "parentId": "hideout",
@@ -2407,8 +2138,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7a9ed9ece005b3e2ca2e7915",
             "_tpl": "5d6e6a5fa4b93614ec501745",
             "parentId": "hideout",
@@ -2419,8 +2149,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "dfb203e62e2092c12584d01c",
             "_tpl": "5e85a9f4add9fe03027d9bf1",
             "parentId": "hideout",
@@ -2431,8 +2160,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b171a43daba1aafeacf82ef7",
             "_tpl": "5f647f31b6238e5dd066e196",
             "parentId": "hideout",
@@ -2443,8 +2171,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "3db1ce73dda3d123aa1e5ca1",
             "_tpl": "5e85a9a6eacf8c039e4e2ac1",
             "parentId": "hideout",
@@ -2455,8 +2182,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "9abc31afafd3af049cf1432d",
             "_tpl": "5e85aa1a988a8701445df1f5",
             "parentId": "hideout",
@@ -2467,8 +2193,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ae574cfa8c9edeffda91eeb3",
             "_tpl": "5e85a9f4add9fe03027d9bf1",
             "parentId": "hideout",
@@ -2479,8 +2204,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bbaa0da51cc5cd3150187212",
             "_tpl": "5f647f31b6238e5dd066e196",
             "parentId": "hideout",
@@ -2491,8 +2215,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c560e753a39628c459aa8e73",
             "_tpl": "5e85a9a6eacf8c039e4e2ac1",
             "parentId": "hideout",
@@ -2503,8 +2226,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "dbd3aacd87e030cd2a76e6d7",
             "_tpl": "5e85aa1a988a8701445df1f5",
             "parentId": "hideout",
@@ -2515,8 +2237,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b4c3ad7f6315dab31c7def05",
             "_tpl": "5fd4c5477a8d854fa0105061",
             "parentId": "hideout",
@@ -2527,8 +2248,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a5f649bf8d44b1893d4fd69b",
             "_tpl": "5e4abc1f86f774069619fbaa",
             "parentId": "hideout",
@@ -2539,8 +2259,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f1a5934eaa76429ab1c7c4fc",
             "_tpl": "5d5d8ca986f7742798716522",
             "parentId": "hideout",
@@ -2551,8 +2270,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "4f98a8eb9c3a3d351c4dc616",
             "_tpl": "6034d0230ca681766b6a0fb5",
             "parentId": "hideout",
@@ -2563,8 +2281,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b5369dabebdaae9f0638690e",
             "_tpl": "59e7643b86f7742cbf2c109a",
             "parentId": "hideout",
@@ -2575,8 +2292,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fd06898aad080db6836c43ee",
             "_tpl": "5c0e3eb886f7742015526062",
             "parentId": "hideout",
@@ -2587,32 +2303,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c02",
-          "_tpl": "65764a4cd8537eb26a0355ee",
-          "parentId": "fd06898aad080db6836c43ee",
-          "slotId": "Soft_armor_front"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c03",
-          "_tpl": "65764bc22bc38ef78e076485",
-          "parentId": "fd06898aad080db6836c43ee",
-          "slotId": "Soft_armor_back"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c04",
-          "_tpl": "65764c39526e320fbe035777",
-          "parentId": "fd06898aad080db6836c43ee",
-          "slotId": "Collar"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c05",
-          "_tpl": "65764c6b526e320fbe03577b",
-          "parentId": "fd06898aad080db6836c43ee",
-          "slotId": "Groin"
-        },
-        {
+        }, {
+            "_id": "666fbf8a05a4eac710002c02",
+            "_tpl": "65764a4cd8537eb26a0355ee",
+            "parentId": "fd06898aad080db6836c43ee",
+            "slotId": "Soft_armor_front"
+        }, {
+            "_id": "666fbf8a05a4eac710002c03",
+            "_tpl": "65764bc22bc38ef78e076485",
+            "parentId": "fd06898aad080db6836c43ee",
+            "slotId": "Soft_armor_back"
+        }, {
+            "_id": "666fbf8a05a4eac710002c04",
+            "_tpl": "65764c39526e320fbe035777",
+            "parentId": "fd06898aad080db6836c43ee",
+            "slotId": "Collar"
+        }, {
+            "_id": "666fbf8a05a4eac710002c05",
+            "_tpl": "65764c6b526e320fbe03577b",
+            "parentId": "fd06898aad080db6836c43ee",
+            "slotId": "Groin"
+        }, {
             "_id": "815bdffbfefaefc1eb946042",
             "_tpl": "5929a2a086f7744f4b234d43",
             "parentId": "hideout",
@@ -2623,8 +2334,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "0df43ca5ffe3fc1ec51dccea",
             "_tpl": "5e4abfed86f77406a2713cf7",
             "parentId": "hideout",
@@ -2635,8 +2345,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "1af4cd84e135f08e84fd00b0",
             "_tpl": "6034cf5fffd42c541047f72e",
             "parentId": "hideout",
@@ -2647,8 +2356,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "5ccae3762dbff05bd55bf93a",
             "_tpl": "5c0e9f2c86f77432297fe0a3",
             "parentId": "hideout",
@@ -2659,8 +2367,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "02b2d5d2c2a0ccecae56cccc",
             "_tpl": "5ca20abf86f77418567a43f2",
             "parentId": "hideout",
@@ -2671,8 +2378,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "1bc8eec0b9c5df19e4b9cd9d",
             "_tpl": "5c0e6a1586f77404597b4965",
             "parentId": "hideout",
@@ -2683,8 +2389,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "127beb33b5eb51fd2e70207a",
             "_tpl": "5c0e446786f7742013381639",
             "parentId": "hideout",
@@ -2695,32 +2400,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c06",
-          "_tpl": "657087577f6d4590ac0d2109",
-          "parentId": "127beb33b5eb51fd2e70207a",
-          "slotId": "Soft_armor_front"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c07",
-          "_tpl": "6570880f4a747dbb63005ee5",
-          "parentId": "127beb33b5eb51fd2e70207a",
-          "slotId": "Soft_armor_back"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c08",
-          "_tpl": "65708afe4a747dbb63005eee",
-          "parentId": "127beb33b5eb51fd2e70207a",
-          "slotId": "Collar"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c09",
-          "_tpl": "65708b4c4a747dbb63005ef3",
-          "parentId": "127beb33b5eb51fd2e70207a",
-          "slotId": "Groin"
-        },
-        {
+        }, {
+            "_id": "666fbf8a05a4eac710002c06",
+            "_tpl": "657087577f6d4590ac0d2109",
+            "parentId": "127beb33b5eb51fd2e70207a",
+            "slotId": "Soft_armor_front"
+        }, {
+            "_id": "666fbf8a05a4eac710002c07",
+            "_tpl": "6570880f4a747dbb63005ee5",
+            "parentId": "127beb33b5eb51fd2e70207a",
+            "slotId": "Soft_armor_back"
+        }, {
+            "_id": "666fbf8a05a4eac710002c08",
+            "_tpl": "65708afe4a747dbb63005eee",
+            "parentId": "127beb33b5eb51fd2e70207a",
+            "slotId": "Collar"
+        }, {
+            "_id": "666fbf8a05a4eac710002c09",
+            "_tpl": "65708b4c4a747dbb63005ef3",
+            "parentId": "127beb33b5eb51fd2e70207a",
+            "slotId": "Groin"
+        }, {
             "_id": "dd80a6c3f7d6deabac4abbfd",
             "_tpl": "5fd4c60f875c30179f5d04c2",
             "parentId": "hideout",
@@ -2731,8 +2431,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "6d4aa0fcc7cbf1deb09bd91e",
             "_tpl": "5d5d85c586f774279a21cbdb",
             "parentId": "hideout",
@@ -2743,8 +2442,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f8d40ee84cf325dd1ea4f277",
             "_tpl": "5f5f41f56760b4138443b352",
             "parentId": "hideout",
@@ -2755,8 +2453,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "0720d68e9bdc9fbfcec106c3",
             "_tpl": "60a6220e953894617404b00a",
             "parentId": "hideout",
@@ -2767,8 +2464,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "14f09c3dcc2f8dcfa5b66d1b",
             "_tpl": "5d5d646386f7742797261fd9",
             "parentId": "hideout",
@@ -2779,32 +2475,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c0a",
-          "_tpl": "65764e1e2bc38ef78e076489",
-          "parentId": "14f09c3dcc2f8dcfa5b66d1b",
-          "slotId": "Soft_armor_front"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c0b",
-          "_tpl": "65764fae2bc38ef78e07648d",
-          "parentId": "14f09c3dcc2f8dcfa5b66d1b",
-          "slotId": "Soft_armor_back"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c0c",
-          "_tpl": "6576504b526e320fbe035783",
-          "parentId": "14f09c3dcc2f8dcfa5b66d1b",
-          "slotId": "Groin"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c0d",
-          "_tpl": "6576500f526e320fbe03577f",
-          "parentId": "14f09c3dcc2f8dcfa5b66d1b",
-          "slotId": "Groin_back"
-        },
-        {
+        }, {
+            "_id": "666fbf8a05a4eac710002c0a",
+            "_tpl": "65764e1e2bc38ef78e076489",
+            "parentId": "14f09c3dcc2f8dcfa5b66d1b",
+            "slotId": "Soft_armor_front"
+        }, {
+            "_id": "666fbf8a05a4eac710002c0b",
+            "_tpl": "65764fae2bc38ef78e07648d",
+            "parentId": "14f09c3dcc2f8dcfa5b66d1b",
+            "slotId": "Soft_armor_back"
+        }, {
+            "_id": "666fbf8a05a4eac710002c0c",
+            "_tpl": "6576504b526e320fbe035783",
+            "parentId": "14f09c3dcc2f8dcfa5b66d1b",
+            "slotId": "Groin"
+        }, {
+            "_id": "666fbf8a05a4eac710002c0d",
+            "_tpl": "6576500f526e320fbe03577f",
+            "parentId": "14f09c3dcc2f8dcfa5b66d1b",
+            "slotId": "Groin_back"
+        }, {
             "_id": "0bdd95825aed498d5edc3fb2",
             "_tpl": "61bc85697113f767765c7fe7",
             "parentId": "hideout",
@@ -2815,44 +2506,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c0e",
-          "_tpl": "6572fc809a866b80ab07eb59",
-          "parentId": "0bdd95825aed498d5edc3fb2",
-          "slotId": "Soft_armor_front"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c0f",
-          "_tpl": "6572fc8c9a866b80ab07eb5d",
-          "parentId": "0bdd95825aed498d5edc3fb2",
-          "slotId": "Soft_armor_back"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c10",
-          "_tpl": "6572fc989a866b80ab07eb61",
-          "parentId": "0bdd95825aed498d5edc3fb2",
-          "slotId": "Soft_armor_left"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c11",
-          "_tpl": "6572fca39a866b80ab07eb65",
-          "parentId": "0bdd95825aed498d5edc3fb2",
-          "slotId": "soft_armor_right"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c12",
-          "_tpl": "656fad8c498d1b7e3e071da0",
-          "parentId": "0bdd95825aed498d5edc3fb2",
-          "slotId": "Front_plate"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c13",
-          "_tpl": "656fad8c498d1b7e3e071da0",
-          "parentId": "0bdd95825aed498d5edc3fb2",
-          "slotId": "Back_plate"
-        },
-        {
+        }, {
+            "_id": "666fbf8a05a4eac710002c0e",
+            "_tpl": "6572fc809a866b80ab07eb59",
+            "parentId": "0bdd95825aed498d5edc3fb2",
+            "slotId": "Soft_armor_front"
+        }, {
+            "_id": "666fbf8a05a4eac710002c0f",
+            "_tpl": "6572fc8c9a866b80ab07eb5d",
+            "parentId": "0bdd95825aed498d5edc3fb2",
+            "slotId": "Soft_armor_back"
+        }, {
+            "_id": "666fbf8a05a4eac710002c10",
+            "_tpl": "6572fc989a866b80ab07eb61",
+            "parentId": "0bdd95825aed498d5edc3fb2",
+            "slotId": "Soft_armor_left"
+        }, {
+            "_id": "666fbf8a05a4eac710002c11",
+            "_tpl": "6572fca39a866b80ab07eb65",
+            "parentId": "0bdd95825aed498d5edc3fb2",
+            "slotId": "soft_armor_right"
+        }, {
+            "_id": "666fbf8a05a4eac710002c12",
+            "_tpl": "656fad8c498d1b7e3e071da0",
+            "parentId": "0bdd95825aed498d5edc3fb2",
+            "slotId": "Front_plate"
+        }, {
+            "_id": "666fbf8a05a4eac710002c13",
+            "_tpl": "656fad8c498d1b7e3e071da0",
+            "parentId": "0bdd95825aed498d5edc3fb2",
+            "slotId": "Back_plate"
+        }, {
             "_id": "e8a0fe4dcca134dc37a7eb89",
             "_tpl": "5ab8dab586f77441cd04f2a2",
             "parentId": "hideout",
@@ -2863,8 +2547,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "1f146f73bf81b60d52f79fdb",
             "_tpl": "603648ff5a45383c122086ac",
             "parentId": "hideout",
@@ -2875,8 +2558,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "87c445dab45bca03aa9eba6d",
             "_tpl": "5648a69d4bdc2ded0b8b457b",
             "parentId": "hideout",
@@ -2887,8 +2569,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "3b8b75b42dff1b2b96cd1243",
             "_tpl": "61bcc89aef0f505f0c6cd0fc",
             "parentId": "hideout",
@@ -2899,50 +2580,42 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c14",
-          "_tpl": "6572eb0e55beba16bc04079f",
-          "parentId": "3b8b75b42dff1b2b96cd1243",
-          "slotId": "Soft_armor_front"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c15",
-          "_tpl": "6572eb1b04ee6483ef039882",
-          "parentId": "3b8b75b42dff1b2b96cd1243",
-          "slotId": "Soft_armor_back"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c16",
-          "_tpl": "6572eb3004ee6483ef039886",
-          "parentId": "3b8b75b42dff1b2b96cd1243",
-          "slotId": "Soft_armor_left"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c17",
-          "_tpl": "6572eb3b04ee6483ef03988a",
-          "parentId": "3b8b75b42dff1b2b96cd1243",
-          "slotId": "soft_armor_right"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c18",
-          "_tpl": "6572eb865b5eac12f10a03ee",
-          "parentId": "3b8b75b42dff1b2b96cd1243",
-          "slotId": "Groin"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c19",
-          "_tpl": "656fb21fa0dce000a2020f7c",
-          "parentId": "3b8b75b42dff1b2b96cd1243",
-          "slotId": "Front_plate"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c1a",
-          "_tpl": "656fb21fa0dce000a2020f7c",
-          "parentId": "3b8b75b42dff1b2b96cd1243",
-          "slotId": "Back_plate"
-        },
-        {
+        }, {
+            "_id": "666fbf8a05a4eac710002c14",
+            "_tpl": "6572eb0e55beba16bc04079f",
+            "parentId": "3b8b75b42dff1b2b96cd1243",
+            "slotId": "Soft_armor_front"
+        }, {
+            "_id": "666fbf8a05a4eac710002c15",
+            "_tpl": "6572eb1b04ee6483ef039882",
+            "parentId": "3b8b75b42dff1b2b96cd1243",
+            "slotId": "Soft_armor_back"
+        }, {
+            "_id": "666fbf8a05a4eac710002c16",
+            "_tpl": "6572eb3004ee6483ef039886",
+            "parentId": "3b8b75b42dff1b2b96cd1243",
+            "slotId": "Soft_armor_left"
+        }, {
+            "_id": "666fbf8a05a4eac710002c17",
+            "_tpl": "6572eb3b04ee6483ef03988a",
+            "parentId": "3b8b75b42dff1b2b96cd1243",
+            "slotId": "soft_armor_right"
+        }, {
+            "_id": "666fbf8a05a4eac710002c18",
+            "_tpl": "6572eb865b5eac12f10a03ee",
+            "parentId": "3b8b75b42dff1b2b96cd1243",
+            "slotId": "Groin"
+        }, {
+            "_id": "666fbf8a05a4eac710002c19",
+            "_tpl": "656fb21fa0dce000a2020f7c",
+            "parentId": "3b8b75b42dff1b2b96cd1243",
+            "slotId": "Front_plate"
+        }, {
+            "_id": "666fbf8a05a4eac710002c1a",
+            "_tpl": "656fb21fa0dce000a2020f7c",
+            "parentId": "3b8b75b42dff1b2b96cd1243",
+            "slotId": "Back_plate"
+        }, {
             "_id": "bebdbbf862ac9db6fe44c8a7",
             "_tpl": "5ab8dced86f774646209ec87",
             "parentId": "hideout",
@@ -2953,44 +2626,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c1b",
-          "_tpl": "6570f6e774d84423df065f21",
-          "parentId": "bebdbbf862ac9db6fe44c8a7",
-          "slotId": "Soft_armor_front"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c1c",
-          "_tpl": "6570f71dd67d0309980a7af8",
-          "parentId": "bebdbbf862ac9db6fe44c8a7",
-          "slotId": "Soft_armor_back"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c1d",
-          "_tpl": "6570f74774d84423df065f25",
-          "parentId": "bebdbbf862ac9db6fe44c8a7",
-          "slotId": "Soft_armor_left"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c1e",
-          "_tpl": "6570f79c4c65ab77a6015121",
-          "parentId": "bebdbbf862ac9db6fe44c8a7",
-          "slotId": "soft_armor_right"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c1f",
-          "_tpl": "656fa25e94b480b8a500c0e0",
-          "parentId": "bebdbbf862ac9db6fe44c8a7",
-          "slotId": "Front_plate"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c20",
-          "_tpl": "656fa25e94b480b8a500c0e0",
-          "parentId": "bebdbbf862ac9db6fe44c8a7",
-          "slotId": "Back_plate"
-        },
-        {
+        }, {
+            "_id": "666fbf8a05a4eac710002c1b",
+            "_tpl": "6570f6e774d84423df065f21",
+            "parentId": "bebdbbf862ac9db6fe44c8a7",
+            "slotId": "Soft_armor_front"
+        }, {
+            "_id": "666fbf8a05a4eac710002c1c",
+            "_tpl": "6570f71dd67d0309980a7af8",
+            "parentId": "bebdbbf862ac9db6fe44c8a7",
+            "slotId": "Soft_armor_back"
+        }, {
+            "_id": "666fbf8a05a4eac710002c1d",
+            "_tpl": "6570f74774d84423df065f25",
+            "parentId": "bebdbbf862ac9db6fe44c8a7",
+            "slotId": "Soft_armor_left"
+        }, {
+            "_id": "666fbf8a05a4eac710002c1e",
+            "_tpl": "6570f79c4c65ab77a6015121",
+            "parentId": "bebdbbf862ac9db6fe44c8a7",
+            "slotId": "soft_armor_right"
+        }, {
+            "_id": "666fbf8a05a4eac710002c1f",
+            "_tpl": "656fa25e94b480b8a500c0e0",
+            "parentId": "bebdbbf862ac9db6fe44c8a7",
+            "slotId": "Front_plate"
+        }, {
+            "_id": "666fbf8a05a4eac710002c20",
+            "_tpl": "656fa25e94b480b8a500c0e0",
+            "parentId": "bebdbbf862ac9db6fe44c8a7",
+            "slotId": "Back_plate"
+        }, {
             "_id": "ab5ad43ae0c94f95adcce72c",
             "_tpl": "592c2d1a86f7746dbe2af32a",
             "parentId": "hideout",
@@ -3001,8 +2667,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ba8ca88daafaf9594ae540e5",
             "_tpl": "5df8a42886f77412640e2e75",
             "parentId": "hideout",
@@ -3013,8 +2678,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "8be67fad35c2041d0ab894b3",
             "_tpl": "5e9db13186f7742f845ee9d3",
             "parentId": "hideout",
@@ -3025,8 +2689,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "4a05cab1ec3fcaecfd869ad7",
             "_tpl": "544a5caa4bdc2d1a388b4568",
             "parentId": "hideout",
@@ -3037,38 +2700,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c21",
-          "_tpl": "6570e83223c1f638ef0b0ede",
-          "parentId": "4a05cab1ec3fcaecfd869ad7",
-          "slotId": "Soft_armor_front"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c22",
-          "_tpl": "6570e87c23c1f638ef0b0ee2",
-          "parentId": "4a05cab1ec3fcaecfd869ad7",
-          "slotId": "Soft_armor_back"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c23",
-          "_tpl": "6570e90b3a5689d85f08db97",
-          "parentId": "4a05cab1ec3fcaecfd869ad7",
-          "slotId": "Groin"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c24",
-          "_tpl": "656f9fa0498d1b7e3e071d98",
-          "parentId": "4a05cab1ec3fcaecfd869ad7",
-          "slotId": "Front_plate"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c25",
-          "_tpl": "656f9fa0498d1b7e3e071d98",
-          "parentId": "4a05cab1ec3fcaecfd869ad7",
-          "slotId": "Back_plate"
-        },
-        {
+        }, {
+            "_id": "666fbf8a05a4eac710002c21",
+            "_tpl": "6570e83223c1f638ef0b0ede",
+            "parentId": "4a05cab1ec3fcaecfd869ad7",
+            "slotId": "Soft_armor_front"
+        }, {
+            "_id": "666fbf8a05a4eac710002c22",
+            "_tpl": "6570e87c23c1f638ef0b0ee2",
+            "parentId": "4a05cab1ec3fcaecfd869ad7",
+            "slotId": "Soft_armor_back"
+        }, {
+            "_id": "666fbf8a05a4eac710002c23",
+            "_tpl": "6570e90b3a5689d85f08db97",
+            "parentId": "4a05cab1ec3fcaecfd869ad7",
+            "slotId": "Groin"
+        }, {
+            "_id": "666fbf8a05a4eac710002c24",
+            "_tpl": "656f9fa0498d1b7e3e071d98",
+            "parentId": "4a05cab1ec3fcaecfd869ad7",
+            "slotId": "Front_plate"
+        }, {
+            "_id": "666fbf8a05a4eac710002c25",
+            "_tpl": "656f9fa0498d1b7e3e071d98",
+            "parentId": "4a05cab1ec3fcaecfd869ad7",
+            "slotId": "Back_plate"
+        }, {
             "_id": "a8cd694ebdfe692520edfac7",
             "_tpl": "5c0e722886f7740458316a57",
             "parentId": "hideout",
@@ -3079,44 +2736,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c26",
-          "_tpl": "65730c0e292ecadbfa09ad49",
-          "parentId": "a8cd694ebdfe692520edfac7",
-          "slotId": "Soft_armor_front"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c27",
-          "_tpl": "65730c2213a2f660f60bea96",
-          "parentId": "a8cd694ebdfe692520edfac7",
-          "slotId": "Soft_armor_back"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c28",
-          "_tpl": "65730c2b292ecadbfa09ad50",
-          "parentId": "a8cd694ebdfe692520edfac7",
-          "slotId": "Soft_armor_left"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c29",
-          "_tpl": "65730c35292ecadbfa09ad54",
-          "parentId": "a8cd694ebdfe692520edfac7",
-          "slotId": "soft_armor_right"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c2a",
-          "_tpl": "656fa0fb498d1b7e3e071d9c",
-          "parentId": "a8cd694ebdfe692520edfac7",
-          "slotId": "Front_plate"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c2b",
-          "_tpl": "656fa0fb498d1b7e3e071d9c",
-          "parentId": "a8cd694ebdfe692520edfac7",
-          "slotId": "Back_plate"
-        },
-        {
+        }, {
+            "_id": "666fbf8a05a4eac710002c26",
+            "_tpl": "65730c0e292ecadbfa09ad49",
+            "parentId": "a8cd694ebdfe692520edfac7",
+            "slotId": "Soft_armor_front"
+        }, {
+            "_id": "666fbf8a05a4eac710002c27",
+            "_tpl": "65730c2213a2f660f60bea96",
+            "parentId": "a8cd694ebdfe692520edfac7",
+            "slotId": "Soft_armor_back"
+        }, {
+            "_id": "666fbf8a05a4eac710002c28",
+            "_tpl": "65730c2b292ecadbfa09ad50",
+            "parentId": "a8cd694ebdfe692520edfac7",
+            "slotId": "Soft_armor_left"
+        }, {
+            "_id": "666fbf8a05a4eac710002c29",
+            "_tpl": "65730c35292ecadbfa09ad54",
+            "parentId": "a8cd694ebdfe692520edfac7",
+            "slotId": "soft_armor_right"
+        }, {
+            "_id": "666fbf8a05a4eac710002c2a",
+            "_tpl": "656fa0fb498d1b7e3e071d9c",
+            "parentId": "a8cd694ebdfe692520edfac7",
+            "slotId": "Front_plate"
+        }, {
+            "_id": "666fbf8a05a4eac710002c2b",
+            "_tpl": "656fa0fb498d1b7e3e071d9c",
+            "parentId": "a8cd694ebdfe692520edfac7",
+            "slotId": "Back_plate"
+        }, {
             "_id": "8107aeabab56728bdbe6181f",
             "_tpl": "60a3c70cde5f453f634816a3",
             "parentId": "hideout",
@@ -3127,62 +2777,52 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c2c",
-          "_tpl": "6570fae34c65ab77a6015146",
-          "parentId": "8107aeabab56728bdbe6181f",
-          "slotId": "Soft_armor_front"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c2d",
-          "_tpl": "6570fa1f4c65ab77a601512f",
-          "parentId": "8107aeabab56728bdbe6181f",
-          "slotId": "Soft_armor_back"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c2e",
-          "_tpl": "6570fb22584a51c23e03251f",
-          "parentId": "8107aeabab56728bdbe6181f",
-          "slotId": "Soft_armor_left"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c2f",
-          "_tpl": "6570fb6ad3eefd23430f8c7c",
-          "parentId": "8107aeabab56728bdbe6181f",
-          "slotId": "soft_armor_right"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c30",
-          "_tpl": "6570fb8f4c65ab77a601514d",
-          "parentId": "8107aeabab56728bdbe6181f",
-          "slotId": "Collar"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c31",
-          "_tpl": "6570fbdd74d84423df065f60",
-          "parentId": "8107aeabab56728bdbe6181f",
-          "slotId": "Shoulder_l"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c32",
-          "_tpl": "6570fc41d3eefd23430f8c83",
-          "parentId": "8107aeabab56728bdbe6181f",
-          "slotId": "Shoulder_r"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c33",
-          "_tpl": "656fb21fa0dce000a2020f7c",
-          "parentId": "8107aeabab56728bdbe6181f",
-          "slotId": "Front_plate"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c34",
-          "_tpl": "656fb21fa0dce000a2020f7c",
-          "parentId": "8107aeabab56728bdbe6181f",
-          "slotId": "Back_plate"
-        },
-        {
+        }, {
+            "_id": "666fbf8a05a4eac710002c2c",
+            "_tpl": "6570fae34c65ab77a6015146",
+            "parentId": "8107aeabab56728bdbe6181f",
+            "slotId": "Soft_armor_front"
+        }, {
+            "_id": "666fbf8a05a4eac710002c2d",
+            "_tpl": "6570fa1f4c65ab77a601512f",
+            "parentId": "8107aeabab56728bdbe6181f",
+            "slotId": "Soft_armor_back"
+        }, {
+            "_id": "666fbf8a05a4eac710002c2e",
+            "_tpl": "6570fb22584a51c23e03251f",
+            "parentId": "8107aeabab56728bdbe6181f",
+            "slotId": "Soft_armor_left"
+        }, {
+            "_id": "666fbf8a05a4eac710002c2f",
+            "_tpl": "6570fb6ad3eefd23430f8c7c",
+            "parentId": "8107aeabab56728bdbe6181f",
+            "slotId": "soft_armor_right"
+        }, {
+            "_id": "666fbf8a05a4eac710002c30",
+            "_tpl": "6570fb8f4c65ab77a601514d",
+            "parentId": "8107aeabab56728bdbe6181f",
+            "slotId": "Collar"
+        }, {
+            "_id": "666fbf8a05a4eac710002c31",
+            "_tpl": "6570fbdd74d84423df065f60",
+            "parentId": "8107aeabab56728bdbe6181f",
+            "slotId": "Shoulder_l"
+        }, {
+            "_id": "666fbf8a05a4eac710002c32",
+            "_tpl": "6570fc41d3eefd23430f8c83",
+            "parentId": "8107aeabab56728bdbe6181f",
+            "slotId": "Shoulder_r"
+        }, {
+            "_id": "666fbf8a05a4eac710002c33",
+            "_tpl": "656fb21fa0dce000a2020f7c",
+            "parentId": "8107aeabab56728bdbe6181f",
+            "slotId": "Front_plate"
+        }, {
+            "_id": "666fbf8a05a4eac710002c34",
+            "_tpl": "656fb21fa0dce000a2020f7c",
+            "parentId": "8107aeabab56728bdbe6181f",
+            "slotId": "Back_plate"
+        }, {
             "_id": "06a26faa77eee1fe7557532a",
             "_tpl": "5c0e746986f7741453628fe5",
             "parentId": "hideout",
@@ -3193,32 +2833,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c35",
-          "_tpl": "6570df294cc0d2ab1e05ed74",
-          "parentId": "06a26faa77eee1fe7557532a",
-          "slotId": "Soft_armor_front"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c36",
-          "_tpl": "6570df9c615f54368b04fca9",
-          "parentId": "06a26faa77eee1fe7557532a",
-          "slotId": "Soft_armor_back"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c37",
-          "_tpl": "656fa0fb498d1b7e3e071d9c",
-          "parentId": "06a26faa77eee1fe7557532a",
-          "slotId": "Front_plate"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c38",
-          "_tpl": "656fa0fb498d1b7e3e071d9c",
-          "parentId": "06a26faa77eee1fe7557532a",
-          "slotId": "Back_plate"
-        },
-        {
+        }, {
+            "_id": "666fbf8a05a4eac710002c35",
+            "_tpl": "6570df294cc0d2ab1e05ed74",
+            "parentId": "06a26faa77eee1fe7557532a",
+            "slotId": "Soft_armor_front"
+        }, {
+            "_id": "666fbf8a05a4eac710002c36",
+            "_tpl": "6570df9c615f54368b04fca9",
+            "parentId": "06a26faa77eee1fe7557532a",
+            "slotId": "Soft_armor_back"
+        }, {
+            "_id": "666fbf8a05a4eac710002c37",
+            "_tpl": "656fa0fb498d1b7e3e071d9c",
+            "parentId": "06a26faa77eee1fe7557532a",
+            "slotId": "Front_plate"
+        }, {
+            "_id": "666fbf8a05a4eac710002c38",
+            "_tpl": "656fa0fb498d1b7e3e071d9c",
+            "parentId": "06a26faa77eee1fe7557532a",
+            "slotId": "Back_plate"
+        }, {
             "_id": "7bcd28b4cbbf7a34d643dce9",
             "_tpl": "5d5d87f786f77427997cfaef",
             "parentId": "hideout",
@@ -3229,44 +2864,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c39",
-          "_tpl": "6570e5100b57c03ec90b970a",
-          "parentId": "7bcd28b4cbbf7a34d643dce9",
-          "slotId": "Soft_armor_front"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c3a",
-          "_tpl": "6570e479a6560e4ee50c2b02",
-          "parentId": "7bcd28b4cbbf7a34d643dce9",
-          "slotId": "Soft_armor_back"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c3b",
-          "_tpl": "6570e5674cc0d2ab1e05edbb",
-          "parentId": "7bcd28b4cbbf7a34d643dce9",
-          "slotId": "Soft_armor_left"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c3c",
-          "_tpl": "6570e59b0b57c03ec90b970e",
-          "parentId": "7bcd28b4cbbf7a34d643dce9",
-          "slotId": "soft_armor_right"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c3d",
-          "_tpl": "656f9fa0498d1b7e3e071d98",
-          "parentId": "7bcd28b4cbbf7a34d643dce9",
-          "slotId": "Front_plate"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c3e",
-          "_tpl": "656f9fa0498d1b7e3e071d98",
-          "parentId": "7bcd28b4cbbf7a34d643dce9",
-          "slotId": "Back_plate"
-        },
-        {
+        }, {
+            "_id": "666fbf8a05a4eac710002c39",
+            "_tpl": "6570e5100b57c03ec90b970a",
+            "parentId": "7bcd28b4cbbf7a34d643dce9",
+            "slotId": "Soft_armor_front"
+        }, {
+            "_id": "666fbf8a05a4eac710002c3a",
+            "_tpl": "6570e479a6560e4ee50c2b02",
+            "parentId": "7bcd28b4cbbf7a34d643dce9",
+            "slotId": "Soft_armor_back"
+        }, {
+            "_id": "666fbf8a05a4eac710002c3b",
+            "_tpl": "6570e5674cc0d2ab1e05edbb",
+            "parentId": "7bcd28b4cbbf7a34d643dce9",
+            "slotId": "Soft_armor_left"
+        }, {
+            "_id": "666fbf8a05a4eac710002c3c",
+            "_tpl": "6570e59b0b57c03ec90b970e",
+            "parentId": "7bcd28b4cbbf7a34d643dce9",
+            "slotId": "soft_armor_right"
+        }, {
+            "_id": "666fbf8a05a4eac710002c3d",
+            "_tpl": "656f9fa0498d1b7e3e071d98",
+            "parentId": "7bcd28b4cbbf7a34d643dce9",
+            "slotId": "Front_plate"
+        }, {
+            "_id": "666fbf8a05a4eac710002c3e",
+            "_tpl": "656f9fa0498d1b7e3e071d98",
+            "parentId": "7bcd28b4cbbf7a34d643dce9",
+            "slotId": "Back_plate"
+        }, {
             "_id": "7f0cd7ce3de8f02a42ceb994",
             "_tpl": "5b44cad286f77402a54ae7e5",
             "parentId": "hideout",
@@ -3277,32 +2905,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c3f",
-          "_tpl": "6575bc88c6700bd6b40e8a57",
-          "parentId": "7f0cd7ce3de8f02a42ceb994",
-          "slotId": "Soft_armor_front"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c40",
-          "_tpl": "6575bca0dc9932aed601c5d7",
-          "parentId": "7f0cd7ce3de8f02a42ceb994",
-          "slotId": "Soft_armor_back"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c41",
-          "_tpl": "656fae5f7c2d57afe200c0d7",
-          "parentId": "7f0cd7ce3de8f02a42ceb994",
-          "slotId": "Front_plate"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c42",
-          "_tpl": "656fae5f7c2d57afe200c0d7",
-          "parentId": "7f0cd7ce3de8f02a42ceb994",
-          "slotId": "Back_plate"
-        },
-        {
+        }, {
+            "_id": "666fbf8a05a4eac710002c3f",
+            "_tpl": "6575bc88c6700bd6b40e8a57",
+            "parentId": "7f0cd7ce3de8f02a42ceb994",
+            "slotId": "Soft_armor_front"
+        }, {
+            "_id": "666fbf8a05a4eac710002c40",
+            "_tpl": "6575bca0dc9932aed601c5d7",
+            "parentId": "7f0cd7ce3de8f02a42ceb994",
+            "slotId": "Soft_armor_back"
+        }, {
+            "_id": "666fbf8a05a4eac710002c41",
+            "_tpl": "656fae5f7c2d57afe200c0d7",
+            "parentId": "7f0cd7ce3de8f02a42ceb994",
+            "slotId": "Front_plate"
+        }, {
+            "_id": "666fbf8a05a4eac710002c42",
+            "_tpl": "656fae5f7c2d57afe200c0d7",
+            "parentId": "7f0cd7ce3de8f02a42ceb994",
+            "slotId": "Back_plate"
+        }, {
             "_id": "bf57c5de5dfc6329e0ed29c4",
             "_tpl": "60a3c68c37ea821725773ef5",
             "parentId": "hideout",
@@ -3313,74 +2936,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c43",
-          "_tpl": "65733312ca0ca984940a2d53",
-          "parentId": "bf57c5de5dfc6329e0ed29c4",
-          "slotId": "Soft_armor_front"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c44",
-          "_tpl": "657333232cc8dfad2c0a3d97",
-          "parentId": "bf57c5de5dfc6329e0ed29c4",
-          "slotId": "Soft_armor_back"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c45",
-          "_tpl": "657333302cc8dfad2c0a3d9b",
-          "parentId": "bf57c5de5dfc6329e0ed29c4",
-          "slotId": "Soft_armor_left"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c46",
-          "_tpl": "6573333eca0ca984940a2d57",
-          "parentId": "bf57c5de5dfc6329e0ed29c4",
-          "slotId": "soft_armor_right"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c47",
-          "_tpl": "6573334aca0ca984940a2d5b",
-          "parentId": "bf57c5de5dfc6329e0ed29c4",
-          "slotId": "Collar"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c48",
-          "_tpl": "65733375b7a8d286530e3dd7",
-          "parentId": "bf57c5de5dfc6329e0ed29c4",
-          "slotId": "Shoulder_l"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c49",
-          "_tpl": "6573337f2cc8dfad2c0a3da7",
-          "parentId": "bf57c5de5dfc6329e0ed29c4",
-          "slotId": "Shoulder_r"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c4a",
-          "_tpl": "656fa53d94b480b8a500c0e4",
-          "parentId": "bf57c5de5dfc6329e0ed29c4",
-          "slotId": "Front_plate"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c4b",
-          "_tpl": "656fa53d94b480b8a500c0e4",
-          "parentId": "bf57c5de5dfc6329e0ed29c4",
-          "slotId": "Back_plate"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c4c",
-          "_tpl": "6557458f83942d705f0c4962",
-          "parentId": "bf57c5de5dfc6329e0ed29c4",
-          "slotId": "Left_side_plate"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c4d",
-          "_tpl": "6557458f83942d705f0c4962",
-          "parentId": "bf57c5de5dfc6329e0ed29c4",
-          "slotId": "Right_side_plate"
-        },
-        {
+        }, {
+            "_id": "666fbf8a05a4eac710002c43",
+            "_tpl": "65733312ca0ca984940a2d53",
+            "parentId": "bf57c5de5dfc6329e0ed29c4",
+            "slotId": "Soft_armor_front"
+        }, {
+            "_id": "666fbf8a05a4eac710002c44",
+            "_tpl": "657333232cc8dfad2c0a3d97",
+            "parentId": "bf57c5de5dfc6329e0ed29c4",
+            "slotId": "Soft_armor_back"
+        }, {
+            "_id": "666fbf8a05a4eac710002c45",
+            "_tpl": "657333302cc8dfad2c0a3d9b",
+            "parentId": "bf57c5de5dfc6329e0ed29c4",
+            "slotId": "Soft_armor_left"
+        }, {
+            "_id": "666fbf8a05a4eac710002c46",
+            "_tpl": "6573333eca0ca984940a2d57",
+            "parentId": "bf57c5de5dfc6329e0ed29c4",
+            "slotId": "soft_armor_right"
+        }, {
+            "_id": "666fbf8a05a4eac710002c47",
+            "_tpl": "6573334aca0ca984940a2d5b",
+            "parentId": "bf57c5de5dfc6329e0ed29c4",
+            "slotId": "Collar"
+        }, {
+            "_id": "666fbf8a05a4eac710002c48",
+            "_tpl": "65733375b7a8d286530e3dd7",
+            "parentId": "bf57c5de5dfc6329e0ed29c4",
+            "slotId": "Shoulder_l"
+        }, {
+            "_id": "666fbf8a05a4eac710002c49",
+            "_tpl": "6573337f2cc8dfad2c0a3da7",
+            "parentId": "bf57c5de5dfc6329e0ed29c4",
+            "slotId": "Shoulder_r"
+        }, {
+            "_id": "666fbf8a05a4eac710002c4a",
+            "_tpl": "656fa53d94b480b8a500c0e4",
+            "parentId": "bf57c5de5dfc6329e0ed29c4",
+            "slotId": "Front_plate"
+        }, {
+            "_id": "666fbf8a05a4eac710002c4b",
+            "_tpl": "656fa53d94b480b8a500c0e4",
+            "parentId": "bf57c5de5dfc6329e0ed29c4",
+            "slotId": "Back_plate"
+        }, {
+            "_id": "666fbf8a05a4eac710002c4c",
+            "_tpl": "6557458f83942d705f0c4962",
+            "parentId": "bf57c5de5dfc6329e0ed29c4",
+            "slotId": "Left_side_plate"
+        }, {
+            "_id": "666fbf8a05a4eac710002c4d",
+            "_tpl": "6557458f83942d705f0c4962",
+            "parentId": "bf57c5de5dfc6329e0ed29c4",
+            "slotId": "Right_side_plate"
+        }, {
             "_id": "b5ec3d0cd03cc5ed7f9e5abc",
             "_tpl": "5e4ac41886f77406a511c9a8",
             "parentId": "hideout",
@@ -3391,56 +3002,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c4e",
-          "_tpl": "6575ef599c7cad336508e453",
-          "parentId": "b5ec3d0cd03cc5ed7f9e5abc",
-          "slotId": "soft_armor_front"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c4f",
-          "_tpl": "6575ef6bf6a13a7b7100b093",
-          "parentId": "b5ec3d0cd03cc5ed7f9e5abc",
-          "slotId": "soft_armor_back"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c50",
-          "_tpl": "6575ef78da698a4e980677eb",
-          "parentId": "b5ec3d0cd03cc5ed7f9e5abc",
-          "slotId": "soft_armor_left"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c51",
-          "_tpl": "6575ef7f9c7cad336508e457",
-          "parentId": "b5ec3d0cd03cc5ed7f9e5abc",
-          "slotId": "soft_armor_right"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c52",
-          "_tpl": "656fae5f7c2d57afe200c0d7",
-          "parentId": "b5ec3d0cd03cc5ed7f9e5abc",
-          "slotId": "front_plate"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c53",
-          "_tpl": "656fae5f7c2d57afe200c0d7",
-          "parentId": "b5ec3d0cd03cc5ed7f9e5abc",
-          "slotId": "back_plate"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c54",
-          "_tpl": "6557458f83942d705f0c4962",
-          "parentId": "b5ec3d0cd03cc5ed7f9e5abc",
-          "slotId": "left_side_plate"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c55",
-          "_tpl": "6557458f83942d705f0c4962",
-          "parentId": "b5ec3d0cd03cc5ed7f9e5abc",
-          "slotId": "right_side_plate"
-        },
-        {
+        }, {
+            "_id": "666fbf8a05a4eac710002c4e",
+            "_tpl": "6575ef599c7cad336508e453",
+            "parentId": "b5ec3d0cd03cc5ed7f9e5abc",
+            "slotId": "soft_armor_front"
+        }, {
+            "_id": "666fbf8a05a4eac710002c4f",
+            "_tpl": "6575ef6bf6a13a7b7100b093",
+            "parentId": "b5ec3d0cd03cc5ed7f9e5abc",
+            "slotId": "soft_armor_back"
+        }, {
+            "_id": "666fbf8a05a4eac710002c50",
+            "_tpl": "6575ef78da698a4e980677eb",
+            "parentId": "b5ec3d0cd03cc5ed7f9e5abc",
+            "slotId": "soft_armor_left"
+        }, {
+            "_id": "666fbf8a05a4eac710002c51",
+            "_tpl": "6575ef7f9c7cad336508e457",
+            "parentId": "b5ec3d0cd03cc5ed7f9e5abc",
+            "slotId": "soft_armor_right"
+        }, {
+            "_id": "666fbf8a05a4eac710002c52",
+            "_tpl": "656fae5f7c2d57afe200c0d7",
+            "parentId": "b5ec3d0cd03cc5ed7f9e5abc",
+            "slotId": "front_plate"
+        }, {
+            "_id": "666fbf8a05a4eac710002c53",
+            "_tpl": "656fae5f7c2d57afe200c0d7",
+            "parentId": "b5ec3d0cd03cc5ed7f9e5abc",
+            "slotId": "back_plate"
+        }, {
+            "_id": "666fbf8a05a4eac710002c54",
+            "_tpl": "6557458f83942d705f0c4962",
+            "parentId": "b5ec3d0cd03cc5ed7f9e5abc",
+            "slotId": "left_side_plate"
+        }, {
+            "_id": "666fbf8a05a4eac710002c55",
+            "_tpl": "6557458f83942d705f0c4962",
+            "parentId": "b5ec3d0cd03cc5ed7f9e5abc",
+            "slotId": "right_side_plate"
+        }, {
             "_id": "972beb8aeb39edac5fb66ab6",
             "_tpl": "5fd4c5477a8d854fa0105061",
             "parentId": "hideout",
@@ -3451,8 +3053,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c5194f82e7a5f0cfd41d0e45",
             "_tpl": "5e4abc1f86f774069619fbaa",
             "parentId": "hideout",
@@ -3463,8 +3064,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "343f9a2592db24c7367d9bb0",
             "_tpl": "5d5d8ca986f7742798716522",
             "parentId": "hideout",
@@ -3475,8 +3075,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "4894ed01ee4ff84e2f01a9ad",
             "_tpl": "6034d0230ca681766b6a0fb5",
             "parentId": "hideout",
@@ -3487,8 +3086,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "abf5d1323a7beedbedef4e7a",
             "_tpl": "59e7643b86f7742cbf2c109a",
             "parentId": "hideout",
@@ -3499,8 +3097,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "60dfff92fdfddbb41fe52ebb",
             "_tpl": "5c0e3eb886f7742015526062",
             "parentId": "hideout",
@@ -3511,32 +3108,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c56",
-          "_tpl": "65764a4cd8537eb26a0355ee",
-          "parentId": "60dfff92fdfddbb41fe52ebb",
-          "slotId": "Soft_armor_front"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c57",
-          "_tpl": "65764bc22bc38ef78e076485",
-          "parentId": "60dfff92fdfddbb41fe52ebb",
-          "slotId": "Soft_armor_back"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c58",
-          "_tpl": "65764c39526e320fbe035777",
-          "parentId": "60dfff92fdfddbb41fe52ebb",
-          "slotId": "Collar"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c59",
-          "_tpl": "65764c6b526e320fbe03577b",
-          "parentId": "60dfff92fdfddbb41fe52ebb",
-          "slotId": "Groin"
-        },
-        {
+        }, {
+            "_id": "666fbf8a05a4eac710002c56",
+            "_tpl": "65764a4cd8537eb26a0355ee",
+            "parentId": "60dfff92fdfddbb41fe52ebb",
+            "slotId": "Soft_armor_front"
+        }, {
+            "_id": "666fbf8a05a4eac710002c57",
+            "_tpl": "65764bc22bc38ef78e076485",
+            "parentId": "60dfff92fdfddbb41fe52ebb",
+            "slotId": "Soft_armor_back"
+        }, {
+            "_id": "666fbf8a05a4eac710002c58",
+            "_tpl": "65764c39526e320fbe035777",
+            "parentId": "60dfff92fdfddbb41fe52ebb",
+            "slotId": "Collar"
+        }, {
+            "_id": "666fbf8a05a4eac710002c59",
+            "_tpl": "65764c6b526e320fbe03577b",
+            "parentId": "60dfff92fdfddbb41fe52ebb",
+            "slotId": "Groin"
+        }, {
             "_id": "d0bf8b7df20d2d5e41d243dd",
             "_tpl": "5929a2a086f7744f4b234d43",
             "parentId": "hideout",
@@ -3547,8 +3139,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "1a97bc5decbca0f037a80aff",
             "_tpl": "5e4abfed86f77406a2713cf7",
             "parentId": "hideout",
@@ -3559,8 +3150,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "5fd0fa716e0cae2f43cfbdde",
             "_tpl": "6034cf5fffd42c541047f72e",
             "parentId": "hideout",
@@ -3571,8 +3161,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "cfe8a8bde180b1eaec91ed90",
             "_tpl": "5c0e9f2c86f77432297fe0a3",
             "parentId": "hideout",
@@ -3583,8 +3172,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "6985d7dca6cba924cab9f3ee",
             "_tpl": "5ca20abf86f77418567a43f2",
             "parentId": "hideout",
@@ -3595,8 +3183,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7936d525b99ffb703cd8ea29",
             "_tpl": "5c0e6a1586f77404597b4965",
             "parentId": "hideout",
@@ -3607,8 +3194,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a3ef1d5febe5abf65dcedcb8",
             "_tpl": "5c0e446786f7742013381639",
             "parentId": "hideout",
@@ -3619,32 +3205,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c5a",
-          "_tpl": "657087577f6d4590ac0d2109",
-          "parentId": "a3ef1d5febe5abf65dcedcb8",
-          "slotId": "Soft_armor_front"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c5b",
-          "_tpl": "6570880f4a747dbb63005ee5",
-          "parentId": "a3ef1d5febe5abf65dcedcb8",
-          "slotId": "Soft_armor_back"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c5c",
-          "_tpl": "65708afe4a747dbb63005eee",
-          "parentId": "a3ef1d5febe5abf65dcedcb8",
-          "slotId": "Collar"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c5d",
-          "_tpl": "65708b4c4a747dbb63005ef3",
-          "parentId": "a3ef1d5febe5abf65dcedcb8",
-          "slotId": "Groin"
-        },
-        {
+        }, {
+            "_id": "666fbf8a05a4eac710002c5a",
+            "_tpl": "657087577f6d4590ac0d2109",
+            "parentId": "a3ef1d5febe5abf65dcedcb8",
+            "slotId": "Soft_armor_front"
+        }, {
+            "_id": "666fbf8a05a4eac710002c5b",
+            "_tpl": "6570880f4a747dbb63005ee5",
+            "parentId": "a3ef1d5febe5abf65dcedcb8",
+            "slotId": "Soft_armor_back"
+        }, {
+            "_id": "666fbf8a05a4eac710002c5c",
+            "_tpl": "65708afe4a747dbb63005eee",
+            "parentId": "a3ef1d5febe5abf65dcedcb8",
+            "slotId": "Collar"
+        }, {
+            "_id": "666fbf8a05a4eac710002c5d",
+            "_tpl": "65708b4c4a747dbb63005ef3",
+            "parentId": "a3ef1d5febe5abf65dcedcb8",
+            "slotId": "Groin"
+        }, {
             "_id": "ac9a2aac2ecfcf9d6ab6fd08",
             "_tpl": "5fd4c60f875c30179f5d04c2",
             "parentId": "hideout",
@@ -3655,8 +3236,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bda6e7e5ff8a22da30aa8ea1",
             "_tpl": "5d5d85c586f774279a21cbdb",
             "parentId": "hideout",
@@ -3667,8 +3247,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "acdf6c8f8ad9de7bdda3eb21",
             "_tpl": "5f5f41f56760b4138443b352",
             "parentId": "hideout",
@@ -3679,8 +3258,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "65d3c74ebed719cd2e7e9eaf",
             "_tpl": "60a6220e953894617404b00a",
             "parentId": "hideout",
@@ -3691,8 +3269,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e1e4be9eb2fb2c7f3dc2bc5c",
             "_tpl": "5d5d646386f7742797261fd9",
             "parentId": "hideout",
@@ -3703,32 +3280,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c5e",
-          "_tpl": "65764e1e2bc38ef78e076489",
-          "parentId": "e1e4be9eb2fb2c7f3dc2bc5c",
-          "slotId": "Soft_armor_front"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c5f",
-          "_tpl": "65764fae2bc38ef78e07648d",
-          "parentId": "e1e4be9eb2fb2c7f3dc2bc5c",
-          "slotId": "Soft_armor_back"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c60",
-          "_tpl": "6576504b526e320fbe035783",
-          "parentId": "e1e4be9eb2fb2c7f3dc2bc5c",
-          "slotId": "Groin"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c61",
-          "_tpl": "6576500f526e320fbe03577f",
-          "parentId": "e1e4be9eb2fb2c7f3dc2bc5c",
-          "slotId": "Groin_back"
-        },
-        {
+        }, {
+            "_id": "666fbf8a05a4eac710002c5e",
+            "_tpl": "65764e1e2bc38ef78e076489",
+            "parentId": "e1e4be9eb2fb2c7f3dc2bc5c",
+            "slotId": "Soft_armor_front"
+        }, {
+            "_id": "666fbf8a05a4eac710002c5f",
+            "_tpl": "65764fae2bc38ef78e07648d",
+            "parentId": "e1e4be9eb2fb2c7f3dc2bc5c",
+            "slotId": "Soft_armor_back"
+        }, {
+            "_id": "666fbf8a05a4eac710002c60",
+            "_tpl": "6576504b526e320fbe035783",
+            "parentId": "e1e4be9eb2fb2c7f3dc2bc5c",
+            "slotId": "Groin"
+        }, {
+            "_id": "666fbf8a05a4eac710002c61",
+            "_tpl": "6576500f526e320fbe03577f",
+            "parentId": "e1e4be9eb2fb2c7f3dc2bc5c",
+            "slotId": "Groin_back"
+        }, {
             "_id": "6ca566b8cfead979b1a041e1",
             "_tpl": "61bc85697113f767765c7fe7",
             "parentId": "hideout",
@@ -3739,44 +3311,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c62",
-          "_tpl": "6572fc809a866b80ab07eb59",
-          "parentId": "6ca566b8cfead979b1a041e1",
-          "slotId": "Soft_armor_front"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c63",
-          "_tpl": "6572fc8c9a866b80ab07eb5d",
-          "parentId": "6ca566b8cfead979b1a041e1",
-          "slotId": "Soft_armor_back"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c64",
-          "_tpl": "6572fc989a866b80ab07eb61",
-          "parentId": "6ca566b8cfead979b1a041e1",
-          "slotId": "Soft_armor_left"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c65",
-          "_tpl": "6572fca39a866b80ab07eb65",
-          "parentId": "6ca566b8cfead979b1a041e1",
-          "slotId": "soft_armor_right"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c66",
-          "_tpl": "656fad8c498d1b7e3e071da0",
-          "parentId": "6ca566b8cfead979b1a041e1",
-          "slotId": "Front_plate"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c67",
-          "_tpl": "656fad8c498d1b7e3e071da0",
-          "parentId": "6ca566b8cfead979b1a041e1",
-          "slotId": "Back_plate"
-        },
-        {
+        }, {
+            "_id": "666fbf8a05a4eac710002c62",
+            "_tpl": "6572fc809a866b80ab07eb59",
+            "parentId": "6ca566b8cfead979b1a041e1",
+            "slotId": "Soft_armor_front"
+        }, {
+            "_id": "666fbf8a05a4eac710002c63",
+            "_tpl": "6572fc8c9a866b80ab07eb5d",
+            "parentId": "6ca566b8cfead979b1a041e1",
+            "slotId": "Soft_armor_back"
+        }, {
+            "_id": "666fbf8a05a4eac710002c64",
+            "_tpl": "6572fc989a866b80ab07eb61",
+            "parentId": "6ca566b8cfead979b1a041e1",
+            "slotId": "Soft_armor_left"
+        }, {
+            "_id": "666fbf8a05a4eac710002c65",
+            "_tpl": "6572fca39a866b80ab07eb65",
+            "parentId": "6ca566b8cfead979b1a041e1",
+            "slotId": "soft_armor_right"
+        }, {
+            "_id": "666fbf8a05a4eac710002c66",
+            "_tpl": "656fad8c498d1b7e3e071da0",
+            "parentId": "6ca566b8cfead979b1a041e1",
+            "slotId": "Front_plate"
+        }, {
+            "_id": "666fbf8a05a4eac710002c67",
+            "_tpl": "656fad8c498d1b7e3e071da0",
+            "parentId": "6ca566b8cfead979b1a041e1",
+            "slotId": "Back_plate"
+        }, {
             "_id": "9e0fb0dc0647ee412eccbfb7",
             "_tpl": "5ab8dab586f77441cd04f2a2",
             "parentId": "hideout",
@@ -3787,8 +3352,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c2dd6ddbf2ee14dd90b20e2b",
             "_tpl": "603648ff5a45383c122086ac",
             "parentId": "hideout",
@@ -3799,8 +3363,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c4cc139e00afaab6aaaedef0",
             "_tpl": "5648a69d4bdc2ded0b8b457b",
             "parentId": "hideout",
@@ -3811,8 +3374,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b503dddf3900caaca0e6cc7b",
             "_tpl": "61bcc89aef0f505f0c6cd0fc",
             "parentId": "hideout",
@@ -3823,50 +3385,42 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c68",
-          "_tpl": "6572eb0e55beba16bc04079f",
-          "parentId": "b503dddf3900caaca0e6cc7b",
-          "slotId": "Soft_armor_front"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c69",
-          "_tpl": "6572eb1b04ee6483ef039882",
-          "parentId": "b503dddf3900caaca0e6cc7b",
-          "slotId": "Soft_armor_back"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c6a",
-          "_tpl": "6572eb3004ee6483ef039886",
-          "parentId": "b503dddf3900caaca0e6cc7b",
-          "slotId": "Soft_armor_left"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c6b",
-          "_tpl": "6572eb3b04ee6483ef03988a",
-          "parentId": "b503dddf3900caaca0e6cc7b",
-          "slotId": "soft_armor_right"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c6c",
-          "_tpl": "6572eb865b5eac12f10a03ee",
-          "parentId": "b503dddf3900caaca0e6cc7b",
-          "slotId": "Groin"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c6d",
-          "_tpl": "656fb21fa0dce000a2020f7c",
-          "parentId": "b503dddf3900caaca0e6cc7b",
-          "slotId": "Front_plate"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c6e",
-          "_tpl": "656fb21fa0dce000a2020f7c",
-          "parentId": "b503dddf3900caaca0e6cc7b",
-          "slotId": "Back_plate"
-        },
-        {
+        }, {
+            "_id": "666fbf8a05a4eac710002c68",
+            "_tpl": "6572eb0e55beba16bc04079f",
+            "parentId": "b503dddf3900caaca0e6cc7b",
+            "slotId": "Soft_armor_front"
+        }, {
+            "_id": "666fbf8a05a4eac710002c69",
+            "_tpl": "6572eb1b04ee6483ef039882",
+            "parentId": "b503dddf3900caaca0e6cc7b",
+            "slotId": "Soft_armor_back"
+        }, {
+            "_id": "666fbf8a05a4eac710002c6a",
+            "_tpl": "6572eb3004ee6483ef039886",
+            "parentId": "b503dddf3900caaca0e6cc7b",
+            "slotId": "Soft_armor_left"
+        }, {
+            "_id": "666fbf8a05a4eac710002c6b",
+            "_tpl": "6572eb3b04ee6483ef03988a",
+            "parentId": "b503dddf3900caaca0e6cc7b",
+            "slotId": "soft_armor_right"
+        }, {
+            "_id": "666fbf8a05a4eac710002c6c",
+            "_tpl": "6572eb865b5eac12f10a03ee",
+            "parentId": "b503dddf3900caaca0e6cc7b",
+            "slotId": "Groin"
+        }, {
+            "_id": "666fbf8a05a4eac710002c6d",
+            "_tpl": "656fb21fa0dce000a2020f7c",
+            "parentId": "b503dddf3900caaca0e6cc7b",
+            "slotId": "Front_plate"
+        }, {
+            "_id": "666fbf8a05a4eac710002c6e",
+            "_tpl": "656fb21fa0dce000a2020f7c",
+            "parentId": "b503dddf3900caaca0e6cc7b",
+            "slotId": "Back_plate"
+        }, {
             "_id": "28a2ceba0f658b7cde82e3db",
             "_tpl": "5ab8dced86f774646209ec87",
             "parentId": "hideout",
@@ -3877,44 +3431,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c6f",
-          "_tpl": "6570f6e774d84423df065f21",
-          "parentId": "28a2ceba0f658b7cde82e3db",
-          "slotId": "Soft_armor_front"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c70",
-          "_tpl": "6570f71dd67d0309980a7af8",
-          "parentId": "28a2ceba0f658b7cde82e3db",
-          "slotId": "Soft_armor_back"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c71",
-          "_tpl": "6570f74774d84423df065f25",
-          "parentId": "28a2ceba0f658b7cde82e3db",
-          "slotId": "Soft_armor_left"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c72",
-          "_tpl": "6570f79c4c65ab77a6015121",
-          "parentId": "28a2ceba0f658b7cde82e3db",
-          "slotId": "soft_armor_right"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c73",
-          "_tpl": "656fa25e94b480b8a500c0e0",
-          "parentId": "28a2ceba0f658b7cde82e3db",
-          "slotId": "Front_plate"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c74",
-          "_tpl": "656fa25e94b480b8a500c0e0",
-          "parentId": "28a2ceba0f658b7cde82e3db",
-          "slotId": "Back_plate"
-        },
-        {
+        }, {
+            "_id": "666fbf8a05a4eac710002c6f",
+            "_tpl": "6570f6e774d84423df065f21",
+            "parentId": "28a2ceba0f658b7cde82e3db",
+            "slotId": "Soft_armor_front"
+        }, {
+            "_id": "666fbf8a05a4eac710002c70",
+            "_tpl": "6570f71dd67d0309980a7af8",
+            "parentId": "28a2ceba0f658b7cde82e3db",
+            "slotId": "Soft_armor_back"
+        }, {
+            "_id": "666fbf8a05a4eac710002c71",
+            "_tpl": "6570f74774d84423df065f25",
+            "parentId": "28a2ceba0f658b7cde82e3db",
+            "slotId": "Soft_armor_left"
+        }, {
+            "_id": "666fbf8a05a4eac710002c72",
+            "_tpl": "6570f79c4c65ab77a6015121",
+            "parentId": "28a2ceba0f658b7cde82e3db",
+            "slotId": "soft_armor_right"
+        }, {
+            "_id": "666fbf8a05a4eac710002c73",
+            "_tpl": "656fa25e94b480b8a500c0e0",
+            "parentId": "28a2ceba0f658b7cde82e3db",
+            "slotId": "Front_plate"
+        }, {
+            "_id": "666fbf8a05a4eac710002c74",
+            "_tpl": "656fa25e94b480b8a500c0e0",
+            "parentId": "28a2ceba0f658b7cde82e3db",
+            "slotId": "Back_plate"
+        }, {
             "_id": "5a8ae15552d7bab96f6deefc",
             "_tpl": "592c2d1a86f7746dbe2af32a",
             "parentId": "hideout",
@@ -3925,8 +3472,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "0ff1bc2be0ac63ee6cabfce9",
             "_tpl": "5df8a42886f77412640e2e75",
             "parentId": "hideout",
@@ -3937,8 +3483,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ef6d7cedd2aa50ee8ac348c1",
             "_tpl": "5e9db13186f7742f845ee9d3",
             "parentId": "hideout",
@@ -3949,8 +3494,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "3c9a94be9f1f085be6bf531a",
             "_tpl": "544a5caa4bdc2d1a388b4568",
             "parentId": "hideout",
@@ -3961,38 +3505,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c75",
-          "_tpl": "6570e83223c1f638ef0b0ede",
-          "parentId": "3c9a94be9f1f085be6bf531a",
-          "slotId": "Soft_armor_front"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c76",
-          "_tpl": "6570e87c23c1f638ef0b0ee2",
-          "parentId": "3c9a94be9f1f085be6bf531a",
-          "slotId": "Soft_armor_back"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c77",
-          "_tpl": "6570e90b3a5689d85f08db97",
-          "parentId": "3c9a94be9f1f085be6bf531a",
-          "slotId": "Groin"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c78",
-          "_tpl": "656f9fa0498d1b7e3e071d98",
-          "parentId": "3c9a94be9f1f085be6bf531a",
-          "slotId": "Front_plate"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c79",
-          "_tpl": "656f9fa0498d1b7e3e071d98",
-          "parentId": "3c9a94be9f1f085be6bf531a",
-          "slotId": "Back_plate"
-        },
-        {
+        }, {
+            "_id": "666fbf8a05a4eac710002c75",
+            "_tpl": "6570e83223c1f638ef0b0ede",
+            "parentId": "3c9a94be9f1f085be6bf531a",
+            "slotId": "Soft_armor_front"
+        }, {
+            "_id": "666fbf8a05a4eac710002c76",
+            "_tpl": "6570e87c23c1f638ef0b0ee2",
+            "parentId": "3c9a94be9f1f085be6bf531a",
+            "slotId": "Soft_armor_back"
+        }, {
+            "_id": "666fbf8a05a4eac710002c77",
+            "_tpl": "6570e90b3a5689d85f08db97",
+            "parentId": "3c9a94be9f1f085be6bf531a",
+            "slotId": "Groin"
+        }, {
+            "_id": "666fbf8a05a4eac710002c78",
+            "_tpl": "656f9fa0498d1b7e3e071d98",
+            "parentId": "3c9a94be9f1f085be6bf531a",
+            "slotId": "Front_plate"
+        }, {
+            "_id": "666fbf8a05a4eac710002c79",
+            "_tpl": "656f9fa0498d1b7e3e071d98",
+            "parentId": "3c9a94be9f1f085be6bf531a",
+            "slotId": "Back_plate"
+        }, {
             "_id": "bcaabb55ecbd2dcaf2401b6b",
             "_tpl": "5c0e722886f7740458316a57",
             "parentId": "hideout",
@@ -4003,44 +3541,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c7a",
-          "_tpl": "65730c0e292ecadbfa09ad49",
-          "parentId": "bcaabb55ecbd2dcaf2401b6b",
-          "slotId": "Soft_armor_front"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c7b",
-          "_tpl": "65730c2213a2f660f60bea96",
-          "parentId": "bcaabb55ecbd2dcaf2401b6b",
-          "slotId": "Soft_armor_back"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c7c",
-          "_tpl": "65730c2b292ecadbfa09ad50",
-          "parentId": "bcaabb55ecbd2dcaf2401b6b",
-          "slotId": "Soft_armor_left"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c7d",
-          "_tpl": "65730c35292ecadbfa09ad54",
-          "parentId": "bcaabb55ecbd2dcaf2401b6b",
-          "slotId": "soft_armor_right"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c7e",
-          "_tpl": "656fa0fb498d1b7e3e071d9c",
-          "parentId": "bcaabb55ecbd2dcaf2401b6b",
-          "slotId": "Front_plate"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c7f",
-          "_tpl": "656fa0fb498d1b7e3e071d9c",
-          "parentId": "bcaabb55ecbd2dcaf2401b6b",
-          "slotId": "Back_plate"
-        },
-        {
+        }, {
+            "_id": "666fbf8a05a4eac710002c7a",
+            "_tpl": "65730c0e292ecadbfa09ad49",
+            "parentId": "bcaabb55ecbd2dcaf2401b6b",
+            "slotId": "Soft_armor_front"
+        }, {
+            "_id": "666fbf8a05a4eac710002c7b",
+            "_tpl": "65730c2213a2f660f60bea96",
+            "parentId": "bcaabb55ecbd2dcaf2401b6b",
+            "slotId": "Soft_armor_back"
+        }, {
+            "_id": "666fbf8a05a4eac710002c7c",
+            "_tpl": "65730c2b292ecadbfa09ad50",
+            "parentId": "bcaabb55ecbd2dcaf2401b6b",
+            "slotId": "Soft_armor_left"
+        }, {
+            "_id": "666fbf8a05a4eac710002c7d",
+            "_tpl": "65730c35292ecadbfa09ad54",
+            "parentId": "bcaabb55ecbd2dcaf2401b6b",
+            "slotId": "soft_armor_right"
+        }, {
+            "_id": "666fbf8a05a4eac710002c7e",
+            "_tpl": "656fa0fb498d1b7e3e071d9c",
+            "parentId": "bcaabb55ecbd2dcaf2401b6b",
+            "slotId": "Front_plate"
+        }, {
+            "_id": "666fbf8a05a4eac710002c7f",
+            "_tpl": "656fa0fb498d1b7e3e071d9c",
+            "parentId": "bcaabb55ecbd2dcaf2401b6b",
+            "slotId": "Back_plate"
+        }, {
             "_id": "bcedb51bce8ca8cec38dbe98",
             "_tpl": "60a3c70cde5f453f634816a3",
             "parentId": "hideout",
@@ -4051,62 +3582,52 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c80",
-          "_tpl": "6570fae34c65ab77a6015146",
-          "parentId": "bcedb51bce8ca8cec38dbe98",
-          "slotId": "Soft_armor_front"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c81",
-          "_tpl": "6570fa1f4c65ab77a601512f",
-          "parentId": "bcedb51bce8ca8cec38dbe98",
-          "slotId": "Soft_armor_back"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c82",
-          "_tpl": "6570fb22584a51c23e03251f",
-          "parentId": "bcedb51bce8ca8cec38dbe98",
-          "slotId": "Soft_armor_left"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c83",
-          "_tpl": "6570fb6ad3eefd23430f8c7c",
-          "parentId": "bcedb51bce8ca8cec38dbe98",
-          "slotId": "soft_armor_right"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c84",
-          "_tpl": "6570fb8f4c65ab77a601514d",
-          "parentId": "bcedb51bce8ca8cec38dbe98",
-          "slotId": "Collar"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c85",
-          "_tpl": "6570fbdd74d84423df065f60",
-          "parentId": "bcedb51bce8ca8cec38dbe98",
-          "slotId": "Shoulder_l"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c86",
-          "_tpl": "6570fc41d3eefd23430f8c83",
-          "parentId": "bcedb51bce8ca8cec38dbe98",
-          "slotId": "Shoulder_r"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c87",
-          "_tpl": "656fb21fa0dce000a2020f7c",
-          "parentId": "bcedb51bce8ca8cec38dbe98",
-          "slotId": "Front_plate"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c88",
-          "_tpl": "656fb21fa0dce000a2020f7c",
-          "parentId": "bcedb51bce8ca8cec38dbe98",
-          "slotId": "Back_plate"
-        },
-        {
+        }, {
+            "_id": "666fbf8a05a4eac710002c80",
+            "_tpl": "6570fae34c65ab77a6015146",
+            "parentId": "bcedb51bce8ca8cec38dbe98",
+            "slotId": "Soft_armor_front"
+        }, {
+            "_id": "666fbf8a05a4eac710002c81",
+            "_tpl": "6570fa1f4c65ab77a601512f",
+            "parentId": "bcedb51bce8ca8cec38dbe98",
+            "slotId": "Soft_armor_back"
+        }, {
+            "_id": "666fbf8a05a4eac710002c82",
+            "_tpl": "6570fb22584a51c23e03251f",
+            "parentId": "bcedb51bce8ca8cec38dbe98",
+            "slotId": "Soft_armor_left"
+        }, {
+            "_id": "666fbf8a05a4eac710002c83",
+            "_tpl": "6570fb6ad3eefd23430f8c7c",
+            "parentId": "bcedb51bce8ca8cec38dbe98",
+            "slotId": "soft_armor_right"
+        }, {
+            "_id": "666fbf8a05a4eac710002c84",
+            "_tpl": "6570fb8f4c65ab77a601514d",
+            "parentId": "bcedb51bce8ca8cec38dbe98",
+            "slotId": "Collar"
+        }, {
+            "_id": "666fbf8a05a4eac710002c85",
+            "_tpl": "6570fbdd74d84423df065f60",
+            "parentId": "bcedb51bce8ca8cec38dbe98",
+            "slotId": "Shoulder_l"
+        }, {
+            "_id": "666fbf8a05a4eac710002c86",
+            "_tpl": "6570fc41d3eefd23430f8c83",
+            "parentId": "bcedb51bce8ca8cec38dbe98",
+            "slotId": "Shoulder_r"
+        }, {
+            "_id": "666fbf8a05a4eac710002c87",
+            "_tpl": "656fb21fa0dce000a2020f7c",
+            "parentId": "bcedb51bce8ca8cec38dbe98",
+            "slotId": "Front_plate"
+        }, {
+            "_id": "666fbf8a05a4eac710002c88",
+            "_tpl": "656fb21fa0dce000a2020f7c",
+            "parentId": "bcedb51bce8ca8cec38dbe98",
+            "slotId": "Back_plate"
+        }, {
             "_id": "2a6b7cf8c5ca055c1b6dc4fa",
             "_tpl": "5c0e746986f7741453628fe5",
             "parentId": "hideout",
@@ -4117,32 +3638,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c89",
-          "_tpl": "6570df294cc0d2ab1e05ed74",
-          "parentId": "2a6b7cf8c5ca055c1b6dc4fa",
-          "slotId": "Soft_armor_front"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c8a",
-          "_tpl": "6570df9c615f54368b04fca9",
-          "parentId": "2a6b7cf8c5ca055c1b6dc4fa",
-          "slotId": "Soft_armor_back"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c8b",
-          "_tpl": "656fa0fb498d1b7e3e071d9c",
-          "parentId": "2a6b7cf8c5ca055c1b6dc4fa",
-          "slotId": "Front_plate"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c8c",
-          "_tpl": "656fa0fb498d1b7e3e071d9c",
-          "parentId": "2a6b7cf8c5ca055c1b6dc4fa",
-          "slotId": "Back_plate"
-        },
-        {
+        }, {
+            "_id": "666fbf8a05a4eac710002c89",
+            "_tpl": "6570df294cc0d2ab1e05ed74",
+            "parentId": "2a6b7cf8c5ca055c1b6dc4fa",
+            "slotId": "Soft_armor_front"
+        }, {
+            "_id": "666fbf8a05a4eac710002c8a",
+            "_tpl": "6570df9c615f54368b04fca9",
+            "parentId": "2a6b7cf8c5ca055c1b6dc4fa",
+            "slotId": "Soft_armor_back"
+        }, {
+            "_id": "666fbf8a05a4eac710002c8b",
+            "_tpl": "656fa0fb498d1b7e3e071d9c",
+            "parentId": "2a6b7cf8c5ca055c1b6dc4fa",
+            "slotId": "Front_plate"
+        }, {
+            "_id": "666fbf8a05a4eac710002c8c",
+            "_tpl": "656fa0fb498d1b7e3e071d9c",
+            "parentId": "2a6b7cf8c5ca055c1b6dc4fa",
+            "slotId": "Back_plate"
+        }, {
             "_id": "9f1f6df81a9bab1a5f7bba6b",
             "_tpl": "5d5d87f786f77427997cfaef",
             "parentId": "hideout",
@@ -4153,44 +3669,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c8d",
-          "_tpl": "6570e5100b57c03ec90b970a",
-          "parentId": "9f1f6df81a9bab1a5f7bba6b",
-          "slotId": "Soft_armor_front"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c8e",
-          "_tpl": "6570e479a6560e4ee50c2b02",
-          "parentId": "9f1f6df81a9bab1a5f7bba6b",
-          "slotId": "Soft_armor_back"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c8f",
-          "_tpl": "6570e5674cc0d2ab1e05edbb",
-          "parentId": "9f1f6df81a9bab1a5f7bba6b",
-          "slotId": "Soft_armor_left"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c90",
-          "_tpl": "6570e59b0b57c03ec90b970e",
-          "parentId": "9f1f6df81a9bab1a5f7bba6b",
-          "slotId": "soft_armor_right"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c91",
-          "_tpl": "656f9fa0498d1b7e3e071d98",
-          "parentId": "9f1f6df81a9bab1a5f7bba6b",
-          "slotId": "Front_plate"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c92",
-          "_tpl": "656f9fa0498d1b7e3e071d98",
-          "parentId": "9f1f6df81a9bab1a5f7bba6b",
-          "slotId": "Back_plate"
-        },
-        {
+        }, {
+            "_id": "666fbf8a05a4eac710002c8d",
+            "_tpl": "6570e5100b57c03ec90b970a",
+            "parentId": "9f1f6df81a9bab1a5f7bba6b",
+            "slotId": "Soft_armor_front"
+        }, {
+            "_id": "666fbf8a05a4eac710002c8e",
+            "_tpl": "6570e479a6560e4ee50c2b02",
+            "parentId": "9f1f6df81a9bab1a5f7bba6b",
+            "slotId": "Soft_armor_back"
+        }, {
+            "_id": "666fbf8a05a4eac710002c8f",
+            "_tpl": "6570e5674cc0d2ab1e05edbb",
+            "parentId": "9f1f6df81a9bab1a5f7bba6b",
+            "slotId": "Soft_armor_left"
+        }, {
+            "_id": "666fbf8a05a4eac710002c90",
+            "_tpl": "6570e59b0b57c03ec90b970e",
+            "parentId": "9f1f6df81a9bab1a5f7bba6b",
+            "slotId": "soft_armor_right"
+        }, {
+            "_id": "666fbf8a05a4eac710002c91",
+            "_tpl": "656f9fa0498d1b7e3e071d98",
+            "parentId": "9f1f6df81a9bab1a5f7bba6b",
+            "slotId": "Front_plate"
+        }, {
+            "_id": "666fbf8a05a4eac710002c92",
+            "_tpl": "656f9fa0498d1b7e3e071d98",
+            "parentId": "9f1f6df81a9bab1a5f7bba6b",
+            "slotId": "Back_plate"
+        }, {
             "_id": "8aab4bd4bc42f6dbde6f6e76",
             "_tpl": "5b44cad286f77402a54ae7e5",
             "parentId": "hideout",
@@ -4201,32 +3710,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c93",
-          "_tpl": "6575bc88c6700bd6b40e8a57",
-          "parentId": "8aab4bd4bc42f6dbde6f6e76",
-          "slotId": "Soft_armor_front"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c94",
-          "_tpl": "6575bca0dc9932aed601c5d7",
-          "parentId": "8aab4bd4bc42f6dbde6f6e76",
-          "slotId": "Soft_armor_back"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c95",
-          "_tpl": "656fae5f7c2d57afe200c0d7",
-          "parentId": "8aab4bd4bc42f6dbde6f6e76",
-          "slotId": "Front_plate"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c96",
-          "_tpl": "656fae5f7c2d57afe200c0d7",
-          "parentId": "8aab4bd4bc42f6dbde6f6e76",
-          "slotId": "Back_plate"
-        },
-        {
+        }, {
+            "_id": "666fbf8a05a4eac710002c93",
+            "_tpl": "6575bc88c6700bd6b40e8a57",
+            "parentId": "8aab4bd4bc42f6dbde6f6e76",
+            "slotId": "Soft_armor_front"
+        }, {
+            "_id": "666fbf8a05a4eac710002c94",
+            "_tpl": "6575bca0dc9932aed601c5d7",
+            "parentId": "8aab4bd4bc42f6dbde6f6e76",
+            "slotId": "Soft_armor_back"
+        }, {
+            "_id": "666fbf8a05a4eac710002c95",
+            "_tpl": "656fae5f7c2d57afe200c0d7",
+            "parentId": "8aab4bd4bc42f6dbde6f6e76",
+            "slotId": "Front_plate"
+        }, {
+            "_id": "666fbf8a05a4eac710002c96",
+            "_tpl": "656fae5f7c2d57afe200c0d7",
+            "parentId": "8aab4bd4bc42f6dbde6f6e76",
+            "slotId": "Back_plate"
+        }, {
             "_id": "5ca0dee49bced1007ebd9fca",
             "_tpl": "60a3c68c37ea821725773ef5",
             "parentId": "hideout",
@@ -4237,74 +3741,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c97",
-          "_tpl": "65733312ca0ca984940a2d53",
-          "parentId": "5ca0dee49bced1007ebd9fca",
-          "slotId": "Soft_armor_front"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c98",
-          "_tpl": "657333232cc8dfad2c0a3d97",
-          "parentId": "5ca0dee49bced1007ebd9fca",
-          "slotId": "Soft_armor_back"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c99",
-          "_tpl": "657333302cc8dfad2c0a3d9b",
-          "parentId": "5ca0dee49bced1007ebd9fca",
-          "slotId": "Soft_armor_left"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c9a",
-          "_tpl": "6573333eca0ca984940a2d57",
-          "parentId": "5ca0dee49bced1007ebd9fca",
-          "slotId": "soft_armor_right"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c9b",
-          "_tpl": "6573334aca0ca984940a2d5b",
-          "parentId": "5ca0dee49bced1007ebd9fca",
-          "slotId": "Collar"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c9c",
-          "_tpl": "65733375b7a8d286530e3dd7",
-          "parentId": "5ca0dee49bced1007ebd9fca",
-          "slotId": "Shoulder_l"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c9d",
-          "_tpl": "6573337f2cc8dfad2c0a3da7",
-          "parentId": "5ca0dee49bced1007ebd9fca",
-          "slotId": "Shoulder_r"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c9e",
-          "_tpl": "656fa53d94b480b8a500c0e4",
-          "parentId": "5ca0dee49bced1007ebd9fca",
-          "slotId": "Front_plate"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002c9f",
-          "_tpl": "656fa53d94b480b8a500c0e4",
-          "parentId": "5ca0dee49bced1007ebd9fca",
-          "slotId": "Back_plate"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002ca0",
-          "_tpl": "6557458f83942d705f0c4962",
-          "parentId": "5ca0dee49bced1007ebd9fca",
-          "slotId": "Left_side_plate"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002ca1",
-          "_tpl": "6557458f83942d705f0c4962",
-          "parentId": "5ca0dee49bced1007ebd9fca",
-          "slotId": "Right_side_plate"
-        },
-        {
+        }, {
+            "_id": "666fbf8a05a4eac710002c97",
+            "_tpl": "65733312ca0ca984940a2d53",
+            "parentId": "5ca0dee49bced1007ebd9fca",
+            "slotId": "Soft_armor_front"
+        }, {
+            "_id": "666fbf8a05a4eac710002c98",
+            "_tpl": "657333232cc8dfad2c0a3d97",
+            "parentId": "5ca0dee49bced1007ebd9fca",
+            "slotId": "Soft_armor_back"
+        }, {
+            "_id": "666fbf8a05a4eac710002c99",
+            "_tpl": "657333302cc8dfad2c0a3d9b",
+            "parentId": "5ca0dee49bced1007ebd9fca",
+            "slotId": "Soft_armor_left"
+        }, {
+            "_id": "666fbf8a05a4eac710002c9a",
+            "_tpl": "6573333eca0ca984940a2d57",
+            "parentId": "5ca0dee49bced1007ebd9fca",
+            "slotId": "soft_armor_right"
+        }, {
+            "_id": "666fbf8a05a4eac710002c9b",
+            "_tpl": "6573334aca0ca984940a2d5b",
+            "parentId": "5ca0dee49bced1007ebd9fca",
+            "slotId": "Collar"
+        }, {
+            "_id": "666fbf8a05a4eac710002c9c",
+            "_tpl": "65733375b7a8d286530e3dd7",
+            "parentId": "5ca0dee49bced1007ebd9fca",
+            "slotId": "Shoulder_l"
+        }, {
+            "_id": "666fbf8a05a4eac710002c9d",
+            "_tpl": "6573337f2cc8dfad2c0a3da7",
+            "parentId": "5ca0dee49bced1007ebd9fca",
+            "slotId": "Shoulder_r"
+        }, {
+            "_id": "666fbf8a05a4eac710002c9e",
+            "_tpl": "656fa53d94b480b8a500c0e4",
+            "parentId": "5ca0dee49bced1007ebd9fca",
+            "slotId": "Front_plate"
+        }, {
+            "_id": "666fbf8a05a4eac710002c9f",
+            "_tpl": "656fa53d94b480b8a500c0e4",
+            "parentId": "5ca0dee49bced1007ebd9fca",
+            "slotId": "Back_plate"
+        }, {
+            "_id": "666fbf8a05a4eac710002ca0",
+            "_tpl": "6557458f83942d705f0c4962",
+            "parentId": "5ca0dee49bced1007ebd9fca",
+            "slotId": "Left_side_plate"
+        }, {
+            "_id": "666fbf8a05a4eac710002ca1",
+            "_tpl": "6557458f83942d705f0c4962",
+            "parentId": "5ca0dee49bced1007ebd9fca",
+            "slotId": "Right_side_plate"
+        }, {
             "_id": "bb33afb00f72bfb3cefc91d7",
             "_tpl": "5e4ac41886f77406a511c9a8",
             "parentId": "hideout",
@@ -4315,56 +3807,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fbf8a05a4eac710002ca2",
-          "_tpl": "6575ef599c7cad336508e453",
-          "parentId": "bb33afb00f72bfb3cefc91d7",
-          "slotId": "soft_armor_front"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002ca3",
-          "_tpl": "6575ef6bf6a13a7b7100b093",
-          "parentId": "bb33afb00f72bfb3cefc91d7",
-          "slotId": "soft_armor_back"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002ca4",
-          "_tpl": "6575ef78da698a4e980677eb",
-          "parentId": "bb33afb00f72bfb3cefc91d7",
-          "slotId": "soft_armor_left"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002ca5",
-          "_tpl": "6575ef7f9c7cad336508e457",
-          "parentId": "bb33afb00f72bfb3cefc91d7",
-          "slotId": "soft_armor_right"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002ca6",
-          "_tpl": "656fae5f7c2d57afe200c0d7",
-          "parentId": "bb33afb00f72bfb3cefc91d7",
-          "slotId": "front_plate"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002ca7",
-          "_tpl": "656fae5f7c2d57afe200c0d7",
-          "parentId": "bb33afb00f72bfb3cefc91d7",
-          "slotId": "back_plate"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002ca8",
-          "_tpl": "6557458f83942d705f0c4962",
-          "parentId": "bb33afb00f72bfb3cefc91d7",
-          "slotId": "left_side_plate"
-        },
-        {
-          "_id": "666fbf8a05a4eac710002ca9",
-          "_tpl": "6557458f83942d705f0c4962",
-          "parentId": "bb33afb00f72bfb3cefc91d7",
-          "slotId": "right_side_plate"
-        },
-        {
+        }, {
+            "_id": "666fbf8a05a4eac710002ca2",
+            "_tpl": "6575ef599c7cad336508e453",
+            "parentId": "bb33afb00f72bfb3cefc91d7",
+            "slotId": "soft_armor_front"
+        }, {
+            "_id": "666fbf8a05a4eac710002ca3",
+            "_tpl": "6575ef6bf6a13a7b7100b093",
+            "parentId": "bb33afb00f72bfb3cefc91d7",
+            "slotId": "soft_armor_back"
+        }, {
+            "_id": "666fbf8a05a4eac710002ca4",
+            "_tpl": "6575ef78da698a4e980677eb",
+            "parentId": "bb33afb00f72bfb3cefc91d7",
+            "slotId": "soft_armor_left"
+        }, {
+            "_id": "666fbf8a05a4eac710002ca5",
+            "_tpl": "6575ef7f9c7cad336508e457",
+            "parentId": "bb33afb00f72bfb3cefc91d7",
+            "slotId": "soft_armor_right"
+        }, {
+            "_id": "666fbf8a05a4eac710002ca6",
+            "_tpl": "656fae5f7c2d57afe200c0d7",
+            "parentId": "bb33afb00f72bfb3cefc91d7",
+            "slotId": "front_plate"
+        }, {
+            "_id": "666fbf8a05a4eac710002ca7",
+            "_tpl": "656fae5f7c2d57afe200c0d7",
+            "parentId": "bb33afb00f72bfb3cefc91d7",
+            "slotId": "back_plate"
+        }, {
+            "_id": "666fbf8a05a4eac710002ca8",
+            "_tpl": "6557458f83942d705f0c4962",
+            "parentId": "bb33afb00f72bfb3cefc91d7",
+            "slotId": "left_side_plate"
+        }, {
+            "_id": "666fbf8a05a4eac710002ca9",
+            "_tpl": "6557458f83942d705f0c4962",
+            "parentId": "bb33afb00f72bfb3cefc91d7",
+            "slotId": "right_side_plate"
+        }, {
             "_id": "f2bffb9aadcdbc2965ce79d0",
             "_tpl": "5580223e4bdc2d1c128b457f",
             "parentId": "hideout",
@@ -4375,20 +3858,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "3feddf18587ed753a51eab13",
             "_tpl": "55d447bb4bdc2d892f8b456f",
             "parentId": "f2bffb9aadcdbc2965ce79d0",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "22ddcefaf86c1d1fb0eebbda",
             "_tpl": "611a31ce5b7ffe001b4649d1",
             "parentId": "f2bffb9aadcdbc2965ce79d0",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "f4a96de7cbf7e245cab905ad",
             "_tpl": "60db29ce99594040e04c4a27",
             "parentId": "hideout",
@@ -4399,38 +3879,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f56ef24e9fb62d7669d4ecd0",
             "_tpl": "60dc519adf4c47305f6d410d",
             "parentId": "f4a96de7cbf7e245cab905ad",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "5f76cd7e337c6e8b80ee3dcd",
             "_tpl": "612368f58b401f4f51239b33",
             "parentId": "f4a96de7cbf7e245cab905ad",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "e87ef2cef7fb294aacd4ce38",
             "_tpl": "619d36da53b4d42ee724fae4",
             "parentId": "5f76cd7e337c6e8b80ee3dcd",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "7c7d3072bffdfeb39da7e5a9",
             "_tpl": "612781056f3d944a17348d60",
             "parentId": "f4a96de7cbf7e245cab905ad",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "e6cfefba91a8f1d0b2a83ce7",
             "_tpl": "6123649463849f3d843da7c4",
             "parentId": "f4a96de7cbf7e245cab905ad",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "b6e30b8cb2ccc9cb52c6dddf",
             "_tpl": "5a38e6bac4a2826c6e06d79b",
             "parentId": "hideout",
@@ -4441,26 +3915,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d5916c7bfeb92e715ae951f5",
             "_tpl": "5a38ee51c4a282000c5a955c",
             "parentId": "b6e30b8cb2ccc9cb52c6dddf",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "2fa78acff0ff0bf6fa70d3e6",
             "_tpl": "5a38ef1fc4a282000b1521f6",
             "parentId": "b6e30b8cb2ccc9cb52c6dddf",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "df2ccb23ebf1a0047bce0cab",
             "_tpl": "5a38eecdc4a282329a73b512",
             "parentId": "2fa78acff0ff0bf6fa70d3e6",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "3bec2fb9ecd6b8eceebda42d",
             "_tpl": "5a38ee51c4a282000c5a955c",
             "parentId": "hideout",
@@ -4471,8 +3941,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7aa3924d668adec0b4bdc172",
             "_tpl": "54491c4f4bdc2db1078b4568",
             "parentId": "hideout",
@@ -4483,32 +3952,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "3b44ec0dc6ba433d0847a588",
             "_tpl": "55d4491a4bdc2d882f8b456e",
             "parentId": "7aa3924d668adec0b4bdc172",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "4bfcda05bcfca0226cddab95",
             "_tpl": "55d45d3f4bdc2d972f8b456c",
             "parentId": "7aa3924d668adec0b4bdc172",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "ea409e59708e45cce4b0a8d2",
             "_tpl": "55d484b44bdc2d1d4e8b456d",
             "parentId": "7aa3924d668adec0b4bdc172",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "ddacc1788bffca8baa91bbdb",
             "_tpl": "56083cba4bdc2de22e8b456f",
             "parentId": "7aa3924d668adec0b4bdc172",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "5b3fbcdbec5daf6c8c94ae9d",
             "_tpl": "5e870397991fd70db46995c8",
             "parentId": "hideout",
@@ -4519,44 +3983,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f1dfccf8323ac261c33d5bf1",
             "_tpl": "5e87071478f43e51ca2de5e1",
             "parentId": "5b3fbcdbec5daf6c8c94ae9d",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "2f233fecb9fbc1b02aac1d3c",
             "_tpl": "5e8708d4ae379e67d22e0102",
             "parentId": "f1dfccf8323ac261c33d5bf1",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "5ceee5ccd1325abc0a1ea8f7",
             "_tpl": "5e87076ce2db31558c75a11d",
             "parentId": "5b3fbcdbec5daf6c8c94ae9d",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "057b9f3cb75efe177f13ea5c",
             "_tpl": "5e87080c81c4ed43e83cefda",
             "parentId": "5b3fbcdbec5daf6c8c94ae9d",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "c0ed5aa80aa1e66dceeaae7f",
             "_tpl": "5e87116b81c4ed43e83cefdd",
             "parentId": "5b3fbcdbec5daf6c8c94ae9d",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "9cfefb1e5b0bf23f5cedce04",
             "_tpl": "5e87114fe2db31558c75a120",
             "parentId": "5b3fbcdbec5daf6c8c94ae9d",
             "slotId": "mod_mount"
-        },
-        {
+        }, {
             "_id": "e39a291deaefa46f7d9ea3d1",
             "_tpl": "5e87080c81c4ed43e83cefda",
             "parentId": "hideout",
@@ -4567,8 +4024,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a909df3fed26210f205d7bb7",
             "_tpl": "56deee15d2720bee328b4567",
             "parentId": "hideout",
@@ -4579,8 +4035,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "caff57e18ced0af048ead93b",
             "_tpl": "5a7828548dc32e5a9c28b516",
             "parentId": "hideout",
@@ -4591,32 +4046,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "0bd5d921d4046b9def2dcf60",
             "_tpl": "5a787f7ac5856700177af660",
             "parentId": "caff57e18ced0af048ead93b",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "46f63b2ceeacebc0c55506ea",
             "_tpl": "5a788089c5856700142fdd9c",
             "parentId": "caff57e18ced0af048ead93b",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "d280fa52cf3852dfdda7d4fb",
             "_tpl": "5a7882dcc5856700177af662",
             "parentId": "caff57e18ced0af048ead93b",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "35ad945bcc2eb72d46f2ac86",
             "_tpl": "5a7880d0c5856700142fdd9d",
             "parentId": "caff57e18ced0af048ead93b",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "bcfb7e5df21c3beeacec529e",
             "_tpl": "606dae0ab0e443224b421bb7",
             "parentId": "hideout",
@@ -4627,32 +4077,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "81ce71c2e5e648cc467ed0b9",
             "_tpl": "6076c1b9f2cb2e02a42acedc",
             "parentId": "bcfb7e5df21c3beeacec529e",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "16cb631be5b64b8cdfd31146",
             "_tpl": "607d5aa50494a626335e12ed",
             "parentId": "bcfb7e5df21c3beeacec529e",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "86b18ee26d220b3c10a41ffe",
             "_tpl": "6076c87f232e5a31c233d50e",
             "parentId": "bcfb7e5df21c3beeacec529e",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "9bba1adab0c87276730ae979",
             "_tpl": "607d5a891246154cad35d6aa",
             "parentId": "bcfb7e5df21c3beeacec529e",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "81b87eca6e8eab6183ba05a6",
             "_tpl": "5a7882dcc5856700177af662",
             "parentId": "hideout",
@@ -4663,8 +4108,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "14fcaf39a7b147e851f54ab8",
             "_tpl": "5882163e24597758206fee8c",
             "parentId": "hideout",
@@ -4675,8 +4119,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b4ab4f3fb9a1c8d3fe4be6db",
             "_tpl": "576165642459773c7a400233",
             "parentId": "hideout",
@@ -4687,50 +4130,42 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e31e5bd424af092afaeca4b7",
             "_tpl": "576169e62459773c69055191",
             "parentId": "b4ab4f3fb9a1c8d3fe4be6db",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "5d92d5d3fec47a3d3f749dfc",
             "_tpl": "576167ab2459773cad038c43",
             "parentId": "b4ab4f3fb9a1c8d3fe4be6db",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "fdf6d063eda6d5fdf09eabe4",
             "_tpl": "5649ade84bdc2d1b2b8b4587",
             "parentId": "b4ab4f3fb9a1c8d3fe4be6db",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "09f09efe153ebd5bc0210fee",
             "_tpl": "57616c112459773cce774d66",
             "parentId": "b4ab4f3fb9a1c8d3fe4be6db",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "28586bc289cfcf8f82bff67e",
             "_tpl": "57a9b9ce2459770ee926038d",
             "parentId": "b4ab4f3fb9a1c8d3fe4be6db",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "2f1bcabcdecdd03afa34dbb3",
             "_tpl": "57616ca52459773c69055192",
             "parentId": "b4ab4f3fb9a1c8d3fe4be6db",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "2a4dc5ca7dcd9dca51f5be58",
             "_tpl": "57616a9e2459773c7a400234",
             "parentId": "b4ab4f3fb9a1c8d3fe4be6db",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "0644e04adbb0df7b7e1adfe8",
             "_tpl": "5e848cc2988a8701445df1e8",
             "parentId": "hideout",
@@ -4741,38 +4176,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e9cf91afe02a616bb4fa0852",
             "_tpl": "5e848d1c264f7c180b5e35a9",
             "parentId": "0644e04adbb0df7b7e1adfe8",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "aafacdb7fe33fab16dac92dd",
             "_tpl": "5e848d51e4dbc5266a4ec63b",
             "parentId": "0644e04adbb0df7b7e1adfe8",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "aeaecba25ce6cf21aec7e2d8",
             "_tpl": "5f647d9f8499b57dc40ddb93",
             "parentId": "0644e04adbb0df7b7e1adfe8",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "f3dfc2a74fff9d50f04274ab",
             "_tpl": "5e848d99865c0f329958c83b",
             "parentId": "0644e04adbb0df7b7e1adfe8",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "21c9471c9cebbba8d3dd48de",
             "_tpl": "5e848dc4e4dbc5266a4ec63d",
             "parentId": "f3dfc2a74fff9d50f04274ab",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "62baccaf0cb7a0dd6efbcff8",
             "_tpl": "57616a9e2459773c7a400234",
             "parentId": "hideout",
@@ -4783,8 +4212,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a4b0cbb6ae80ca76a5ad2afa",
             "_tpl": "5f647d9f8499b57dc40ddb93",
             "parentId": "hideout",
@@ -4795,8 +4223,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "9d5fc650ffb2dadbae0af289",
             "_tpl": "5580223e4bdc2d1c128b457f",
             "parentId": "hideout",
@@ -4807,20 +4234,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c309c77e2def5eaaa0856acc",
             "_tpl": "55d447bb4bdc2d892f8b456f",
             "parentId": "9d5fc650ffb2dadbae0af289",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "e9a08ed00efeafb6ce2f0b19",
             "_tpl": "611a31ce5b7ffe001b4649d1",
             "parentId": "9d5fc650ffb2dadbae0af289",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "b60d3d77d62c4408f924a38c",
             "_tpl": "60db29ce99594040e04c4a27",
             "parentId": "hideout",
@@ -4831,38 +4255,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e684da084edcdcd9581aeefd",
             "_tpl": "60dc519adf4c47305f6d410d",
             "parentId": "b60d3d77d62c4408f924a38c",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "bfc4b7e63da74eedfbad6059",
             "_tpl": "612368f58b401f4f51239b33",
             "parentId": "b60d3d77d62c4408f924a38c",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "41f1fe2509a43aec084be2fa",
             "_tpl": "619d36da53b4d42ee724fae4",
             "parentId": "bfc4b7e63da74eedfbad6059",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "e8f04ff0b08da3dcee8cceed",
             "_tpl": "612781056f3d944a17348d60",
             "parentId": "b60d3d77d62c4408f924a38c",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "d98feeeeabe1b83b3ddef8c5",
             "_tpl": "6123649463849f3d843da7c4",
             "parentId": "b60d3d77d62c4408f924a38c",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "2fcbee555002fa95add0cde5",
             "_tpl": "5a38e6bac4a2826c6e06d79b",
             "parentId": "hideout",
@@ -4873,26 +4291,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7922127aaff765502147ae4d",
             "_tpl": "5a38ee51c4a282000c5a955c",
             "parentId": "2fcbee555002fa95add0cde5",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "d05412fda9f305dae51ae4af",
             "_tpl": "5a38ef1fc4a282000b1521f6",
             "parentId": "2fcbee555002fa95add0cde5",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "b73c9bebda7547e4fab3a1ec",
             "_tpl": "5a38eecdc4a282329a73b512",
             "parentId": "d05412fda9f305dae51ae4af",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "e7dba0b556bbdedd48bb3efc",
             "_tpl": "54491c4f4bdc2db1078b4568",
             "parentId": "hideout",
@@ -4903,32 +4317,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c06aaafa8de0cae8a7a0eeee",
             "_tpl": "55d4491a4bdc2d882f8b456e",
             "parentId": "e7dba0b556bbdedd48bb3efc",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "b1bbda5a36ea5efffea1b518",
             "_tpl": "55d45d3f4bdc2d972f8b456c",
             "parentId": "e7dba0b556bbdedd48bb3efc",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "d4a98fe8ae6a3fcfcf6521fd",
             "_tpl": "55d484b44bdc2d1d4e8b456d",
             "parentId": "e7dba0b556bbdedd48bb3efc",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "9ae8eb0ac6e0e7eb7fb7aa39",
             "_tpl": "56083cba4bdc2de22e8b456f",
             "parentId": "e7dba0b556bbdedd48bb3efc",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "de565b1ba801acabcd28247d",
             "_tpl": "5e870397991fd70db46995c8",
             "parentId": "hideout",
@@ -4939,44 +4348,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d7eeb8aa9c13a2d5fbdca9cc",
             "_tpl": "5e87071478f43e51ca2de5e1",
             "parentId": "de565b1ba801acabcd28247d",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "dc4c2914646df7ec52baac11",
             "_tpl": "5e8708d4ae379e67d22e0102",
             "parentId": "d7eeb8aa9c13a2d5fbdca9cc",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "b1a1e6f2be5886a16b75d466",
             "_tpl": "5e87076ce2db31558c75a11d",
             "parentId": "de565b1ba801acabcd28247d",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "61c72cbe722bb4c54d4bef3e",
             "_tpl": "5e87080c81c4ed43e83cefda",
             "parentId": "de565b1ba801acabcd28247d",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "afcfe6acf6bfadfdefdcfbba",
             "_tpl": "5e87116b81c4ed43e83cefdd",
             "parentId": "de565b1ba801acabcd28247d",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "5efc8dd460e7431beb104bb5",
             "_tpl": "5e87114fe2db31558c75a120",
             "parentId": "de565b1ba801acabcd28247d",
             "slotId": "mod_mount"
-        },
-        {
+        }, {
             "_id": "6e8a643bca8daa84dbacabbc",
             "_tpl": "5a7828548dc32e5a9c28b516",
             "parentId": "hideout",
@@ -4987,32 +4389,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b2212ceb5fcf954cdaf69692",
             "_tpl": "5a787f7ac5856700177af660",
             "parentId": "6e8a643bca8daa84dbacabbc",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "502708aefb2a1ebdc974a7e3",
             "_tpl": "5a788089c5856700142fdd9c",
             "parentId": "6e8a643bca8daa84dbacabbc",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "0e47792501b1e939010a413e",
             "_tpl": "5a7882dcc5856700177af662",
             "parentId": "6e8a643bca8daa84dbacabbc",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "8bfbf3f47cbab29f76065c4d",
             "_tpl": "5a7880d0c5856700142fdd9d",
             "parentId": "6e8a643bca8daa84dbacabbc",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "fd4b6e085dacd9ded83fc8f6",
             "_tpl": "606dae0ab0e443224b421bb7",
             "parentId": "hideout",
@@ -5023,32 +4420,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "4c1532c5cf2b38934c4d245f",
             "_tpl": "6076c1b9f2cb2e02a42acedc",
             "parentId": "fd4b6e085dacd9ded83fc8f6",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "9afe77d390fd3d22ee8cf8dc",
             "_tpl": "607d5aa50494a626335e12ed",
             "parentId": "fd4b6e085dacd9ded83fc8f6",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "b5ae905b63360db1cca2db5b",
             "_tpl": "6076c87f232e5a31c233d50e",
             "parentId": "fd4b6e085dacd9ded83fc8f6",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "a261a3bb532adad0938bfa1e",
             "_tpl": "607d5a891246154cad35d6aa",
             "parentId": "fd4b6e085dacd9ded83fc8f6",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "1dcacae3060cacdda409dd3b",
             "_tpl": "56dee2bdd2720bc8328b4567",
             "parentId": "hideout",
@@ -5059,32 +4451,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e8461ccf7cedfe07f102e3d9",
             "_tpl": "56deec93d2720bec348b4568",
             "parentId": "1dcacae3060cacdda409dd3b",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "14eea5ae83dc29affeb02fae",
             "_tpl": "56deed6ed2720b4c698b4583",
             "parentId": "1dcacae3060cacdda409dd3b",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "422f184d852d6fdc6a7dacfc",
             "_tpl": "56deee15d2720bee328b4567",
             "parentId": "1dcacae3060cacdda409dd3b",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "0a2ff4f491adefe6f8aaea9f",
             "_tpl": "56083be64bdc2d20478b456f",
             "parentId": "1dcacae3060cacdda409dd3b",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "7be6cf2fbddcdc064d19f3d8",
             "_tpl": "56dee2bdd2720bc8328b4567",
             "parentId": "hideout",
@@ -5095,32 +4482,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "155fdb7f50962d93a87da484",
             "_tpl": "56deec93d2720bec348b4568",
             "parentId": "7be6cf2fbddcdc064d19f3d8",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "48c0acbaafc7debae5b0beee",
             "_tpl": "56deed6ed2720b4c698b4583",
             "parentId": "7be6cf2fbddcdc064d19f3d8",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "5fa742aeeb532d8079daa13f",
             "_tpl": "56deee15d2720bee328b4567",
             "parentId": "7be6cf2fbddcdc064d19f3d8",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "eed4bdf79dbb1c3dbb0cff39",
             "_tpl": "56083be64bdc2d20478b456f",
             "parentId": "7be6cf2fbddcdc064d19f3d8",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "eedeeaa88d99b468cfe8c9db",
             "_tpl": "576165642459773c7a400233",
             "parentId": "hideout",
@@ -5131,50 +4513,42 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ff85324997bd3f0cdc69ab1b",
             "_tpl": "576169e62459773c69055191",
             "parentId": "eedeeaa88d99b468cfe8c9db",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "0f987afbefdc9fe2effc3beb",
             "_tpl": "576167ab2459773cad038c43",
             "parentId": "eedeeaa88d99b468cfe8c9db",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "80d1f7093553667ccff7bf7d",
             "_tpl": "5649ade84bdc2d1b2b8b4587",
             "parentId": "eedeeaa88d99b468cfe8c9db",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "8fbfd7e3203054faffe91cbf",
             "_tpl": "57616c112459773cce774d66",
             "parentId": "eedeeaa88d99b468cfe8c9db",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "6a85d659e0fe3c722dba40ee",
             "_tpl": "57a9b9ce2459770ee926038d",
             "parentId": "eedeeaa88d99b468cfe8c9db",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "3b1fcc7c30b2c9cd4dd2d23f",
             "_tpl": "57616ca52459773c69055192",
             "parentId": "eedeeaa88d99b468cfe8c9db",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "b0d547eac182e1d1ce1ae9ae",
             "_tpl": "57616a9e2459773c7a400234",
             "parentId": "eedeeaa88d99b468cfe8c9db",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "befe0e3d6b6187afc6bed13d",
             "_tpl": "5e848cc2988a8701445df1e8",
             "parentId": "hideout",
@@ -5185,38 +4559,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fcce3f036f2b6b4bfb26045e",
             "_tpl": "5e848d1c264f7c180b5e35a9",
             "parentId": "befe0e3d6b6187afc6bed13d",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "ab5b5afdb3f18dcff8a00f9a",
             "_tpl": "5e848d51e4dbc5266a4ec63b",
             "parentId": "befe0e3d6b6187afc6bed13d",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "6b4ce9a3c0acbaed04141601",
             "_tpl": "5f647d9f8499b57dc40ddb93",
             "parentId": "befe0e3d6b6187afc6bed13d",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "2dbaeffbdaffdb97ecab14ad",
             "_tpl": "5e848d99865c0f329958c83b",
             "parentId": "befe0e3d6b6187afc6bed13d",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "62b2cc9c0fbe0ff25eef78d0",
             "_tpl": "5e848dc4e4dbc5266a4ec63d",
             "parentId": "2dbaeffbdaffdb97ecab14ad",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "aecaeaaa617a6a05bb821bbd",
             "_tpl": "64b8ee384b75259c590fa89b",
             "parentId": "hideout",
@@ -5227,8 +4595,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "087717cededfbc19aeff9c37",
             "_tpl": "64b8ee384b75259c590fa89b",
             "parentId": "hideout",
@@ -5239,8 +4606,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "623aa1c90154a75c100edff9",
             "_tpl": "572b7adb24597762ae139821",
             "parentId": "hideout",
@@ -5251,8 +4617,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "89fc36ba93333ceddffbbde8",
             "_tpl": "572b7adb24597762ae139821",
             "parentId": "hideout",
@@ -5263,8 +4628,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "eff24cfec6c89e39dfacfddb",
             "_tpl": "64be7095047e826eae02b0c1",
             "parentId": "hideout",
@@ -5275,8 +4639,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "56b4fdb5172ed0f32bcdfea3",
             "_tpl": "64be7095047e826eae02b0c1",
             "parentId": "hideout",
@@ -5287,8 +4650,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fdafbace8bbf37ceedd73095",
             "_tpl": "5fd4c4fa16cac650092f6771",
             "parentId": "hideout",
@@ -5299,8 +4661,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "afac1b2faff7b091519bcb09",
             "_tpl": "5fd4c4fa16cac650092f6771",
             "parentId": "hideout",
@@ -5311,8 +4672,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "af9861dc3f89985ecf89a4a9",
             "_tpl": "64be7110bf597ba84a0a41ea",
             "parentId": "hideout",
@@ -5323,8 +4683,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a81c21e4ef358ce073b64b61",
             "_tpl": "64be7110bf597ba84a0a41ea",
             "parentId": "hideout",
@@ -5335,8 +4694,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "4ffda1ff3ccba63e3f39ebad",
             "_tpl": "63611865ba5b90db0c0399d1",
             "parentId": "hideout",
@@ -5347,8 +4705,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "3ce1e4fd4a2ca2fddaf1ef24",
             "_tpl": "63611865ba5b90db0c0399d1",
             "parentId": "hideout",
@@ -5359,8 +4716,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "956afc80c1f135f7d0c0cbe9",
             "_tpl": "5b44c8ea86f7742d1627baf1",
             "parentId": "hideout",
@@ -5371,8 +4727,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e99ecee55633440e3feff2d0",
             "_tpl": "5b44c8ea86f7742d1627baf1",
             "parentId": "hideout",
@@ -5383,8 +4738,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "acebc7ca3a8ac16ce17df0aa",
             "_tpl": "60a621c49c197e4e8c4455e6",
             "parentId": "hideout",
@@ -5395,8 +4749,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e3a7b67a679103cbc4cb9c00",
             "_tpl": "60a621c49c197e4e8c4455e6",
             "parentId": "hideout",
@@ -5407,8 +4760,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "db976b5c10f48fd4b0caccba",
             "_tpl": "6040dd4ddcf9592f401632d2",
             "parentId": "hideout",
@@ -5419,8 +4771,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ddd1dbe15b4468ac443df650",
             "_tpl": "6040dd4ddcf9592f401632d2",
             "parentId": "hideout",
@@ -5431,8 +4782,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a08fca03a1dfd7a1f5bdddfb",
             "_tpl": "628cd624459354321c4b7fa2",
             "parentId": "hideout",
@@ -5443,20 +4793,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "10f1eeeca768e4e3c425a761",
             "_tpl": "64afdcb83efdfea28601d041",
             "parentId": "a08fca03a1dfd7a1f5bdddfb",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "eabbb3b2a82aabc44e957cdb",
             "_tpl": "64afdcb83efdfea28601d041",
             "parentId": "a08fca03a1dfd7a1f5bdddfb",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "dd05d9eaa23f4dbca40fdf08",
             "_tpl": "628d0618d1ba6e4fa07ce5a4",
             "parentId": "hideout",
@@ -5467,44 +4814,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ba6cfee85da734b61bd65ded",
             "_tpl": "64afdcb83efdfea28601d041",
             "parentId": "dd05d9eaa23f4dbca40fdf08",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "daa8b4c00ff13d2b3dbdf1fa",
             "_tpl": "657322a4cea9255e21023651",
             "parentId": "dd05d9eaa23f4dbca40fdf08",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "0f120bd83daaff5cfacbfdfd",
             "_tpl": "6570f3890b4ae5847f060dad",
             "parentId": "dd05d9eaa23f4dbca40fdf08",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "741026a3cee0bff8f8126031",
             "_tpl": "6570f3bb0b4ae5847f060db2",
             "parentId": "dd05d9eaa23f4dbca40fdf08",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "a3676b91e74eabd9aaddf46b",
             "_tpl": "656fb0bd7c2d57afe200c0dc",
             "parentId": "dd05d9eaa23f4dbca40fdf08",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "3dfff94da3d0663f957f2ba6",
             "_tpl": "656fb0bd7c2d57afe200c0dc",
             "parentId": "dd05d9eaa23f4dbca40fdf08",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "2c73afd9cdfbc0562e5f4115",
             "_tpl": "628dc750b910320f4c27a732",
             "parentId": "hideout",
@@ -5515,50 +4855,42 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d3d0ffc43220a8e8d0ebaa9c",
             "_tpl": "6572f1ca4c8d903cc60c874e",
             "parentId": "2c73afd9cdfbc0562e5f4115",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "4dee2d8dd1d243016d1e2e53",
             "_tpl": "6572f1d60103b4a3270332db",
             "parentId": "2c73afd9cdfbc0562e5f4115",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "01a90cadc60e86c7bbcafda2",
             "_tpl": "6572f1e10103b4a3270332df",
             "parentId": "2c73afd9cdfbc0562e5f4115",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "7cccd2f844aacd34e6e7a7be",
             "_tpl": "6572f1edea457732140ce875",
             "parentId": "2c73afd9cdfbc0562e5f4115",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "cfdb65868cf680a8b5ffaa9c",
             "_tpl": "656fa25e94b480b8a500c0e0",
             "parentId": "2c73afd9cdfbc0562e5f4115",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "02cbb1081ad726ec4aabc72b",
             "_tpl": "656fa25e94b480b8a500c0e0",
             "parentId": "2c73afd9cdfbc0562e5f4115",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "eafa8ad06defabb08dbe3eeb",
             "_tpl": "6572f1f7ea457732140ce879",
             "parentId": "2c73afd9cdfbc0562e5f4115",
             "slotId": "Groin"
-        },
-        {
+        }, {
             "_id": "7afc02b5923ad5c054bd79b6",
             "_tpl": "639343fce101f4caa40a4ef3",
             "parentId": "hideout",
@@ -5569,44 +4901,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ff237fc0b56cf37e970c9c76",
             "_tpl": "6573101e292ecadbfa09b389",
             "parentId": "7afc02b5923ad5c054bd79b6",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "aa4e7e3ab4ae99f46bdb36ed",
             "_tpl": "6573102b292ecadbfa09b38d",
             "parentId": "7afc02b5923ad5c054bd79b6",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "5f37e53b4accb32855aeeaa2",
             "_tpl": "65731038292ecadbfa09b391",
             "parentId": "7afc02b5923ad5c054bd79b6",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "b248637adabb643ee17903e6",
             "_tpl": "65731045f31d5be00e08a75a",
             "parentId": "7afc02b5923ad5c054bd79b6",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "64e98a7cdfdfcb95f7362743",
             "_tpl": "656fad8c498d1b7e3e071da0",
             "parentId": "7afc02b5923ad5c054bd79b6",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "3b8f41d68d6a19dccaeaca8f",
             "_tpl": "656fad8c498d1b7e3e071da0",
             "parentId": "7afc02b5923ad5c054bd79b6",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "7cb4be3b3adb4f7617eb8a4a",
             "_tpl": "64a536392d2c4e6e970f4121",
             "parentId": "hideout",
@@ -5617,32 +4942,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "eeacff4a2abfe2abeb800bce",
             "_tpl": "6570653e89fd4926380b733e",
             "parentId": "7cb4be3b3adb4f7617eb8a4a",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "5a5a46ecb5cf14e3bf5103fd",
             "_tpl": "6570658a89fd4926380b7346",
             "parentId": "7cb4be3b3adb4f7617eb8a4a",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "b1f47abd609bcc06e11fda41",
             "_tpl": "656fac30c6baea13cd07e10c",
             "parentId": "7cb4be3b3adb4f7617eb8a4a",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "eef90133ab2e8ed39ac8e5cc",
             "_tpl": "656fac30c6baea13cd07e10c",
             "parentId": "7cb4be3b3adb4f7617eb8a4a",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "aef1470bcf2378f3f32bcfb6",
             "_tpl": "64a5366719bab53bd203bf33",
             "parentId": "hideout",
@@ -5653,20 +4973,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "1bec01fb60cad9afce61adc1",
             "_tpl": "656fac30c6baea13cd07e10c",
             "parentId": "aef1470bcf2378f3f32bcfb6",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "7d4c6c1bbbdb6f635c67d4fc",
             "_tpl": "656fac30c6baea13cd07e10c",
             "parentId": "aef1470bcf2378f3f32bcfb6",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "6fffc98890b7cfb0580eb651",
             "_tpl": "609e860ebd219504d8507525",
             "parentId": "hideout",
@@ -5677,32 +4994,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c112ee9b4bd48141645dad0a",
             "_tpl": "6575f5cbf6a13a7b7100b0bf",
             "parentId": "6fffc98890b7cfb0580eb651",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "abb1dfca41ccafba9e2ebfa8",
             "_tpl": "6575f5e1da698a4e98067869",
             "parentId": "6fffc98890b7cfb0580eb651",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "98c29eef43297d7b8123a8bd",
             "_tpl": "656fa99800d62bcd2e024088",
             "parentId": "6fffc98890b7cfb0580eb651",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "ea3df57899948aba9f367cd4",
             "_tpl": "656fa0fb498d1b7e3e071d9c",
             "parentId": "6fffc98890b7cfb0580eb651",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "dab0b75515263367b57489fe",
             "_tpl": "628b9784bcf6e2659e09b8a2",
             "parentId": "hideout",
@@ -5713,32 +5025,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "0f02ee226c9b7baa8d7ced75",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "dab0b75515263367b57489fe",
             "slotId": "Left_side_plate"
-        },
-        {
+        }, {
             "_id": "ed8ce46d813b69ebcaeba5ca",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "dab0b75515263367b57489fe",
             "slotId": "Right_side_plate"
-        },
-        {
+        }, {
             "_id": "aea2fdbfd62f9a9de29d3ae7",
             "_tpl": "656fae5f7c2d57afe200c0d7",
             "parentId": "dab0b75515263367b57489fe",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "9e4e2cae4ce148b9da52d16d",
             "_tpl": "656fae5f7c2d57afe200c0d7",
             "parentId": "dab0b75515263367b57489fe",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "acdc3fe76a21feaad0c7e2f0",
             "_tpl": "628b9c7d45122232a872358f",
             "parentId": "hideout",
@@ -5749,56 +5056,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "9a28b8dbabdaba98da863a57",
             "_tpl": "6575f24ff6a13a7b7100b09e",
             "parentId": "acdc3fe76a21feaad0c7e2f0",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "4ff9bfe9ddeca45cd12de61c",
             "_tpl": "6575f25ada698a4e98067836",
             "parentId": "acdc3fe76a21feaad0c7e2f0",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "1c32b1e4a461ecfba10e9a9c",
             "_tpl": "6575f2649cfdfe416f0399b8",
             "parentId": "acdc3fe76a21feaad0c7e2f0",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "e9b97e1f08bc9ba2d11e04e5",
             "_tpl": "6575f26d9c7cad336508e480",
             "parentId": "acdc3fe76a21feaad0c7e2f0",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "0db3a1fb8dbb65d9d5d9e27a",
             "_tpl": "656fa53d94b480b8a500c0e4",
             "parentId": "acdc3fe76a21feaad0c7e2f0",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "6a8da3591c5e034f28c66837",
             "_tpl": "656fa53d94b480b8a500c0e4",
             "parentId": "acdc3fe76a21feaad0c7e2f0",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "d8aa3a94af90c351c5afaa4d",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "acdc3fe76a21feaad0c7e2f0",
             "slotId": "Left_side_plate"
-        },
-        {
+        }, {
             "_id": "041ff10c6db7eead4de3bcaf",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "acdc3fe76a21feaad0c7e2f0",
             "slotId": "Right_side_plate"
-        },
-        {
+        }, {
             "_id": "d2ee21b623e2fcfeea03b359",
             "_tpl": "628baf0b967de16aab5a4f36",
             "parentId": "hideout",
@@ -5809,8 +5107,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "cf6fbdaf8bcabe38b62d180a",
             "_tpl": "628cd624459354321c4b7fa2",
             "parentId": "hideout",
@@ -5821,20 +5118,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "5adeb8fbe53d45cec7509063",
             "_tpl": "64afdcb83efdfea28601d041",
             "parentId": "cf6fbdaf8bcabe38b62d180a",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "adaab1aa9a45ad2790904eab",
             "_tpl": "64afdcb83efdfea28601d041",
             "parentId": "cf6fbdaf8bcabe38b62d180a",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "81f94b456a68be8f28d2de69",
             "_tpl": "628d0618d1ba6e4fa07ce5a4",
             "parentId": "hideout",
@@ -5845,44 +5139,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "af4d30bd645965810f618b7c",
             "_tpl": "64afdcb83efdfea28601d041",
             "parentId": "81f94b456a68be8f28d2de69",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "bdd6d8f9867c2287dacd2f77",
             "_tpl": "657322a4cea9255e21023651",
             "parentId": "81f94b456a68be8f28d2de69",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "a2d6e0bde0d6b387f7c16663",
             "_tpl": "6570f3890b4ae5847f060dad",
             "parentId": "81f94b456a68be8f28d2de69",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "fe404f0ce7f7b7dc5ecc8468",
             "_tpl": "6570f3bb0b4ae5847f060db2",
             "parentId": "81f94b456a68be8f28d2de69",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "edcbfbff7e968cf65d6bac2e",
             "_tpl": "656fb0bd7c2d57afe200c0dc",
             "parentId": "81f94b456a68be8f28d2de69",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "1f7aeae53beafeb16ce2f60a",
             "_tpl": "656fb0bd7c2d57afe200c0dc",
             "parentId": "81f94b456a68be8f28d2de69",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "55b1c789d288f78e634ca086",
             "_tpl": "628dc750b910320f4c27a732",
             "parentId": "hideout",
@@ -5893,50 +5180,42 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "df7d194fc2f98e0bcbfaeacc",
             "_tpl": "6572f1ca4c8d903cc60c874e",
             "parentId": "55b1c789d288f78e634ca086",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "9b4baa746d9500deaebbdd87",
             "_tpl": "6572f1d60103b4a3270332db",
             "parentId": "55b1c789d288f78e634ca086",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "0d5f30370cfeed4ffce2c5d6",
             "_tpl": "6572f1e10103b4a3270332df",
             "parentId": "55b1c789d288f78e634ca086",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "369fdc5aeefcfd8ff20337ef",
             "_tpl": "6572f1edea457732140ce875",
             "parentId": "55b1c789d288f78e634ca086",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "cbccbaada4aa4ea3bdbbefec",
             "_tpl": "656fa25e94b480b8a500c0e0",
             "parentId": "55b1c789d288f78e634ca086",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "cd38af0a0fddb56eb9cebe0b",
             "_tpl": "656fa25e94b480b8a500c0e0",
             "parentId": "55b1c789d288f78e634ca086",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "c0d096e57b6f5b97ad2becde",
             "_tpl": "6572f1f7ea457732140ce879",
             "parentId": "55b1c789d288f78e634ca086",
             "slotId": "Groin"
-        },
-        {
+        }, {
             "_id": "77dde8e2fff0ccb2aa60bb12",
             "_tpl": "639343fce101f4caa40a4ef3",
             "parentId": "hideout",
@@ -5947,44 +5226,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "905e7ea97547f60a770e2c91",
             "_tpl": "6573101e292ecadbfa09b389",
             "parentId": "77dde8e2fff0ccb2aa60bb12",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "b9e4f3bb19fe9a6cff5b0b2e",
             "_tpl": "6573102b292ecadbfa09b38d",
             "parentId": "77dde8e2fff0ccb2aa60bb12",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "92b4a5feaf0dbfc09b43ce69",
             "_tpl": "65731038292ecadbfa09b391",
             "parentId": "77dde8e2fff0ccb2aa60bb12",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "f39ffe2b3ba1cc858cb2cb6b",
             "_tpl": "65731045f31d5be00e08a75a",
             "parentId": "77dde8e2fff0ccb2aa60bb12",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "e029a9ece1ff0dd38925e3fe",
             "_tpl": "656fad8c498d1b7e3e071da0",
             "parentId": "77dde8e2fff0ccb2aa60bb12",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "ed7747dd573cf700c3ad321b",
             "_tpl": "656fad8c498d1b7e3e071da0",
             "parentId": "77dde8e2fff0ccb2aa60bb12",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "d57fd8b6bbd1def2a9939aff",
             "_tpl": "64a536392d2c4e6e970f4121",
             "parentId": "hideout",
@@ -5995,32 +5267,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "cecedea8c20c3aee3358d0c4",
             "_tpl": "6570653e89fd4926380b733e",
             "parentId": "d57fd8b6bbd1def2a9939aff",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "cdca4e601aad0f546d37ae41",
             "_tpl": "6570658a89fd4926380b7346",
             "parentId": "d57fd8b6bbd1def2a9939aff",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "7c6d5cbddf32044b610fd424",
             "_tpl": "656fac30c6baea13cd07e10c",
             "parentId": "d57fd8b6bbd1def2a9939aff",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "ccd82f887c64fad6a50af7b5",
             "_tpl": "656fac30c6baea13cd07e10c",
             "parentId": "d57fd8b6bbd1def2a9939aff",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "f1b2f521bd8dfbbbae294d20",
             "_tpl": "64a5366719bab53bd203bf33",
             "parentId": "hideout",
@@ -6031,20 +5298,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "3fbca21e6c312f8fdefe0032",
             "_tpl": "656fac30c6baea13cd07e10c",
             "parentId": "f1b2f521bd8dfbbbae294d20",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "4bfe8941fab33f3cde0bc3a4",
             "_tpl": "656fac30c6baea13cd07e10c",
             "parentId": "f1b2f521bd8dfbbbae294d20",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "9e0da78f93fcd9bcd11c93ee",
             "_tpl": "609e860ebd219504d8507525",
             "parentId": "hideout",
@@ -6055,32 +5319,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "acf9ed07bb5d2aa7cbabaa9d",
             "_tpl": "6575f5cbf6a13a7b7100b0bf",
             "parentId": "9e0da78f93fcd9bcd11c93ee",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "f95065b21f7b25ad978006f2",
             "_tpl": "6575f5e1da698a4e98067869",
             "parentId": "9e0da78f93fcd9bcd11c93ee",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "cedaac58becd81fa7fabafab",
             "_tpl": "656fa99800d62bcd2e024088",
             "parentId": "9e0da78f93fcd9bcd11c93ee",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "cbee0a1bba16ddc47d69d608",
             "_tpl": "656fa0fb498d1b7e3e071d9c",
             "parentId": "9e0da78f93fcd9bcd11c93ee",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "4cfc5b3d8ab89f4d2ac8f4aa",
             "_tpl": "628b9784bcf6e2659e09b8a2",
             "parentId": "hideout",
@@ -6091,32 +5350,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ac0cc9c4ba7913fbb54402bb",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "4cfc5b3d8ab89f4d2ac8f4aa",
             "slotId": "Left_side_plate"
-        },
-        {
+        }, {
             "_id": "fe4adce9f1eeec17abbddb6f",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "4cfc5b3d8ab89f4d2ac8f4aa",
             "slotId": "Right_side_plate"
-        },
-        {
+        }, {
             "_id": "991c22001ddf2ebcdffcb777",
             "_tpl": "656fae5f7c2d57afe200c0d7",
             "parentId": "4cfc5b3d8ab89f4d2ac8f4aa",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "68addc550be25026a96b253d",
             "_tpl": "656fae5f7c2d57afe200c0d7",
             "parentId": "4cfc5b3d8ab89f4d2ac8f4aa",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "d6fdaeeee9e64b5cd68624e9",
             "_tpl": "628b9c7d45122232a872358f",
             "parentId": "hideout",
@@ -6127,56 +5381,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "5ddd374d1ba0c2254edc1c8b",
             "_tpl": "6575f24ff6a13a7b7100b09e",
             "parentId": "d6fdaeeee9e64b5cd68624e9",
             "slotId": "Soft_armor_front"
-        },
-        {
+        }, {
             "_id": "fcf7a7c065bd99d6e08ce735",
             "_tpl": "6575f25ada698a4e98067836",
             "parentId": "d6fdaeeee9e64b5cd68624e9",
             "slotId": "Soft_armor_back"
-        },
-        {
+        }, {
             "_id": "e7c3877fb4fd0591bd0a7b81",
             "_tpl": "6575f2649cfdfe416f0399b8",
             "parentId": "d6fdaeeee9e64b5cd68624e9",
             "slotId": "Soft_armor_left"
-        },
-        {
+        }, {
             "_id": "d6785a3d33952d0cdbeb1c34",
             "_tpl": "6575f26d9c7cad336508e480",
             "parentId": "d6fdaeeee9e64b5cd68624e9",
             "slotId": "soft_armor_right"
-        },
-        {
+        }, {
             "_id": "c9dc588f43fc1c9bbb1cf8d0",
             "_tpl": "656fa53d94b480b8a500c0e4",
             "parentId": "d6fdaeeee9e64b5cd68624e9",
             "slotId": "Front_plate"
-        },
-        {
+        }, {
             "_id": "6fc783883d0fd4c65ace030a",
             "_tpl": "656fa53d94b480b8a500c0e4",
             "parentId": "d6fdaeeee9e64b5cd68624e9",
             "slotId": "Back_plate"
-        },
-        {
+        }, {
             "_id": "e566cc74ddf5cf5faf1bfca6",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "d6fdaeeee9e64b5cd68624e9",
             "slotId": "Left_side_plate"
-        },
-        {
+        }, {
             "_id": "d2ae9a9e46bc88afceac7ea1",
             "_tpl": "6557458f83942d705f0c4962",
             "parentId": "d6fdaeeee9e64b5cd68624e9",
             "slotId": "Right_side_plate"
-        },
-        {
+        }, {
             "_id": "d710d13c10a0ed5e1dbf1cfe",
             "_tpl": "628baf0b967de16aab5a4f36",
             "parentId": "hideout",
@@ -6187,8 +5432,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "39f40cb623d2f57f165eeb8c",
             "_tpl": "64748cb8de82c85eaf0a273a",
             "parentId": "hideout",
@@ -6199,14 +5443,12 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b78afad0ef9deee7fd935f67",
             "_tpl": "64748d02d1c009260702b526",
             "parentId": "39f40cb623d2f57f165eeb8c",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "8a1f6ebbaacd2c8ebbc8452d",
             "_tpl": "61f7c9e189e6fb1a5e3ea78d",
             "parentId": "hideout",
@@ -6217,26 +5459,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fefa63e6f9d9666e4bb3a779",
             "_tpl": "61f4012adfc9f01a816adda1",
             "parentId": "8a1f6ebbaacd2c8ebbc8452d",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "59f4c06eb5b2bdeeaeeddcf3",
             "_tpl": "61f7b85367ddd414173fdb36",
             "parentId": "fefa63e6f9d9666e4bb3a779",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "d3c9774c228caf44d98d2a0e",
             "_tpl": "61f7b234ea4ab34f2f59c3ec",
             "parentId": "8a1f6ebbaacd2c8ebbc8452d",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "c5b9dc5b10f8ab52f6a0a3c0",
             "_tpl": "6259b864ebedf17603599e88",
             "parentId": "hideout",
@@ -6247,56 +5485,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "aecdff8ad0ac9b2bc5e68ece",
             "_tpl": "6259c2c1d714855d182bad85",
             "parentId": "c5b9dc5b10f8ab52f6a0a3c0",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "b276cc9debfa28bc7debfbc4",
             "_tpl": "6259c3387d6aab70bc23a18d",
             "parentId": "c5b9dc5b10f8ab52f6a0a3c0",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "7dbc8cde54c359299981fb04",
             "_tpl": "6259c3d8012d6678ec38eeb8",
             "parentId": "b276cc9debfa28bc7debfbc4",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "bd2ce48a771be207ab9baee9",
             "_tpl": "6259c4347d6aab70bc23a190",
             "parentId": "c5b9dc5b10f8ab52f6a0a3c0",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "fab81cacbcf008a5eaa98e27",
             "_tpl": "625ff2ccb8c587128c1a01dd",
             "parentId": "c5b9dc5b10f8ab52f6a0a3c0",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "8f6ce766f698cc55caeda0af",
             "_tpl": "625ebcef6f53af4aa66b44dc",
             "parentId": "c5b9dc5b10f8ab52f6a0a3c0",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "efed4b6ffe75cdb2bca3e27b",
             "_tpl": "625ed7c64d9b6612df732146",
             "parentId": "c5b9dc5b10f8ab52f6a0a3c0",
             "slotId": "mod_mount"
-        },
-        {
+        }, {
             "_id": "fa1d1f35fef27cc3bfead0db",
             "_tpl": "625ec45bb14d7326ac20f572",
             "parentId": "c5b9dc5b10f8ab52f6a0a3c0",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "cd18bd455119eafb5bdfb605",
             "_tpl": "61f7c9e189e6fb1a5e3ea78d",
             "parentId": "hideout",
@@ -6307,26 +5536,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "716d5bc84c8fded4e2f4ced8",
             "_tpl": "61f4012adfc9f01a816adda1",
             "parentId": "cd18bd455119eafb5bdfb605",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "e771db28d4bc7f2afd7a40d9",
             "_tpl": "61f7b85367ddd414173fdb36",
             "parentId": "716d5bc84c8fded4e2f4ced8",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "cd552ad6d5769e9a12d4d7f3",
             "_tpl": "61f7b234ea4ab34f2f59c3ec",
             "parentId": "cd18bd455119eafb5bdfb605",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "f0a75666e2cf7d2ff9eef1ce",
             "_tpl": "6259b864ebedf17603599e88",
             "parentId": "hideout",
@@ -6337,56 +5562,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "0af4eedeb6e9c6f0cc4fd58b",
             "_tpl": "6259c2c1d714855d182bad85",
             "parentId": "f0a75666e2cf7d2ff9eef1ce",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "b3fe86eecd01fb855bcc5dff",
             "_tpl": "6259c3387d6aab70bc23a18d",
             "parentId": "f0a75666e2cf7d2ff9eef1ce",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "91bfb7c71dc5d9f61d07f8ac",
             "_tpl": "6259c3d8012d6678ec38eeb8",
             "parentId": "b3fe86eecd01fb855bcc5dff",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "7aedcdb5ade0edbececf0dae",
             "_tpl": "6259c4347d6aab70bc23a190",
             "parentId": "f0a75666e2cf7d2ff9eef1ce",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "d5f23ddeaa3df8bed88a5bd5",
             "_tpl": "625ff2ccb8c587128c1a01dd",
             "parentId": "f0a75666e2cf7d2ff9eef1ce",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "59be8fdc6fecb8b1177beb7e",
             "_tpl": "625ebcef6f53af4aa66b44dc",
             "parentId": "f0a75666e2cf7d2ff9eef1ce",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "ece024cda377dda43dcfd45a",
             "_tpl": "625ed7c64d9b6612df732146",
             "parentId": "f0a75666e2cf7d2ff9eef1ce",
             "slotId": "mod_mount"
-        },
-        {
+        }, {
             "_id": "aa3c70c12fe4857f5f2d8c78",
             "_tpl": "625ec45bb14d7326ac20f572",
             "parentId": "f0a75666e2cf7d2ff9eef1ce",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "7b351e290bfc09b0cf879dce",
             "_tpl": "625ff2ccb8c587128c1a01dd",
             "parentId": "hideout",
@@ -6397,8 +5613,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "facee397e8b3cdfcac07c3ca",
             "_tpl": "6259bdcabd28e4721447a2aa",
             "parentId": "hideout",
@@ -6409,8 +5624,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "6ccccc393cde0a66d0bc68a7",
             "_tpl": "625ff2eb9f5537057932257d",
             "parentId": "hideout",
@@ -6421,8 +5635,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "2c36d4e2f9534d1db9cdb37b",
             "_tpl": "625ff3046d721f05d93bf2ee",
             "parentId": "hideout",
@@ -6433,8 +5646,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e14d2ef0f42a294e7a52ff9d",
             "_tpl": "625ff31daaaa8c1130599f64",
             "parentId": "hideout",

--- a/db/traders/6765fbd20fdc7eb79b00000e/assort.json
+++ b/db/traders/6765fbd20fdc7eb79b00000e/assort.json
@@ -1,1600 +1,1832 @@
 {
     "barter_scheme": {
         "89ff7373b1fb0ec4c705db2d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 25000
                 }
             ]
         ],
         "dfeae76c2aed94ebee2db4e8": [
-            [{
+            [
+                {
                     "_tpl": "57347d90245977448f7b7f65",
                     "count": 5
                 }
             ]
         ],
         "1cce5068f5ddbcaadac3ee4d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 30000
                 }
             ]
         ],
         "ff109e00a8dde480eefa87fb": [
-            [{
+            [
+                {
                     "_tpl": "5c3df7d588a4501f290594e5",
                     "count": 5
                 }
             ]
         ],
         "49cbcb5c5fdbc6790e0a5ada": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 50
                 }
             ]
         ],
         "9c57bd1cd8bfa381ce391fcd": [
-            [{
+            [
+                {
                     "_tpl": "57347c1124597737fb1379e3",
                     "count": 2
                 }
             ]
         ],
         "1a317ae89abb5bbaf89720cd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 20000
                 }
             ]
         ],
         "1c5bfbedb7bf2eb8db265d4d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1300
                 }
             ]
         ],
         "411cd2a6bbf37e7aa9f7e8c5": [
-            [{
+            [
+                {
                     "_tpl": "57e26fc7245977162a14b800",
                     "count": 8
                 }
             ]
         ],
         "b6aa0aa8dbfd624a530dd9ba": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 37000
                 }
             ]
         ],
         "5a70a9da8c157810dfebd608": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24000
                 }
             ]
         ],
         "5513f6c7155b5ed8731abff7": [
-            [{
+            [
+                {
                     "_tpl": "5737201124597760fc4431f1",
                     "count": 2
                 }
             ]
         ],
         "db39e5eba0da6e91ac7d0baf": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 45
                 }
             ]
         ],
         "21e6a3b3abfab4f1dfcbb9fe": [
-            [{
+            [
+                {
                     "_tpl": "57347d7224597744596b4e72",
                     "count": 10
                 }
             ]
         ],
         "2c2cdfcaaedf64f3c33a6bfe": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 44000
                 }
             ]
         ],
         "b629cffeee7365bbbdb4fdf9": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1800
                 }
             ]
         ],
         "70457fc9d9c8d617a11de7c1": [
-            [{
+            [
+                {
                     "_tpl": "590c5f0d86f77413997acfab",
                     "count": 6
                 }
             ]
         ],
         "43bcca99f2e7ceebff948ee1": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 36000
                 }
             ]
         ],
         "aa8cfaf93a0a12f3a61fa33b": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3400
                 }
             ]
         ],
         "fdff4ca46bfc60e6fc1a1deb": [
-            [{
+            [
+                {
                     "_tpl": "575146b724597720a27126d5",
                     "count": 2
-                }, {
+                },
+                {
                     "_tpl": "619cbfeb6b8a1b37a54eebfa",
                     "count": 2
                 }
             ]
         ],
         "0b79d8fc0aeee03ff2d7aaff": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 21000
                 }
             ]
         ],
         "707d0a9feff99f8bb17ddcdc": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1400
                 }
             ]
         ],
         "d5c5a21fb1fcbfcbdbdd4ecf": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2000
                 }
             ]
         ],
         "63cd7aaedb0bbec7e50fbb25": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 4500
                 }
             ]
         ],
         "2c477417ea95eae017c9e01f": [
-            [{
+            [
+                {
                     "_tpl": "5672cb124bdc2d1a0f8b4568",
                     "count": 3
                 }
             ]
         ],
         "1eaaadbbd63ebd7cb88ccc7e": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 7500
                 }
             ]
         ],
         "6bea2af7470a11f1c027bffa": [
-            [{
+            [
+                {
                     "_tpl": "5448ff904bdc2d6f028b456e",
                     "count": 3
                 }
             ]
         ],
         "3f4c9d2d18fadcc5aa4d319c": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 16000
                 }
             ]
         ],
         "8bf71225f5321d4a20ab6e0c": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 25000
                 }
             ]
         ],
         "a4067e1a0ccad3e45acf0f1b": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 57000
                 }
             ]
         ],
         "d4dece77c70ad1dedde21fee": [
-            [{
+            [
+                {
                     "_tpl": "5d403f9186f7743cac3f229b",
                     "count": 2
                 }
             ]
         ],
         "f47e63136d9e2e21d9b9bdfc": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 98000
                 }
             ]
         ],
         "00bb3bd10a94d4dd0edae2b5": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 78000
                 }
             ]
         ],
         "23e630e3ac5c0c0c32fa2fdc": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2800
                 }
             ]
         ],
         "98e0f0c9f9ce788ee52dc05a": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2200
                 }
             ]
         ],
         "afd3a6259deff7df0eb300a4": [
-            [{
+            [
+                {
                     "_tpl": "59e36c6f86f774176c10a2a7",
                     "count": 3
                 }
             ]
         ],
         "9f80addca7aa1dcd0beef6ef": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 18500
                 }
             ]
         ],
         "9d2e7ec756fb719f65440bb1": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 12000
                 }
             ]
         ],
         "a1ceaecdd0ca33ac6ede8fdf": [
-            [{
+            [
+                {
                     "_tpl": "56d59d3ad2720bdb418b4577",
                     "count": 4
                 }
             ]
         ],
         "f07ecb6db63bb03eac6fcfab": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 145
                 }
             ]
         ],
         "4c8894693818128cfbde5e7a": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1500
                 }
             ]
         ],
         "d01ac040ed0e7ec2afaf000f": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 7500
                 }
             ]
         ],
         "cadfd8d099bf6fbcbe95b33b": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3300
                 }
             ]
         ],
         "fd942eafa8b2f18a42cc56d3": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2250
                 }
             ]
         ],
         "134cbe54aabbe3b49ede24fd": [
-            [{
+            [
+                {
                     "_tpl": "5734758f24597738025ee253",
                     "count": 1
                 }
             ]
         ],
         "f1af81dc1dff3ea1b5ac6e4e": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 33000
                 }
             ]
         ],
         "c39ea5eedfd45a72e9b1ffb3": [
-            [{
+            [
+                {
                     "_tpl": "590c311186f77424d1667482",
                     "count": 4
                 }
             ]
         ],
         "f334efa7eed9b05fa4c5f0be": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 27000
                 }
             ]
         ],
         "dbf7e6c04b7b0dd1e90b3e0e": [
-            [{
+            [
+                {
                     "_tpl": "5734773724597737fd047c14",
                     "count": 3
                 }
             ]
         ],
         "ddd6a65fdf9f16d83b318daa": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 30000
                 }
             ]
         ],
         "886d1e5ad9842e5bc40e1143": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 63000
                 }
             ]
         ],
         "3d950b64d16c7c245d6b5f9e": [
-            [{
+            [
+                {
                     "_tpl": "5d0376a486f7747d8050965c",
                     "count": 5
                 }
             ]
         ],
         "68bbbdaee53cad9c6a01d0ac": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 156000
                 }
             ]
         ],
         "7fd3bed1c9fcf118b00cbbea": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 25000
                 }
             ]
         ],
         "cf3a1965f725ecbc81c7545d": [
-            [{
+            [
+                {
                     "_tpl": "590a3b0486f7743954552bdb",
                     "count": 5
                 }
             ]
         ],
         "fdfc68e5aecfe2d355e05df4": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 42000
                 }
             ]
         ],
         "faf2b1d5e543abb9b72966ab": [
-            [{
+            [
+                {
                     "_tpl": "5af0534a86f7743b6f354284",
                     "count": 2
                 }
             ]
         ],
         "fbeaec0f91c1204fac95e7a0": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 88000
                 }
             ]
         ],
         "9e1a1c3faeefb88c67846aaf": [
-            [{
+            [
+                {
                     "_tpl": "5e2af29386f7746d4159f077",
                     "count": 3
                 }
             ]
         ],
         "8f538ebbd5a3ddf1d3b47d62": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 48000
                 }
             ]
         ],
         "fbc0a8d0fc3ac65aa3bba661": [
-            [{
+            [
+                {
                     "_tpl": "590a3c0a86f774385a33c450",
                     "count": 3
-                }, {
+                },
+                {
                     "_tpl": "59e36c6f86f774176c10a2a7",
                     "count": 5
                 }
             ]
         ],
         "df6bde5f07ac961aa9da4b8b": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 52000
                 }
             ]
         ],
         "c03dcd84bec6e0d23dceed92": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 13500
                 }
             ]
         ],
         "da9ca8940d4e39ccec53d5e1": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 9400
                 }
             ]
         ],
         "735805162eaad4267bf6edfa": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 31000
                 }
             ]
         ],
         "0fbee497ded7aa5ead7d3f7a": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 7000
                 }
             ]
         ],
         "d57eed678ae9bfef5d13efab": [
-            [{
+            [
+                {
                     "_tpl": "54491bb74bdc2d09088b4567",
                     "count": 2
                 }
             ]
         ],
         "c96f3e5d2360105f8bebcc9d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 30000
                 }
             ]
         ],
         "ce16ab92fc2fdedbbce276a0": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 45000
                 }
             ]
         ],
         "9daca13fdf45feffda929ec9": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 8455
                 }
             ]
         ],
         "ba0b2efdc707d20a50bcf9ed": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5800
                 }
             ]
         ],
         "b5ec0ccd20e80a520e8ca1ac": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 10200
                 }
             ]
         ],
         "ee685e4dae31cfbb2bf9cdb1": [
-            [{
+            [
+                {
                     "_tpl": "5ba26844d4351e00334c9475",
                     "count": 3
                 }
             ]
         ],
         "b7ba97bed5ae6d3d1eafce2f": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 360
                 }
             ]
         ],
         "c554dccc730ccae2e6fccb0b": [
-            [{
+            [
+                {
                     "_tpl": "56dff216d2720bbd668b4568",
                     "count": 4
                 }
             ]
         ],
         "6445be79d68ff6ac7ac7fc1e": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60
                 }
             ]
         ],
         "dbefe090123ecf1d6a29fab7": [
-            [{
+            [
+                {
                     "_tpl": "5ba2678ad4351e44f824b344",
                     "count": 3
                 }
             ]
         ],
         "3a1fd1a3f34ca2d9f8c3c8ff": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 630
                 }
             ]
         ],
         "762eedaabb6f6ecca9e0edda": [
-            [{
+            [
+                {
                     "_tpl": "5ba26812d4351e003201fef1",
                     "count": 12
                 }
             ]
         ],
         "f5afa9cb6f4e95c4effc5acc": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 90
                 }
             ]
         ],
         "cc4a5f48f7a3a3f164f91fb5": [
-            [{
+            [
+                {
                     "_tpl": "5d235a5986f77443f6329bc6",
                     "count": 2
                 }
             ]
         ],
         "a4f4cebdd504df8c6cdd5cbd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 51000
                 }
             ]
         ],
         "be0f57a8dfcd34bd7dfe5803": [
-            [{
+            [
+                {
                     "_tpl": "590a386e86f77429692b27ab",
                     "count": 5
                 }
             ]
         ],
         "5d9d636c1faa4c42df6d97d5": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60000
                 }
             ]
         ],
         "72fdb7f3a277dfd6eabfafe3": [
-            [{
+            [
+                {
                     "_tpl": "5d1b392c86f77425243e98fe",
                     "count": 5
                 }
             ]
         ],
         "a7fa1a09e49cf4d42dbc4d7c": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 18000
                 }
             ]
         ],
         "4f71eccb9884c69a1c1a2538": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2800
                 }
             ]
         ],
         "bbb80f3f7abcc46de99adcdd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1600
                 }
             ]
         ],
         "cfc41c8b0ad9d8f2ea8e8e6a": [
-            [{
+            [
+                {
                     "_tpl": "590c5f0d86f77413997acfab",
                     "count": 5
                 }
             ]
         ],
         "ccccfde8dbcaec0cdaecbe47": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24000
                 }
             ]
         ],
         "685b7bdaf4ab7190803721d0": [
-            [{
+            [
+                {
                     "_tpl": "5c06782b86f77426df5407d2",
                     "count": 3
                 }
             ]
         ],
         "8bcea9cbaa2f75ff22abafe7": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 8800
                 }
             ]
         ],
         "db3939bbe8bd0b4b678d7aed": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 67500
                 }
             ]
         ],
         "1da5efc9bd2954b0ffd862c8": [
-            [{
+            [
+                {
                     "_tpl": "5b43575a86f77424f443fe62",
                     "count": 5
                 }
             ]
         ],
         "ecde82bb1f509f9bb9dabd38": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 58000
                 }
             ]
         ],
         "4f4ebc0fbba3a49c6c5fb461": [
-            [{
+            [
+                {
                     "_tpl": "59e35ef086f7741777737012",
                     "count": 4
                 }
             ]
         ],
         "d69977a2fdb1cc6c4d771bee": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 9500
                 }
             ]
         ],
         "3bcca6aacfafdb6edf1025ab": [
-            [{
+            [
+                {
                     "_tpl": "5efb0e16aeb21837e749c7ff",
                     "count": 2
                 }
             ]
         ],
         "dfacfe909d6558de7ced5138": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 360
                 }
             ]
         ],
         "b8aa67394c3c826a5c20b8c4": [
-            [{
+            [
+                {
                     "_tpl": "590a358486f77429692b2790",
                     "count": 1
                 }
             ]
         ],
         "4c185bc28fa79ef071e7a73c": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 55000
                 }
             ]
         ],
         "3cee7d223e197b0dad7adbb3": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 45000
                 }
             ]
         ],
         "e83ddc049dee9f799566c41a": [
-            [{
+            [
+                {
                     "_tpl": "5d235b4d86f7742e017bc88a",
                     "count": 4
                 }
             ]
         ],
         "f0afb4c0c05bfd31ce85e0ea": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 81000
                 }
             ]
         ],
         "4db52961fe841e07df9cf7eb": [
-            [{
+            [
+                {
                     "_tpl": "58864a4f2459770fcc257101",
                     "count": 2
                 }
             ]
         ],
         "0c01ae762a3d31f9d3faadef": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60
                 }
             ]
         ],
         "ef19a9e9fcef6fcaabc3e3c5": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1250
                 }
             ]
         ],
         "fbedd2b04e2ae33febbd7ebc": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5000
                 }
             ]
         ],
         "4c12bbc8f9d4cb99c5dbbca8": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 13500
                 }
             ]
         ],
         "bcff76cf2f12963e14cc6ba0": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 200
                 }
             ]
         ],
         "acc0590e51abf65d0be5dcee": [
-            [{
+            [
+                {
                     "_tpl": "5c0d56a986f774449d5de529",
                     "count": 2
                 }
             ]
         ],
         "03842e3abd93bda4bcd836cb": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 180
                 }
             ]
         ],
         "a00ea4e635aca7242c3ca430": [
-            [{
+            [
+                {
                     "_tpl": "569668774bdc2da2298b4568",
                     "count": 200
-                }, {
+                },
+                {
                     "_tpl": "5696686a4bdc2da3298b456a",
                     "count": 200
                 }
             ]
         ],
         "d8fe280b7eddf7cdea85fbbc": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 58000
                 }
             ]
         ],
         "6aae6b7bb7b4312faabefc51": [
-            [{
+            [
+                {
                     "_tpl": "5d1b317c86f7742523398392",
                     "count": 2
                 }
             ]
         ],
         "bafb4f2becff3fa1edd0c9df": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 153000
                 }
             ]
         ],
         "a5d2b379faf0f2dcdea70b5b": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 10000
                 }
             ]
         ],
         "e4389c85c2d0d411e59baba9": [
-            [{
+            [
+                {
                     "_tpl": "5d403f9186f7743cac3f229b",
                     "count": 3
                 }
             ]
         ],
         "5f874db0cbfb83bc7c1dacbc": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 90000
                 }
             ]
         ],
         "0d4e53f8dde4728245fa4ea7": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 21000
                 }
             ]
         ],
         "f430ae634bd13deb5793af3b": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2400
                 }
             ]
         ],
         "a4fd56c04d6f0c1f0c8e1ebc": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1800
                 }
             ]
         ],
         "b15a46448abeb15a8066e1e4": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24000
                 }
             ]
         ],
         "19311f9cdd8b19dc4af8de71": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 105000
                 }
             ]
         ],
         "fd5dc6c29021fbfcdd29bce2": [
-            [{
+            [
+                {
                     "_tpl": "59e36c6f86f774176c10a2a7",
                     "count": 5
                 }
             ]
         ],
         "8bcc62f3374c3a29696f40e8": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 48000
                 }
             ]
         ],
         "e0efb555332fde2bdeb1bc7a": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1000000
                 }
             ]
         ],
         "d5bba9bd21b779abfdddbe9e": [
-            [{
+            [
+                {
                     "_tpl": "5c1265fc86f7743f896a21c2",
                     "count": 1
                 }
             ]
         ],
         "133526a998c8ba1c22c5e8f8": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 45000
                 }
             ]
         ],
         "f1dcaf138aba4de379da1efe": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 31000
                 }
             ]
         ],
         "f556c7af8ac720eb0e21d3e0": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1500
                 }
             ]
         ],
         "358832f6bcdb70ab7c84bb91": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 31000
                 }
             ]
         ],
         "a3760f2fe7af2ced96fdda0f": [
-            [{
+            [
+                {
                     "_tpl": "5d235a5986f77443f6329bc6",
                     "count": 1
                 }
             ]
         ],
         "86add03867ecbb5adc6ad520": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 73000
                 }
             ]
         ],
         "9bac87edd4ddfd88cd22c4b7": [
-            [{
+            [
+                {
                     "_tpl": "5c10c8fd86f7743d7d706df3",
                     "count": 2
-                }, {
+                },
+                {
                     "_tpl": "5d1b392c86f77425243e98fe",
                     "count": 3
                 }
             ]
         ],
         "bcafda5baf624ab54c5cf8c5": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 33000
                 }
             ]
         ],
         "ef9f6ab8edda8baf2add0d4d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1500
                 }
             ]
         ],
         "4dfa00005451cb7add4284ac": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1600
                 }
             ]
         ],
         "ead40fcbfed6589bb4d5bfe5": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2150
                 }
             ]
         ],
         "6e0a2ab073bb0f04b7e7bc19": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3400
                 }
             ]
         ],
         "3c4f321dc26ddfdade21e1fa": [
-            [{
+            [
+                {
                     "_tpl": "5d4042a986f7743185265463",
                     "count": 2
                 }
             ]
         ],
         "1f416a7c5a7c6ddeaeebd5ff": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5500
                 }
             ]
         ],
         "d20fda6f5f13c3f4c827e0ab": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 33000
                 }
             ]
         ],
         "5207bc9fcaf7cf96a7aa1d7f": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 45000
                 }
             ]
         ],
         "eef3c5cda00670a1ef8cbafb": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 45000
                 }
             ]
         ],
         "db4dcfca7c812792be3dfdcd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 45000
                 }
             ]
         ],
         "d8d19cb46c2ff2933ba26063": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 45000
                 }
             ]
         ],
         "1ecbdfb87cb0ffca0c546c62": [
-            [{
+            [
+                {
                     "_tpl": "59e3639286f7741777737013",
                     "count": 1
                 }
             ]
         ],
         "6a28a2a53e78d37ea166e2e3": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 105000
                 }
             ]
         ],
         "6afcbe2a67c6fb9e424da5de": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 37000
                 }
             ]
         ],
         "bfd8de56d5a8ccc0bb708520": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 145000
                 }
             ]
         ],
         "8fa9494e26ae6b5c68fccd20": [
-            [{
+            [
+                {
                     "_tpl": "5d1b2ffd86f77425243e8d17",
                     "count": 2
-                }, {
+                },
+                {
                     "_tpl": "5d1b2fa286f77425227d1674",
                     "count": 1
                 }
             ]
         ],
         "64156ef7a70e700a91fa1b8a": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 51000
                 }
             ]
         ],
         "d8164c716ada59d45f408efe": [
-            [{
+            [
+                {
                     "_tpl": "5737201124597760fc4431f1",
                     "count": 6
                 }
             ]
         ],
         "63bfefcf3ba0e6fdfe9e218a": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 75
                 }
             ]
         ],
         "a42cfec0d481218fafaedfd7": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2200
                 }
             ]
         ],
         "f3fdee5c0a803449e2b7ebf2": [
-            [{
+            [
+                {
                     "_tpl": "590c5d4b86f774784e1b9c45",
                     "count": 3
                 }
             ]
         ],
         "25afb67abb3fbbce0acaa089": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 21000
                 }
             ]
         ],
         "cb4acecde9baec539a62da71": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3300
                 }
             ]
         ],
         "9fb2fbaede7ffc0d75fefade": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5200
                 }
             ]
         ],
         "5eb4baf778cc3de2e4b3a655": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 12500
                 }
             ]
         ],
         "3da4fd75e2ff9cef10dbb93d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5200
                 }
             ]
         ],
         "cdaca450e6bb3d8c34a34e77": [
-            [{
+            [
+                {
                     "_tpl": "5d6d2ef3a4b93618084f58bd",
                     "count": 1
                 }
             ]
         ],
         "637eace9ce063ef4905bfe1b": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 10500
                 }
             ]
         ],
         "ede0c041f1745b50d6aeee8c": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 113000
                 }
             ]
         ],
         "dcbe6dd65b0fad9af9613ebc": [
-            [{
+            [
+                {
                     "_tpl": "5d4042a986f7743185265463",
                     "count": 5
                 }
             ]
         ],
         "a455ef9e2c766cc4eadce8b6": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 55500
                 }
             ]
         ],
         "bbabbbcbadc33f5d4fbfbaac": [
-            [{
+            [
+                {
                     "_tpl": "5efb0fc6aeb21837e749c801",
                     "count": 3
                 }
             ]
         ],
         "a21a702f3f459ee2ed8fecb8": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 360
                 }
             ]
         ],
         "5f8ddbc9d1ef0e979b4bf6ae": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1800
                 }
             ]
         ],
         "5ce84d8f4d1cb6439b3f2f43": [
-            [{
+            [
+                {
                     "_tpl": "5ea2a8e200685063ec28c05a",
                     "count": 4
                 }
             ]
         ],
         "d51efbffa21acf695dffbdfd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 600
                 }
             ]
         ],
         "a3addf8d2ff7fcbabbe41fac": [
-            [{
+            [
+                {
                     "_tpl": "5e81f423763d9f754677bf2e",
                     "count": 3
                 }
             ]
         ],
         "6dfcc3abbc72eacca9d876e0": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 65
                 }
             ]
         ],
         "fd4ea54bb4faedcd1534cc91": [
-            [{
+            [
+                {
                     "_tpl": "5c925fa22e221601da359b7b",
                     "count": 3
                 }
             ]
         ],
         "c7c89cceb7784ba782ebdab2": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 520
                 }
             ]
         ],
         "360436dadb8e7ae7791cae75": [
-            [{
+            [
+                {
                     "_tpl": "5a3c16fe86f77452b62de32a",
                     "count": 3
                 }
             ]
         ],
         "fb2abbccdfeb412605e07fe2": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 270
                 }
             ]
         ],
         "c9bbc0eb1bab34bb7eb82fba": [
-            [{
+            [
+                {
                     "_tpl": "5efb0d4f4bc50b58e81710f3",
                     "count": 4
                 }
             ]
         ],
         "c7e5ec38ab530f97e251ef78": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 135
                 }
             ]
         ],
         "54d28a12e773aeef1a0ebd4a": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 63000
                 }
             ]
         ],
         "fdd72a909dc6bb25a43a27b2": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 21000
                 }
             ]
         ],
         "0f60b93c29a52aaa6d1aadb2": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 22500
                 }
             ]
         ],
         "7f8f9e5befc5c2301aacf31d": [
-            [{
+            [
+                {
                     "_tpl": "5d1b33a686f7742523398398",
                     "count": 2
                 }
             ]
         ],
         "055f0b1adae017b34e200261": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 48000
                 }
             ]
         ],
         "b9cc2b686082dd7875d7eef4": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 75000
                 }
             ]
         ],
         "1254d5ccefdaf9a3d3bd1a32": [
-            [{
+            [
+                {
                     "_tpl": "59faff1d86f7746c51718c9c",
                     "count": 1
                 }
             ]
         ],
         "706bbc2e7e6f0aa5cbb739d6": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 165000
                 }
             ]
         ],
         "3b599e4fa7eea0fd56c690c9": [
-            [{
+            [
+                {
                     "_tpl": "5734773724597737fd047c14",
                     "count": 6
                 }
             ]
         ],
         "eeba2eb4ddaceeea20ddab1a": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 54000
                 }
             ]
         ],
         "bba2edf2e3af5aa89cfc0cfe": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1300
                 }
             ]
         ],
         "a44dfffc36fde586f68fe2c1": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 4000
                 }
             ]
         ],
         "2ab5a3ea6c9865161ae7bf1b": [
-            [{
+            [
+                {
                     "_tpl": "6196364158ef8c428c287d9f",
                     "count": 3
                 }
             ]
         ],
         "a8d6e6f6cdffcae177bf4834": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 240
                 }
             ]
         ],
         "ee2afb8cfb954d413b1ef95a": [
-            [{
+            [
+                {
                     "_tpl": "544fb3f34bdc2d03748b456a",
                     "count": 5
                 }
             ]
         ],
         "8da19e3fc5b0c049798ebccd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 40000
                 }
             ]
         ],
         "ac30fc6c8b0fe5c833bf4fd6": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1900
                 }
             ]
         ],
         "cab3bd2bbcbc04261bcdb2e5": [
-            [{
+            [
+                {
                     "_tpl": "59e3577886f774176a362503",
                     "count": 6
                 }
             ]
         ],
         "f56f21853db9b53d4ac5dd5d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 50000
                 }
             ]
         ],
         "48eefecd10abc2fb87c6522e": [
-            [{
+            [
+                {
                     "_tpl": "619636be6db0f2477964e710",
                     "count": 10
                 }
             ]
         ],
         "fc7bdc3fedf43f8c9fc88fd2": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 725
                 }
             ]
         ],
         "89ef642beb27bdf51ffbb4b7": [
-            [{
+            [
+                {
                     "_tpl": "5d235b4d86f7742e017bc88a",
                     "count": 3
                 }
             ]
         ],
         "30d38a39f4ae6338a4128f1f": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 55000
                 }
             ]
         ],
         "3bf2186faab1aa8fe38fdb7e": [
-            [{
+            [
+                {
                     "_tpl": "6196365d58ef8c428c287da1",
                     "count": 3
                 }
             ]
         ],
         "f2471030b1ac6bf06b2aac1b": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 135
                 }
             ]
         ],
         "0ab0cd246a7e3a38c2ad6b4d": [
-            [{
+            [
+                {
                     "_tpl": "5d6e6911a4b9361bd5780d52",
                     "count": 2
                 }
             ]
         ],
         "0a7bcdb53e27eec9fb318f0a": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 105
                 }
             ]
         ],
         "8a193beffcdce75b82ffcc37": [
-            [{
+            [
+                {
                     "_tpl": "5fbe3ffdf8b6a877a729ea82",
                     "count": 3
                 }
             ]
         ],
         "fba15a623c779d1cafc09088": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 360
                 }
             ]
         ],
         "ddc32da7abafdeaca4e62c74": [
-            [{
+            [
+                {
                     "_tpl": "590a3c0a86f774385a33c450",
                     "count": 3
-                }, {
+                },
+                {
                     "_tpl": "59e36c6f86f774176c10a2a7",
                     "count": 5
                 }
             ]
         ],
         "df41faf3dec812bb69aece6d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 54000
                 }
             ]
         ],
         "edefbc1e1e81e1c3aee5e0c6": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "5da63b260eca83e9cefbd1ad": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 230
                 }
             ]
         ],
         "64922cbcebffceeeea5ad7a5": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "d3d5ed8e05e02a233770ca06": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 100
                 }
             ]
         ],
         "fd3af4d1f7c8a28c6d3538b8": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "bcec0a0eb24c1fbdd7bd1437": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 460
                 }
             ]
         ],
         "d2023daced2c72d8a7d858e7": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "4a76efbf9ad1ed239033dbeb": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 49000
                 }
             ]
         ],
         "4bac8d6dcefb3a0cad419f56": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "dcb2d8f8d4b5fd2ffb4e96de": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 61000
                 }
             ]
         ],
         "a57e52aefc8ede2ed9eafa1f": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "36e6e5da727bcbf1ecfb6ef3": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 37000
                 }
             ]
         ],
         "099cd41b2f9c849ff68efda7": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3000
                 }
             ]
         ],
         "c3adac0c4ccf4b56eca2fc50": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2400
                 }
             ]
         ]
     },
-    "items": [{
+    "items": [
+        {
             "_id": "d8164c716ada59d45f408efe",
             "_tpl": "5e81f423763d9f754677bf2e",
             "parentId": "hideout",
@@ -1605,7 +1837,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a3addf8d2ff7fcbabbe41fac",
             "_tpl": "5efb0d4f4bc50b58e81710f3",
             "parentId": "hideout",
@@ -1616,7 +1849,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c9bbc0eb1bab34bb7eb82fba",
             "_tpl": "5efb0fc6aeb21837e749c801",
             "parentId": "hideout",
@@ -1627,7 +1861,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "5f8ddbc9d1ef0e979b4bf6ae",
             "_tpl": "5ef3448ab37dfd6af863525c",
             "parentId": "hideout",
@@ -1638,7 +1873,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bbabbbcbadc33f5d4fbfbaac",
             "_tpl": "5ea2a8e200685063ec28c05a",
             "parentId": "hideout",
@@ -1649,7 +1885,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a44dfffc36fde586f68fe2c1",
             "_tpl": "5fb651dc85f90547f674b6f4",
             "parentId": "hideout",
@@ -1660,7 +1897,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "5ce84d8f4d1cb6439b3f2f43",
             "_tpl": "5efb0cabfb3e451d70735af5",
             "parentId": "hideout",
@@ -1671,7 +1909,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "63bfefcf3ba0e6fdfe9e218a",
             "_tpl": "5e81f423763d9f754677bf2e",
             "parentId": "hideout",
@@ -1682,7 +1921,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "6dfcc3abbc72eacca9d876e0",
             "_tpl": "5efb0d4f4bc50b58e81710f3",
             "parentId": "hideout",
@@ -1693,7 +1933,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c7e5ec38ab530f97e251ef78",
             "_tpl": "5efb0fc6aeb21837e749c801",
             "parentId": "hideout",
@@ -1704,7 +1945,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a21a702f3f459ee2ed8fecb8",
             "_tpl": "5ea2a8e200685063ec28c05a",
             "parentId": "hideout",
@@ -1715,7 +1957,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d51efbffa21acf695dffbdfd",
             "_tpl": "5efb0cabfb3e451d70735af5",
             "parentId": "hideout",
@@ -1726,7 +1969,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c554dccc730ccae2e6fccb0b",
             "_tpl": "5ba26812d4351e003201fef1",
             "parentId": "hideout",
@@ -1737,7 +1981,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "762eedaabb6f6ecca9e0edda",
             "_tpl": "5ba26844d4351e00334c9475",
             "parentId": "hideout",
@@ -1748,7 +1993,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ba0b2efdc707d20a50bcf9ed",
             "_tpl": "5ba2657ed4351e0035628ff2",
             "parentId": "hideout",
@@ -1759,7 +2005,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ee685e4dae31cfbb2bf9cdb1",
             "_tpl": "5ba2678ad4351e44f824b344",
             "parentId": "hideout",
@@ -1770,7 +2017,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "dbefe090123ecf1d6a29fab7",
             "_tpl": "5ba26835d4351e0035628ff5",
             "parentId": "hideout",
@@ -1781,7 +2029,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b5ec0ccd20e80a520e8ca1ac",
             "_tpl": "5ba26586d4351e44f824b340",
             "parentId": "hideout",
@@ -1792,7 +2041,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "6445be79d68ff6ac7ac7fc1e",
             "_tpl": "5ba26812d4351e003201fef1",
             "parentId": "hideout",
@@ -1803,7 +2053,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f5afa9cb6f4e95c4effc5acc",
             "_tpl": "5ba26844d4351e00334c9475",
             "parentId": "hideout",
@@ -1814,7 +2065,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b7ba97bed5ae6d3d1eafce2f",
             "_tpl": "5ba2678ad4351e44f824b344",
             "parentId": "hideout",
@@ -1825,7 +2077,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "3a1fd1a3f34ca2d9f8c3c8ff",
             "_tpl": "5ba26835d4351e0035628ff5",
             "parentId": "hideout",
@@ -1836,7 +2089,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "0ab0cd246a7e3a38c2ad6b4d",
             "_tpl": "6196365d58ef8c428c287da1",
             "parentId": "hideout",
@@ -1847,7 +2101,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "3bf2186faab1aa8fe38fdb7e",
             "_tpl": "6196364158ef8c428c287d9f",
             "parentId": "hideout",
@@ -1858,7 +2113,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "2ab5a3ea6c9865161ae7bf1b",
             "_tpl": "5fbe3ffdf8b6a877a729ea82",
             "parentId": "hideout",
@@ -1869,7 +2125,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "8a193beffcdce75b82ffcc37",
             "_tpl": "619636be6db0f2477964e710",
             "parentId": "hideout",
@@ -1880,7 +2137,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "48eefecd10abc2fb87c6522e",
             "_tpl": "5fd20ff893a8961fc660a954",
             "parentId": "hideout",
@@ -1891,7 +2149,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "0a7bcdb53e27eec9fb318f0a",
             "_tpl": "6196365d58ef8c428c287da1",
             "parentId": "hideout",
@@ -1902,7 +2161,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f2471030b1ac6bf06b2aac1b",
             "_tpl": "6196364158ef8c428c287d9f",
             "parentId": "hideout",
@@ -1913,7 +2173,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a8d6e6f6cdffcae177bf4834",
             "_tpl": "5fbe3ffdf8b6a877a729ea82",
             "parentId": "hideout",
@@ -1924,7 +2185,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fba15a623c779d1cafc09088",
             "_tpl": "619636be6db0f2477964e710",
             "parentId": "hideout",
@@ -1935,7 +2197,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fc7bdc3fedf43f8c9fc88fd2",
             "_tpl": "5fd20ff893a8961fc660a954",
             "parentId": "hideout",
@@ -1946,7 +2209,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "5513f6c7155b5ed8731abff7",
             "_tpl": "58864a4f2459770fcc257101",
             "parentId": "hideout",
@@ -1957,7 +2221,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "4db52961fe841e07df9cf7eb",
             "_tpl": "5c3df7d588a4501f290594e5",
             "parentId": "hideout",
@@ -1968,7 +2233,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "4dfa00005451cb7add4284ac",
             "_tpl": "5de8ea8ffd6b4e6e2276dc35",
             "parentId": "hideout",
@@ -1979,7 +2245,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b629cffeee7365bbbdb4fdf9",
             "_tpl": "5894a05586f774094708ef75",
             "parentId": "hideout",
@@ -1990,7 +2257,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ff109e00a8dde480eefa87fb",
             "_tpl": "56d59d3ad2720bdb418b4577",
             "parentId": "hideout",
@@ -2001,7 +2269,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "9c57bd1cd8bfa381ce391fcd",
             "_tpl": "5739d41224597779c3645501",
             "parentId": "hideout",
@@ -2012,7 +2281,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "364bcd572edfcc0eede35b82",
             "_tpl": "56d59d3ad2720bdb418b4577",
             "parentId": "9c57bd1cd8bfa381ce391fcd",
@@ -2021,7 +2291,8 @@
             "upd": {
                 "StackObjectsCount": 16
             }
-        }, {
+        },
+        {
             "_id": "aa8cfaf93a0a12f3a61fa33b",
             "_tpl": "5926c3b286f774640d189b6b",
             "parentId": "hideout",
@@ -2032,7 +2303,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a1ceaecdd0ca33ac6ede8fdf",
             "_tpl": "5a3c16fe86f77452b62de32a",
             "parentId": "hideout",
@@ -2043,7 +2315,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ead40fcbfed6589bb4d5bfe5",
             "_tpl": "5de8eaadbbaf010b10528a6d",
             "parentId": "hideout",
@@ -2054,7 +2327,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "360436dadb8e7ae7791cae75",
             "_tpl": "5efb0e16aeb21837e749c7ff",
             "parentId": "hideout",
@@ -2065,7 +2339,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bcff76cf2f12963e14cc6ba0",
             "_tpl": "5c920e902e221644f31c3c99",
             "parentId": "hideout",
@@ -2076,7 +2351,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "4f71eccb9884c69a1c1a2538",
             "_tpl": "5c0672ed0db834001b7353f3",
             "parentId": "hideout",
@@ -2087,7 +2363,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d5c5a21fb1fcbfcbdbdd4ecf",
             "_tpl": "599860ac86f77436b225ed1a",
             "parentId": "hideout",
@@ -2098,7 +2375,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fbedd2b04e2ae33febbd7ebc",
             "_tpl": "5c5db6652e221600113fba51",
             "parentId": "hideout",
@@ -2109,7 +2387,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "3bcca6aacfafdb6edf1025ab",
             "_tpl": "5c0d56a986f774449d5de529",
             "parentId": "hideout",
@@ -2120,7 +2399,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b8aa67394c3c826a5c20b8c4",
             "_tpl": "5c1127bdd174af44217ab8b9",
             "parentId": "hideout",
@@ -2131,7 +2411,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "00983daaac2acfdb2c45be0d",
             "_tpl": "5c0d56a986f774449d5de529",
             "parentId": "b8aa67394c3c826a5c20b8c4",
@@ -2140,7 +2421,8 @@
             "upd": {
                 "StackObjectsCount": 20
             }
-        }, {
+        },
+        {
             "_id": "9d2e7ec756fb719f65440bb1",
             "_tpl": "5a351711c4a282000b1521a4",
             "parentId": "hideout",
@@ -2151,7 +2433,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "acc0590e51abf65d0be5dcee",
             "_tpl": "5c925fa22e221601da359b7b",
             "parentId": "hideout",
@@ -2162,7 +2445,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "6e0a2ab073bb0f04b7e7bc19",
             "_tpl": "5de8eac42a78646d96665d91",
             "parentId": "hideout",
@@ -2173,7 +2457,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "4c12bbc8f9d4cb99c5dbbca8",
             "_tpl": "5c5db6742e2216000f1b2852",
             "parentId": "hideout",
@@ -2184,7 +2469,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fd4ea54bb4faedcd1534cc91",
             "_tpl": "5efb0da7a29a85116f6ea05f",
             "parentId": "hideout",
@@ -2195,7 +2481,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d01ac040ed0e7ec2afaf000f",
             "_tpl": "5a718f958dc32e00094b97e7",
             "parentId": "hideout",
@@ -2206,7 +2493,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "db39e5eba0da6e91ac7d0baf",
             "_tpl": "58864a4f2459770fcc257101",
             "parentId": "hideout",
@@ -2217,7 +2505,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "0c01ae762a3d31f9d3faadef",
             "_tpl": "5c3df7d588a4501f290594e5",
             "parentId": "hideout",
@@ -2228,7 +2517,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "49cbcb5c5fdbc6790e0a5ada",
             "_tpl": "56d59d3ad2720bdb418b4577",
             "parentId": "hideout",
@@ -2239,7 +2529,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f07ecb6db63bb03eac6fcfab",
             "_tpl": "5a3c16fe86f77452b62de32a",
             "parentId": "hideout",
@@ -2250,7 +2541,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fb2abbccdfeb412605e07fe2",
             "_tpl": "5efb0e16aeb21837e749c7ff",
             "parentId": "hideout",
@@ -2261,7 +2553,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "dfacfe909d6558de7ced5138",
             "_tpl": "5c0d56a986f774449d5de529",
             "parentId": "hideout",
@@ -2272,7 +2565,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "03842e3abd93bda4bcd836cb",
             "_tpl": "5c925fa22e221601da359b7b",
             "parentId": "hideout",
@@ -2283,7 +2577,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c7c89cceb7784ba782ebdab2",
             "_tpl": "5efb0da7a29a85116f6ea05f",
             "parentId": "hideout",
@@ -2294,7 +2589,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "2c477417ea95eae017c9e01f",
             "_tpl": "59e7711e86f7746cae05fbe1",
             "parentId": "hideout",
@@ -2305,22 +2601,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b21",
             "_tpl": "657ba50c23918923cb0df56c",
             "parentId": "2c477417ea95eae017c9e01f",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b22",
             "_tpl": "657ba5439ba22f103e08139f",
             "parentId": "2c477417ea95eae017c9e01f",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b23",
             "_tpl": "657ba57af58ba5a62501079e",
             "parentId": "2c477417ea95eae017c9e01f",
             "slotId": "Helmet_ears"
-        }, {
+        },
+        {
             "_id": "685b7bdaf4ab7190803721d0",
             "_tpl": "5c08f87c0db8340019124324",
             "parentId": "hideout",
@@ -2331,27 +2631,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b24",
             "_tpl": "657ba85ecfcf63c951052da7",
             "parentId": "685b7bdaf4ab7190803721d0",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b25",
             "_tpl": "657ba8bccfcf63c951052dab",
             "parentId": "685b7bdaf4ab7190803721d0",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b26",
             "_tpl": "65818e4e566d2de69901b1b1",
             "parentId": "685b7bdaf4ab7190803721d0",
             "slotId": "helmet_eyes"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b27",
             "_tpl": "657ba8eab7e9ca9a02045bfd",
             "parentId": "685b7bdaf4ab7190803721d0",
             "slotId": "Helmet_ears"
-        }, {
+        },
+        {
             "_id": "4f4ebc0fbba3a49c6c5fb461",
             "_tpl": "5c0d2727d174af02a012cf58",
             "parentId": "hideout",
@@ -2362,27 +2667,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b28",
             "_tpl": "657ba6c3c6f689d3a205b857",
             "parentId": "4f4ebc0fbba3a49c6c5fb461",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b29",
             "_tpl": "657ba737b7e9ca9a02045bf6",
             "parentId": "4f4ebc0fbba3a49c6c5fb461",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b2a",
             "_tpl": "658188edf026a90c1708c827",
             "parentId": "4f4ebc0fbba3a49c6c5fb461",
             "slotId": "helmet_eyes"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b2b",
             "_tpl": "657ba75e23918923cb0df573",
             "parentId": "4f4ebc0fbba3a49c6c5fb461",
             "slotId": "Helmet_ears"
-        }, {
+        },
+        {
             "_id": "afd3a6259deff7df0eb300a4",
             "_tpl": "5a16bb52fcdbcb001a3b00dc",
             "parentId": "hideout",
@@ -2393,7 +2703,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "3c4f321dc26ddfdade21e1fa",
             "_tpl": "5df8a58286f77412631087ed",
             "parentId": "hideout",
@@ -2404,22 +2715,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b2c",
             "_tpl": "657ba096e57570b7f80a17fb",
             "parentId": "3c4f321dc26ddfdade21e1fa",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b2d",
             "_tpl": "657ba145e57570b7f80a17ff",
             "parentId": "3c4f321dc26ddfdade21e1fa",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b2e",
             "_tpl": "657ba18923918923cb0df568",
             "parentId": "3c4f321dc26ddfdade21e1fa",
             "slotId": "Helmet_ears"
-        }, {
+        },
+        {
             "_id": "cdaca450e6bb3d8c34a34e77",
             "_tpl": "5ea05cf85ad9772e6624305d",
             "parentId": "hideout",
@@ -2430,17 +2745,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b2f",
             "_tpl": "657ba2eef58ba5a625010798",
             "parentId": "cdaca450e6bb3d8c34a34e77",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b30",
             "_tpl": "657ba34b9ba22f103e08139b",
             "parentId": "cdaca450e6bb3d8c34a34e77",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "cfc41c8b0ad9d8f2ea8e8e6a",
             "_tpl": "5c06c6a80db834001b735491",
             "parentId": "hideout",
@@ -2451,22 +2769,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b31",
             "_tpl": "6571199565daf6aa960c9b10",
             "parentId": "cfc41c8b0ad9d8f2ea8e8e6a",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b32",
             "_tpl": "657119d49eb8c145180dbb95",
             "parentId": "cfc41c8b0ad9d8f2ea8e8e6a",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b33",
             "_tpl": "657119fea330b8c9060f7afc",
             "parentId": "cfc41c8b0ad9d8f2ea8e8e6a",
             "slotId": "Helmet_ears"
-        }, {
+        },
+        {
             "_id": "dfeae76c2aed94ebee2db4e8",
             "_tpl": "5645bc214bdc2d363b8b4571",
             "parentId": "hideout",
@@ -2477,22 +2799,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b34",
             "_tpl": "657bae18b7e9ca9a02045c0a",
             "parentId": "dfeae76c2aed94ebee2db4e8",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b35",
             "_tpl": "657baeaacfcf63c951052db3",
             "parentId": "dfeae76c2aed94ebee2db4e8",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b36",
             "_tpl": "657baecbc6f689d3a205b863",
             "parentId": "dfeae76c2aed94ebee2db4e8",
             "slotId": "Helmet_ears"
-        }, {
+        },
+        {
             "_id": "d57eed678ae9bfef5d13efab",
             "_tpl": "5b432d215acfc4771e1c6624",
             "parentId": "hideout",
@@ -2503,17 +2829,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b37",
             "_tpl": "657bb92fa1c61ee0c303631f",
             "parentId": "d57eed678ae9bfef5d13efab",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b38",
             "_tpl": "657bb99db30eca976305117f",
             "parentId": "d57eed678ae9bfef5d13efab",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "dbf7e6c04b7b0dd1e90b3e0e",
             "_tpl": "5aa7d193e5b5b000171d063f",
             "parentId": "hideout",
@@ -2524,22 +2853,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b39",
             "_tpl": "657bb70486c7f9ef7a009936",
             "parentId": "dbf7e6c04b7b0dd1e90b3e0e",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b3a",
             "_tpl": "657bb79ba1c61ee0c303631a",
             "parentId": "dbf7e6c04b7b0dd1e90b3e0e",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b3b",
             "_tpl": "657bb7d7b30eca9763051176",
             "parentId": "dbf7e6c04b7b0dd1e90b3e0e",
             "slotId": "Helmet_ears"
-        }, {
+        },
+        {
             "_id": "c39ea5eedfd45a72e9b1ffb3",
             "_tpl": "5aa7d03ae5b5b00016327db5",
             "parentId": "hideout",
@@ -2550,22 +2883,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b3c",
             "_tpl": "654a90aff4f81a421b0a7c86",
             "parentId": "c39ea5eedfd45a72e9b1ffb3",
             "slotId": "helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b3d",
             "_tpl": "654a91068e1ce698150fd1e2",
             "parentId": "c39ea5eedfd45a72e9b1ffb3",
             "slotId": "helmet_back"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b3e",
             "_tpl": "654a9189bcc67a392b056c79",
             "parentId": "c39ea5eedfd45a72e9b1ffb3",
             "slotId": "helmet_ears"
-        }, {
+        },
+        {
             "_id": "134cbe54aabbe3b49ede24fd",
             "_tpl": "5a7c4850e899ef00150be885",
             "parentId": "hideout",
@@ -2576,22 +2913,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b3f",
             "_tpl": "657baaf0b7e9ca9a02045c02",
             "parentId": "134cbe54aabbe3b49ede24fd",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b40",
             "_tpl": "657bab6ec6f689d3a205b85f",
             "parentId": "134cbe54aabbe3b49ede24fd",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b41",
             "_tpl": "657babc6f58ba5a6250107a2",
             "parentId": "134cbe54aabbe3b49ede24fd",
             "slotId": "Helmet_ears"
-        }, {
+        },
+        {
             "_id": "ddc32da7abafdeaca4e62c74",
             "_tpl": "61bca7cda0eae612383adf57",
             "parentId": "hideout",
@@ -2602,17 +2943,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b42",
             "_tpl": "657bbcc9a1c61ee0c3036327",
             "parentId": "ddc32da7abafdeaca4e62c74",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b43",
             "_tpl": "657bbcffbbd440df880b2dd5",
             "parentId": "ddc32da7abafdeaca4e62c74",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "fbc0a8d0fc3ac65aa3bba661",
             "_tpl": "5b4329f05acfc47a86086aa1",
             "parentId": "hideout",
@@ -2623,32 +2967,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b44",
             "_tpl": "65711b07a330b8c9060f7b01",
             "parentId": "fbc0a8d0fc3ac65aa3bba661",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b45",
             "_tpl": "65711b489eb8c145180dbb9d",
             "parentId": "fbc0a8d0fc3ac65aa3bba661",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b46",
             "_tpl": "65711b9b65daf6aa960c9b1b",
             "parentId": "fbc0a8d0fc3ac65aa3bba661",
             "slotId": "helmet_eyes"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b47",
             "_tpl": "65711bc79eb8c145180dbba1",
             "parentId": "fbc0a8d0fc3ac65aa3bba661",
             "slotId": "helmet_jaw"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b48",
             "_tpl": "65711b706d197c216005b31c",
             "parentId": "fbc0a8d0fc3ac65aa3bba661",
             "slotId": "Helmet_ears"
-        }, {
+        },
+        {
             "_id": "cf3a1965f725ecbc81c7545d",
             "_tpl": "5aa7e4a4e5b5b000137b76f2",
             "parentId": "hideout",
@@ -2659,22 +3009,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b49",
             "_tpl": "657f925dada5fadd1f07a57a",
             "parentId": "cf3a1965f725ecbc81c7545d",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b4a",
             "_tpl": "657f92acada5fadd1f07a57e",
             "parentId": "cf3a1965f725ecbc81c7545d",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b4b",
             "_tpl": "657f92e7f4c82973640b2354",
             "parentId": "cf3a1965f725ecbc81c7545d",
             "slotId": "Helmet_ears"
-        }, {
+        },
+        {
             "_id": "fd5dc6c29021fbfcdd29bce2",
             "_tpl": "5d5e7d28a4b936645d161203",
             "parentId": "hideout",
@@ -2685,17 +3039,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b4c",
             "_tpl": "657f8a8d7db258e5600fe33d",
             "parentId": "fd5dc6c29021fbfcdd29bce2",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b4d",
             "_tpl": "657f8b05f4c82973640b2348",
             "parentId": "fd5dc6c29021fbfcdd29bce2",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "d5bba9bd21b779abfdddbe9e",
             "_tpl": "5d5e9c74a4b9364855191c40",
             "parentId": "hideout",
@@ -2706,17 +3063,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b4e",
             "_tpl": "657f8b94f92cd718b70154ff",
             "parentId": "d5bba9bd21b779abfdddbe9e",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b4f",
             "_tpl": "657f8b43f92cd718b70154fb",
             "parentId": "d5bba9bd21b779abfdddbe9e",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "9e1a1c3faeefb88c67846aaf",
             "_tpl": "5b40e3f35acfc40016388218",
             "parentId": "hideout",
@@ -2727,17 +3087,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b50",
             "_tpl": "657f95bff92cd718b701550c",
             "parentId": "9e1a1c3faeefb88c67846aaf",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b51",
             "_tpl": "657f9605f4c82973640b2358",
             "parentId": "9e1a1c3faeefb88c67846aaf",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "8fa9494e26ae6b5c68fccd20",
             "_tpl": "5e4bfc1586f774264f7582d3",
             "parentId": "hideout",
@@ -2748,17 +3111,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b52",
             "_tpl": "657f9c78ada5fadd1f07a58d",
             "parentId": "8fa9494e26ae6b5c68fccd20",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b53",
             "_tpl": "657f9cb587e11c61f70bfaca",
             "parentId": "8fa9494e26ae6b5c68fccd20",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "72fdb7f3a277dfd6eabfafe3",
             "_tpl": "5c066ef40db834001966a595",
             "parentId": "hideout",
@@ -2769,7 +3135,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "be0f57a8dfcd34bd7dfe5803",
             "_tpl": "5c066e3a0db834001b7353f0",
             "parentId": "hideout",
@@ -2780,7 +3147,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a3760f2fe7af2ced96fdda0f",
             "_tpl": "5d6d3716a4b9361bc8618872",
             "parentId": "hideout",
@@ -2791,22 +3159,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b54",
             "_tpl": "657fa009d4caf976440afe3a",
             "parentId": "a3760f2fe7af2ced96fdda0f",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b55",
             "_tpl": "657fa04ac6679fefb3051e24",
             "parentId": "a3760f2fe7af2ced96fdda0f",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b56",
             "_tpl": "657fa07387e11c61f70bface",
             "parentId": "a3760f2fe7af2ced96fdda0f",
             "slotId": "Helmet_ears"
-        }, {
+        },
+        {
             "_id": "1da5efc9bd2954b0ffd862c8",
             "_tpl": "5c091a4e0db834001d5addc8",
             "parentId": "hideout",
@@ -2817,22 +3189,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b57",
             "_tpl": "6571133d22996eaf11088200",
             "parentId": "1da5efc9bd2954b0ffd862c8",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b58",
             "_tpl": "6571138e818110db4600aa71",
             "parentId": "1da5efc9bd2954b0ffd862c8",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b59",
             "_tpl": "657112fa818110db4600aa6b",
             "parentId": "1da5efc9bd2954b0ffd862c8",
             "slotId": "Helmet_ears"
-        }, {
+        },
+        {
             "_id": "dcbe6dd65b0fad9af9613ebc",
             "_tpl": "5ea17ca01412a1425304d1c0",
             "parentId": "hideout",
@@ -2843,17 +3219,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b5a",
             "_tpl": "657f9a55c6679fefb3051e19",
             "parentId": "dcbe6dd65b0fad9af9613ebc",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b5b",
             "_tpl": "657f9a94ada5fadd1f07a589",
             "parentId": "dcbe6dd65b0fad9af9613ebc",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "faf2b1d5e543abb9b72966ab",
             "_tpl": "5b40e1525acfc4771e1c6611",
             "parentId": "hideout",
@@ -2864,22 +3243,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b5c",
             "_tpl": "657112234269e9a568089eac",
             "parentId": "faf2b1d5e543abb9b72966ab",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b5d",
             "_tpl": "657112a4818110db4600aa66",
             "parentId": "faf2b1d5e543abb9b72966ab",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b5e",
             "_tpl": "657112ce22996eaf110881fb",
             "parentId": "faf2b1d5e543abb9b72966ab",
             "slotId": "Helmet_ears"
-        }, {
+        },
+        {
             "_id": "7f8f9e5befc5c2301aacf31d",
             "_tpl": "5f60b34a41e30a4ab12a6947",
             "parentId": "hideout",
@@ -2890,17 +3273,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b5f",
             "_tpl": "657bbad7a1c61ee0c3036323",
             "parentId": "7f8f9e5befc5c2301aacf31d",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b60",
             "_tpl": "657bbb31b30eca9763051183",
             "parentId": "7f8f9e5befc5c2301aacf31d",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "d4dece77c70ad1dedde21fee",
             "_tpl": "5a154d5cfcdbcb001a3b00da",
             "parentId": "hideout",
@@ -2911,17 +3297,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b61",
             "_tpl": "657f8ec5f4c82973640b234c",
             "parentId": "d4dece77c70ad1dedde21fee",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b62",
             "_tpl": "657f8f10f4c82973640b2350",
             "parentId": "d4dece77c70ad1dedde21fee",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "e83ddc049dee9f799566c41a",
             "_tpl": "5c17a7ed2e2216152142459c",
             "parentId": "hideout",
@@ -2932,17 +3321,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b63",
             "_tpl": "657f9897f4c82973640b235e",
             "parentId": "e83ddc049dee9f799566c41a",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b64",
             "_tpl": "657f98fbada5fadd1f07a585",
             "parentId": "e83ddc049dee9f799566c41a",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "3d950b64d16c7c245d6b5f9e",
             "_tpl": "5aa7e276e5b5b000171d0647",
             "parentId": "hideout",
@@ -2953,22 +3345,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b65",
             "_tpl": "657bc06daab96fccee08be9b",
             "parentId": "3d950b64d16c7c245d6b5f9e",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b66",
             "_tpl": "657bc0d8a1c61ee0c303632f",
             "parentId": "3d950b64d16c7c245d6b5f9e",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b67",
             "_tpl": "657bc107aab96fccee08be9f",
             "parentId": "3d950b64d16c7c245d6b5f9e",
             "slotId": "Helmet_ears"
-        }, {
+        },
+        {
             "_id": "1254d5ccefdaf9a3d3bd1a32",
             "_tpl": "5f60c74e3b85f6263c145586",
             "parentId": "hideout",
@@ -2979,22 +3375,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b68",
             "_tpl": "657bc285aab96fccee08bea3",
             "parentId": "1254d5ccefdaf9a3d3bd1a32",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b69",
             "_tpl": "657bc2c5a1c61ee0c3036333",
             "parentId": "1254d5ccefdaf9a3d3bd1a32",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b6a",
             "_tpl": "657bc2e7b30eca976305118d",
             "parentId": "1254d5ccefdaf9a3d3bd1a32",
             "slotId": "Helmet_ears"
-        }, {
+        },
+        {
             "_id": "1ecbdfb87cb0ffca0c546c62",
             "_tpl": "5e00c1ad86f774747333222c",
             "parentId": "hideout",
@@ -3005,17 +3405,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b6b",
             "_tpl": "6551fec55d0cf82e51014288",
             "parentId": "1ecbdfb87cb0ffca0c546c62",
             "slotId": "helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b6c",
             "_tpl": "655200ba0ef76cf7be09d528",
             "parentId": "1ecbdfb87cb0ffca0c546c62",
             "slotId": "helmet_back"
-        }, {
+        },
+        {
             "_id": "6aae6b7bb7b4312faabefc51",
             "_tpl": "5ca20ee186f774799474abc2",
             "parentId": "hideout",
@@ -3026,22 +3429,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b6d",
             "_tpl": "657bbe73a1c61ee0c303632b",
             "parentId": "6aae6b7bb7b4312faabefc51",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b6e",
             "_tpl": "657bbed0aab96fccee08be96",
             "parentId": "6aae6b7bb7b4312faabefc51",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b6f",
             "_tpl": "657bbefeb30eca9763051189",
             "parentId": "6aae6b7bb7b4312faabefc51",
             "slotId": "Helmet_ears"
-        }, {
+        },
+        {
             "_id": "1eaaadbbd63ebd7cb88ccc7e",
             "_tpl": "59e7711e86f7746cae05fbe1",
             "parentId": "hideout",
@@ -3052,22 +3459,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b70",
             "_tpl": "657ba50c23918923cb0df56c",
             "parentId": "1eaaadbbd63ebd7cb88ccc7e",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b71",
             "_tpl": "657ba5439ba22f103e08139f",
             "parentId": "1eaaadbbd63ebd7cb88ccc7e",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b72",
             "_tpl": "657ba57af58ba5a62501079e",
             "parentId": "1eaaadbbd63ebd7cb88ccc7e",
             "slotId": "Helmet_ears"
-        }, {
+        },
+        {
             "_id": "63cd7aaedb0bbec7e50fbb25",
             "_tpl": "5ac4c50d5acfc40019262e87",
             "parentId": "hideout",
@@ -3078,7 +3489,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "8bcea9cbaa2f75ff22abafe7",
             "_tpl": "5c08f87c0db8340019124324",
             "parentId": "hideout",
@@ -3089,27 +3501,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b73",
             "_tpl": "657ba85ecfcf63c951052da7",
             "parentId": "8bcea9cbaa2f75ff22abafe7",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b74",
             "_tpl": "657ba8bccfcf63c951052dab",
             "parentId": "8bcea9cbaa2f75ff22abafe7",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b75",
             "_tpl": "65818e4e566d2de69901b1b1",
             "parentId": "8bcea9cbaa2f75ff22abafe7",
             "slotId": "helmet_eyes"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b76",
             "_tpl": "657ba8eab7e9ca9a02045bfd",
             "parentId": "8bcea9cbaa2f75ff22abafe7",
             "slotId": "Helmet_ears"
-        }, {
+        },
+        {
             "_id": "d69977a2fdb1cc6c4d771bee",
             "_tpl": "5c0d2727d174af02a012cf58",
             "parentId": "hideout",
@@ -3120,27 +3537,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b77",
             "_tpl": "657ba6c3c6f689d3a205b857",
             "parentId": "d69977a2fdb1cc6c4d771bee",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b78",
             "_tpl": "657ba737b7e9ca9a02045bf6",
             "parentId": "d69977a2fdb1cc6c4d771bee",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b79",
             "_tpl": "658188edf026a90c1708c827",
             "parentId": "d69977a2fdb1cc6c4d771bee",
             "slotId": "helmet_eyes"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b7a",
             "_tpl": "657ba75e23918923cb0df573",
             "parentId": "d69977a2fdb1cc6c4d771bee",
             "slotId": "Helmet_ears"
-        }, {
+        },
+        {
             "_id": "9f80addca7aa1dcd0beef6ef",
             "_tpl": "5a16bb52fcdbcb001a3b00dc",
             "parentId": "hideout",
@@ -3151,7 +3573,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "23e630e3ac5c0c0c32fa2fdc",
             "_tpl": "5a16b8a9fcdbcb00165aa6ca",
             "parentId": "hideout",
@@ -3162,7 +3585,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "98e0f0c9f9ce788ee52dc05a",
             "_tpl": "5a16b93dfcdbcbcae6687261",
             "parentId": "hideout",
@@ -3173,7 +3597,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "00bb3bd10a94d4dd0edae2b5",
             "_tpl": "57235b6f24597759bf5a30f1",
             "parentId": "hideout",
@@ -3184,7 +3609,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "1f416a7c5a7c6ddeaeebd5ff",
             "_tpl": "5df8a58286f77412631087ed",
             "parentId": "hideout",
@@ -3195,22 +3621,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b7b",
             "_tpl": "657ba096e57570b7f80a17fb",
             "parentId": "1f416a7c5a7c6ddeaeebd5ff",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b7c",
             "_tpl": "657ba145e57570b7f80a17ff",
             "parentId": "1f416a7c5a7c6ddeaeebd5ff",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b7d",
             "_tpl": "657ba18923918923cb0df568",
             "parentId": "1f416a7c5a7c6ddeaeebd5ff",
             "slotId": "Helmet_ears"
-        }, {
+        },
+        {
             "_id": "637eace9ce063ef4905bfe1b",
             "_tpl": "5ea05cf85ad9772e6624305d",
             "parentId": "hideout",
@@ -3221,17 +3651,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b7e",
             "_tpl": "657ba2eef58ba5a625010798",
             "parentId": "637eace9ce063ef4905bfe1b",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b7f",
             "_tpl": "657ba34b9ba22f103e08139b",
             "parentId": "637eace9ce063ef4905bfe1b",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "5eb4baf778cc3de2e4b3a655",
             "_tpl": "5a16b672fcdbcb001912fa83",
             "parentId": "hideout",
@@ -3242,7 +3675,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "3da4fd75e2ff9cef10dbb93d",
             "_tpl": "5a398ab9c4a282000c5a9842",
             "parentId": "hideout",
@@ -3253,7 +3687,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "9fb2fbaede7ffc0d75fefade",
             "_tpl": "59d790f486f77403cb06aec6",
             "parentId": "hideout",
@@ -3264,7 +3699,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "cb4acecde9baec539a62da71",
             "_tpl": "57d17c5e2459775a5c57d17d",
             "parentId": "hideout",
@@ -3275,7 +3711,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ccccfde8dbcaec0cdaecbe47",
             "_tpl": "5c06c6a80db834001b735491",
             "parentId": "hideout",
@@ -3286,22 +3723,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b80",
             "_tpl": "6571199565daf6aa960c9b10",
             "parentId": "ccccfde8dbcaec0cdaecbe47",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b81",
             "_tpl": "657119d49eb8c145180dbb95",
             "parentId": "ccccfde8dbcaec0cdaecbe47",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b82",
             "_tpl": "657119fea330b8c9060f7afc",
             "parentId": "ccccfde8dbcaec0cdaecbe47",
             "slotId": "Helmet_ears"
-        }, {
+        },
+        {
             "_id": "1cce5068f5ddbcaadac3ee4d",
             "_tpl": "5645bc214bdc2d363b8b4571",
             "parentId": "hideout",
@@ -3312,22 +3753,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b83",
             "_tpl": "657bae18b7e9ca9a02045c0a",
             "parentId": "1cce5068f5ddbcaadac3ee4d",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b84",
             "_tpl": "657baeaacfcf63c951052db3",
             "parentId": "1cce5068f5ddbcaadac3ee4d",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b85",
             "_tpl": "657baecbc6f689d3a205b863",
             "parentId": "1cce5068f5ddbcaadac3ee4d",
             "slotId": "Helmet_ears"
-        }, {
+        },
+        {
             "_id": "89ff7373b1fb0ec4c705db2d",
             "_tpl": "5b46238386f7741a693bcf9c",
             "parentId": "hideout",
@@ -3338,7 +3783,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c96f3e5d2360105f8bebcc9d",
             "_tpl": "5b432d215acfc4771e1c6624",
             "parentId": "hideout",
@@ -3349,17 +3795,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b86",
             "_tpl": "657bb92fa1c61ee0c303631f",
             "parentId": "c96f3e5d2360105f8bebcc9d",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b87",
             "_tpl": "657bb99db30eca976305117f",
             "parentId": "c96f3e5d2360105f8bebcc9d",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "735805162eaad4267bf6edfa",
             "_tpl": "5a16badafcdbcb001865f72d",
             "parentId": "hideout",
@@ -3370,7 +3819,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "0fbee497ded7aa5ead7d3f7a",
             "_tpl": "5a398b75c4a282000a51a266",
             "parentId": "hideout",
@@ -3381,7 +3831,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c03dcd84bec6e0d23dceed92",
             "_tpl": "560d657b4bdc2da74d8b4572",
             "parentId": "hideout",
@@ -3392,7 +3843,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "da9ca8940d4e39ccec53d5e1",
             "_tpl": "56def37dd2720bec348b456a",
             "parentId": "hideout",
@@ -3403,7 +3855,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ddd6a65fdf9f16d83b318daa",
             "_tpl": "5aa7d193e5b5b000171d063f",
             "parentId": "hideout",
@@ -3414,22 +3867,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b88",
             "_tpl": "657bb70486c7f9ef7a009936",
             "parentId": "ddd6a65fdf9f16d83b318daa",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b89",
             "_tpl": "657bb79ba1c61ee0c303631a",
             "parentId": "ddd6a65fdf9f16d83b318daa",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b8a",
             "_tpl": "657bb7d7b30eca9763051176",
             "parentId": "ddd6a65fdf9f16d83b318daa",
             "slotId": "Helmet_ears"
-        }, {
+        },
+        {
             "_id": "f334efa7eed9b05fa4c5f0be",
             "_tpl": "5aa7d03ae5b5b00016327db5",
             "parentId": "hideout",
@@ -3440,22 +3897,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b8b",
             "_tpl": "654a90aff4f81a421b0a7c86",
             "parentId": "f334efa7eed9b05fa4c5f0be",
             "slotId": "helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b8c",
             "_tpl": "654a91068e1ce698150fd1e2",
             "parentId": "f334efa7eed9b05fa4c5f0be",
             "slotId": "helmet_back"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b8d",
             "_tpl": "654a9189bcc67a392b056c79",
             "parentId": "f334efa7eed9b05fa4c5f0be",
             "slotId": "helmet_ears"
-        }, {
+        },
+        {
             "_id": "f1af81dc1dff3ea1b5ac6e4e",
             "_tpl": "5a7c4850e899ef00150be885",
             "parentId": "hideout",
@@ -3466,22 +3927,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b8e",
             "_tpl": "657baaf0b7e9ca9a02045c02",
             "parentId": "f1af81dc1dff3ea1b5ac6e4e",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b8f",
             "_tpl": "657bab6ec6f689d3a205b85f",
             "parentId": "f1af81dc1dff3ea1b5ac6e4e",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b90",
             "_tpl": "657babc6f58ba5a6250107a2",
             "parentId": "f1af81dc1dff3ea1b5ac6e4e",
             "slotId": "Helmet_ears"
-        }, {
+        },
+        {
             "_id": "fd942eafa8b2f18a42cc56d3",
             "_tpl": "5c11046cd174af02a012e42b",
             "parentId": "hideout",
@@ -3492,7 +3957,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "df41faf3dec812bb69aece6d",
             "_tpl": "61bca7cda0eae612383adf57",
             "parentId": "hideout",
@@ -3503,17 +3969,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b91",
             "_tpl": "657bbcc9a1c61ee0c3036327",
             "parentId": "df41faf3dec812bb69aece6d",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b92",
             "_tpl": "657bbcffbbd440df880b2dd5",
             "parentId": "df41faf3dec812bb69aece6d",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "df6bde5f07ac961aa9da4b8b",
             "_tpl": "5b4329f05acfc47a86086aa1",
             "parentId": "hideout",
@@ -3524,32 +3993,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b93",
             "_tpl": "65711b07a330b8c9060f7b01",
             "parentId": "df6bde5f07ac961aa9da4b8b",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b94",
             "_tpl": "65711b489eb8c145180dbb9d",
             "parentId": "df6bde5f07ac961aa9da4b8b",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b95",
             "_tpl": "65711b9b65daf6aa960c9b1b",
             "parentId": "df6bde5f07ac961aa9da4b8b",
             "slotId": "helmet_eyes"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b96",
             "_tpl": "65711bc79eb8c145180dbba1",
             "parentId": "df6bde5f07ac961aa9da4b8b",
             "slotId": "helmet_jaw"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b97",
             "_tpl": "65711b706d197c216005b31c",
             "parentId": "df6bde5f07ac961aa9da4b8b",
             "slotId": "Helmet_ears"
-        }, {
+        },
+        {
             "_id": "fdfc68e5aecfe2d355e05df4",
             "_tpl": "5aa7e4a4e5b5b000137b76f2",
             "parentId": "hideout",
@@ -3560,22 +4035,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b98",
             "_tpl": "657f925dada5fadd1f07a57a",
             "parentId": "fdfc68e5aecfe2d355e05df4",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b99",
             "_tpl": "657f92acada5fadd1f07a57e",
             "parentId": "fdfc68e5aecfe2d355e05df4",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b9a",
             "_tpl": "657f92e7f4c82973640b2354",
             "parentId": "fdfc68e5aecfe2d355e05df4",
             "slotId": "Helmet_ears"
-        }, {
+        },
+        {
             "_id": "7fd3bed1c9fcf118b00cbbea",
             "_tpl": "5aa7e3abe5b5b000171d064d",
             "parentId": "hideout",
@@ -3586,7 +4065,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "8bcc62f3374c3a29696f40e8",
             "_tpl": "5d5e7d28a4b936645d161203",
             "parentId": "hideout",
@@ -3597,17 +4077,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b9b",
             "_tpl": "657f8a8d7db258e5600fe33d",
             "parentId": "8bcc62f3374c3a29696f40e8",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b9c",
             "_tpl": "657f8b05f4c82973640b2348",
             "parentId": "8bcc62f3374c3a29696f40e8",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "19311f9cdd8b19dc4af8de71",
             "_tpl": "5c0e66e2d174af02a96252f4",
             "parentId": "hideout",
@@ -3618,7 +4101,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a4fd56c04d6f0c1f0c8e1ebc",
             "_tpl": "5c0695860db834001b735461",
             "parentId": "hideout",
@@ -3629,7 +4113,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b15a46448abeb15a8066e1e4",
             "_tpl": "5c0696830db834001d23f5da",
             "parentId": "hideout",
@@ -3640,7 +4125,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "133526a998c8ba1c22c5e8f8",
             "_tpl": "5d5e9c74a4b9364855191c40",
             "parentId": "hideout",
@@ -3651,17 +4137,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b9d",
             "_tpl": "657f8b94f92cd718b70154ff",
             "parentId": "133526a998c8ba1c22c5e8f8",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002b9e",
             "_tpl": "657f8b43f92cd718b70154fb",
             "parentId": "133526a998c8ba1c22c5e8f8",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "e0efb555332fde2bdeb1bc7a",
             "_tpl": "5c110624d174af029e69734c",
             "parentId": "hideout",
@@ -3672,7 +4161,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "8f538ebbd5a3ddf1d3b47d62",
             "_tpl": "5b40e3f35acfc40016388218",
             "parentId": "hideout",
@@ -3683,17 +4173,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002bc0",
             "_tpl": "657f95bff92cd718b701550c",
             "parentId": "8f538ebbd5a3ddf1d3b47d62",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002bc1",
             "_tpl": "657f9605f4c82973640b2358",
             "parentId": "8f538ebbd5a3ddf1d3b47d62",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "64156ef7a70e700a91fa1b8a",
             "_tpl": "5e4bfc1586f774264f7582d3",
             "parentId": "hideout",
@@ -3704,17 +4197,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002ba2",
             "_tpl": "657f9c78ada5fadd1f07a58d",
             "parentId": "64156ef7a70e700a91fa1b8a",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002ba3",
             "_tpl": "657f9cb587e11c61f70bfaca",
             "parentId": "64156ef7a70e700a91fa1b8a",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "6afcbe2a67c6fb9e424da5de",
             "_tpl": "5a16b7e1fcdbcb00165aa6c9",
             "parentId": "hideout",
@@ -3725,7 +4221,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bfd8de56d5a8ccc0bb708520",
             "_tpl": "5c0558060db834001b735271",
             "parentId": "hideout",
@@ -3736,7 +4233,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a7fa1a09e49cf4d42dbc4d7c",
             "_tpl": "5c066ef40db834001966a595",
             "parentId": "hideout",
@@ -3747,7 +4245,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "5d9d636c1faa4c42df6d97d5",
             "_tpl": "5c066e3a0db834001b7353f0",
             "parentId": "hideout",
@@ -3758,7 +4257,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "86add03867ecbb5adc6ad520",
             "_tpl": "5d6d3716a4b9361bc8618872",
             "parentId": "hideout",
@@ -3769,22 +4269,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002ba4",
             "_tpl": "657fa009d4caf976440afe3a",
             "parentId": "86add03867ecbb5adc6ad520",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002ba5",
             "_tpl": "657fa04ac6679fefb3051e24",
             "parentId": "86add03867ecbb5adc6ad520",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002ba6",
             "_tpl": "657fa07387e11c61f70bface",
             "parentId": "86add03867ecbb5adc6ad520",
             "slotId": "Helmet_ears"
-        }, {
+        },
+        {
             "_id": "f556c7af8ac720eb0e21d3e0",
             "_tpl": "5d6d3943a4b9360dbc46d0cc",
             "parentId": "hideout",
@@ -3795,7 +4299,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "358832f6bcdb70ab7c84bb91",
             "_tpl": "5d6d3be5a4b9361bc73bc763",
             "parentId": "hideout",
@@ -3806,7 +4311,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f1dcaf138aba4de379da1efe",
             "_tpl": "5d6d3829a4b9361bc8618943",
             "parentId": "hideout",
@@ -3817,7 +4323,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ecde82bb1f509f9bb9dabd38",
             "_tpl": "5c091a4e0db834001d5addc8",
             "parentId": "hideout",
@@ -3828,22 +4335,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002ba7",
             "_tpl": "6571133d22996eaf11088200",
             "parentId": "ecde82bb1f509f9bb9dabd38",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002ba8",
             "_tpl": "6571138e818110db4600aa71",
             "parentId": "ecde82bb1f509f9bb9dabd38",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002ba9",
             "_tpl": "657112fa818110db4600aa6b",
             "parentId": "ecde82bb1f509f9bb9dabd38",
             "slotId": "Helmet_ears"
-        }, {
+        },
+        {
             "_id": "db3939bbe8bd0b4b678d7aed",
             "_tpl": "5c0919b50db834001b7ce3b9",
             "parentId": "hideout",
@@ -3854,7 +4365,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a455ef9e2c766cc4eadce8b6",
             "_tpl": "5ea17ca01412a1425304d1c0",
             "parentId": "hideout",
@@ -3865,17 +4377,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002baa",
             "_tpl": "657f9a55c6679fefb3051e19",
             "parentId": "a455ef9e2c766cc4eadce8b6",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002bab",
             "_tpl": "657f9a94ada5fadd1f07a589",
             "parentId": "a455ef9e2c766cc4eadce8b6",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "ede0c041f1745b50d6aeee8c",
             "_tpl": "5ea18c84ecf1982c7712d9a2",
             "parentId": "hideout",
@@ -3886,7 +4401,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fbeaec0f91c1204fac95e7a0",
             "_tpl": "5b40e1525acfc4771e1c6611",
             "parentId": "hideout",
@@ -3897,22 +4413,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002bac",
             "_tpl": "657112234269e9a568089eac",
             "parentId": "fbeaec0f91c1204fac95e7a0",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002bad",
             "_tpl": "657112a4818110db4600aa66",
             "parentId": "fbeaec0f91c1204fac95e7a0",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002bae",
             "_tpl": "657112ce22996eaf110881fb",
             "parentId": "fbeaec0f91c1204fac95e7a0",
             "slotId": "Helmet_ears"
-        }, {
+        },
+        {
             "_id": "055f0b1adae017b34e200261",
             "_tpl": "5f60b34a41e30a4ab12a6947",
             "parentId": "hideout",
@@ -3923,17 +4443,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002baf",
             "_tpl": "657bbad7a1c61ee0c3036323",
             "parentId": "055f0b1adae017b34e200261",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002bb0",
             "_tpl": "657bbb31b30eca9763051183",
             "parentId": "055f0b1adae017b34e200261",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "0f60b93c29a52aaa6d1aadb2",
             "_tpl": "5f60c076f2bcbb675b00dac2",
             "parentId": "hideout",
@@ -3944,7 +4467,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "54d28a12e773aeef1a0ebd4a",
             "_tpl": "5f60b85bbdb8e27dee3dc985",
             "parentId": "hideout",
@@ -3955,7 +4479,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fdd72a909dc6bb25a43a27b2",
             "_tpl": "5f60bf4558eff926626a60f2",
             "parentId": "hideout",
@@ -3966,7 +4491,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f47e63136d9e2e21d9b9bdfc",
             "_tpl": "5a154d5cfcdbcb001a3b00da",
             "parentId": "hideout",
@@ -3977,17 +4503,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002bb1",
             "_tpl": "657f8ec5f4c82973640b234c",
             "parentId": "f47e63136d9e2e21d9b9bdfc",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002bb2",
             "_tpl": "657f8f10f4c82973640b2350",
             "parentId": "f47e63136d9e2e21d9b9bdfc",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "8bf71225f5321d4a20ab6e0c",
             "_tpl": "5a16ba61fcdbcb098008728a",
             "parentId": "hideout",
@@ -3998,7 +4527,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a4067e1a0ccad3e45acf0f1b",
             "_tpl": "5ea058e01dbce517f324b3e2",
             "parentId": "hideout",
@@ -4009,7 +4539,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f0afb4c0c05bfd31ce85e0ea",
             "_tpl": "5c17a7ed2e2216152142459c",
             "parentId": "hideout",
@@ -4020,17 +4551,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002bb3",
             "_tpl": "657f9897f4c82973640b235e",
             "parentId": "f0afb4c0c05bfd31ce85e0ea",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002bb4",
             "_tpl": "657f98fbada5fadd1f07a585",
             "parentId": "f0afb4c0c05bfd31ce85e0ea",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "4c185bc28fa79ef071e7a73c",
             "_tpl": "5c178a942e22164bef5ceca3",
             "parentId": "hideout",
@@ -4041,7 +4575,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "3cee7d223e197b0dad7adbb3",
             "_tpl": "5c1793902e221602b21d3de2",
             "parentId": "hideout",
@@ -4052,7 +4587,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "68bbbdaee53cad9c6a01d0ac",
             "_tpl": "5aa7e276e5b5b000171d0647",
             "parentId": "hideout",
@@ -4063,22 +4599,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002bb5",
             "_tpl": "657bc06daab96fccee08be9b",
             "parentId": "68bbbdaee53cad9c6a01d0ac",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002bb6",
             "_tpl": "657bc0d8a1c61ee0c303632f",
             "parentId": "68bbbdaee53cad9c6a01d0ac",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002bb7",
             "_tpl": "657bc107aab96fccee08be9f",
             "parentId": "68bbbdaee53cad9c6a01d0ac",
             "slotId": "Helmet_ears"
-        }, {
+        },
+        {
             "_id": "886d1e5ad9842e5bc40e1143",
             "_tpl": "5aa7e373e5b5b000137b76f0",
             "parentId": "hideout",
@@ -4089,7 +4629,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "706bbc2e7e6f0aa5cbb739d6",
             "_tpl": "5f60c74e3b85f6263c145586",
             "parentId": "hideout",
@@ -4100,22 +4641,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002bb8",
             "_tpl": "657bc285aab96fccee08bea3",
             "parentId": "706bbc2e7e6f0aa5cbb739d6",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002bb9",
             "_tpl": "657bc2c5a1c61ee0c3036333",
             "parentId": "706bbc2e7e6f0aa5cbb739d6",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002bba",
             "_tpl": "657bc2e7b30eca976305118d",
             "parentId": "706bbc2e7e6f0aa5cbb739d6",
             "slotId": "Helmet_ears"
-        }, {
+        },
+        {
             "_id": "b9cc2b686082dd7875d7eef4",
             "_tpl": "5f60c85b58eff926626a60f7",
             "parentId": "hideout",
@@ -4126,7 +4671,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "6a28a2a53e78d37ea166e2e3",
             "_tpl": "5e00c1ad86f774747333222c",
             "parentId": "hideout",
@@ -4137,17 +4683,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002bbb",
             "_tpl": "6551fec55d0cf82e51014288",
             "parentId": "6a28a2a53e78d37ea166e2e3",
             "slotId": "helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002bbc",
             "_tpl": "655200ba0ef76cf7be09d528",
             "parentId": "6a28a2a53e78d37ea166e2e3",
             "slotId": "helmet_back"
-        }, {
+        },
+        {
             "_id": "5207bc9fcaf7cf96a7aa1d7f",
             "_tpl": "5e00cdd986f7747473332240",
             "parentId": "hideout",
@@ -4158,7 +4707,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d8d19cb46c2ff2933ba26063",
             "_tpl": "5e01f37686f774773c6f6c15",
             "parentId": "hideout",
@@ -4169,7 +4719,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "eef3c5cda00670a1ef8cbafb",
             "_tpl": "5e00cfa786f77469dc6e5685",
             "parentId": "hideout",
@@ -4180,7 +4731,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "db4dcfca7c812792be3dfdcd",
             "_tpl": "5e01f31d86f77465cf261343",
             "parentId": "hideout",
@@ -4191,7 +4743,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bafb4f2becff3fa1edd0c9df",
             "_tpl": "5ca20ee186f774799474abc2",
             "parentId": "hideout",
@@ -4202,22 +4755,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002bbd",
             "_tpl": "657bbe73a1c61ee0c303632b",
             "parentId": "bafb4f2becff3fa1edd0c9df",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002bbe",
             "_tpl": "657bbed0aab96fccee08be96",
             "parentId": "bafb4f2becff3fa1edd0c9df",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "666fad3005a4eac710002bbf",
             "_tpl": "657bbefeb30eca9763051189",
             "parentId": "bafb4f2becff3fa1edd0c9df",
             "slotId": "Helmet_ears"
-        }, {
+        },
+        {
             "_id": "d8fe280b7eddf7cdea85fbbc",
             "_tpl": "5ca2113f86f7740b2547e1d2",
             "parentId": "hideout",
@@ -4228,7 +4785,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a00ea4e635aca7242c3ca430",
             "_tpl": "59ef13ca86f77445fd0e2483",
             "parentId": "hideout",
@@ -4239,7 +4797,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "70457fc9d9c8d617a11de7c1",
             "_tpl": "5926bb2186f7744b1c6c6e60",
             "parentId": "hideout",
@@ -4250,42 +4809,50 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "5df600181ebbcecab3dfe32e",
             "_tpl": "5926c3b286f774640d189b6b",
             "parentId": "70457fc9d9c8d617a11de7c1",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "f154cba1fca2af4bef44be36",
             "_tpl": "5926c36d86f77467a92a8629",
             "parentId": "bafb11cbefb08aa23ff8c45f",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "e0526ad2cbbae4e4fbfa6aa1",
             "_tpl": "5926d2be86f774134d668e4e",
             "parentId": "bafb11cbefb08aa23ff8c45f",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "eaadb7b56241f3eaf2a56b7b",
             "_tpl": "5926d3c686f77410de68ebc8",
             "parentId": "bafb11cbefb08aa23ff8c45f",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "8f38227a95c9e4c4a3abe1db",
             "_tpl": "5926e16e86f7742f5a0f7ecb",
             "parentId": "bafb11cbefb08aa23ff8c45f",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "bafb11cbefb08aa23ff8c45f",
             "_tpl": "5926c0df86f77462f647f764",
             "parentId": "70457fc9d9c8d617a11de7c1",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "19f5fcc57c52b6eaa83d9ba6",
             "_tpl": "5926c32286f774616e42de99",
             "parentId": "70457fc9d9c8d617a11de7c1",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "6bea2af7470a11f1c027bffa",
             "_tpl": "59f9cabd86f7743a10721f46",
             "parentId": "hideout",
@@ -4296,47 +4863,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ba1bff1a7158ee3ddcdbde5e",
             "_tpl": "5998517986f7746017232f7e",
             "parentId": "6bea2af7470a11f1c027bffa",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "5bab5bcadceaecfbf6c48f09",
             "_tpl": "599851db86f77467372f0a18",
             "parentId": "6bea2af7470a11f1c027bffa",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "dbebec43ad90bda1dfc6e6ce",
             "_tpl": "5998529a86f774647f44f421",
             "parentId": "6bea2af7470a11f1c027bffa",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "0deff70eeadc0dfd77987cc7",
             "_tpl": "5998598e86f7740b3f498a86",
             "parentId": "6bea2af7470a11f1c027bffa",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "e75481f028b98fcc4251406b",
             "_tpl": "59985a8086f77414ec448d1a",
             "parentId": "6bea2af7470a11f1c027bffa",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "4ebf16fade86fc7b03e01ce1",
             "_tpl": "599860e986f7743bb57573a6",
             "parentId": "6bea2af7470a11f1c027bffa",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "a3cfbef7c9dccea0b2f8c2b6",
             "_tpl": "59ccd11386f77428f24a488f",
             "parentId": "6bea2af7470a11f1c027bffa",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "09b410af5b8cb7e4813b3cff",
             "_tpl": "5648b1504bdc2d9d488b4584",
             "parentId": "a3cfbef7c9dccea0b2f8c2b6",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "f3fdee5c0a803449e2b7ebf2",
             "_tpl": "5ea03f7400685063ec28bfa8",
             "parentId": "hideout",
@@ -4347,27 +4923,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "78c26ec1ec2c7dae9e7cb6a6",
             "_tpl": "5ea03e9400685063ec28bfa4",
             "parentId": "f3fdee5c0a803449e2b7ebf2",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "f06491aa0d9ee1eb0f1bb4fb",
             "_tpl": "5ea034eb5aad6446a939737b",
             "parentId": "f3fdee5c0a803449e2b7ebf2",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "bdac8a2cdb5eb4fbf704eb65",
             "_tpl": "5ea03e5009aa976f2e7a514b",
             "parentId": "f3fdee5c0a803449e2b7ebf2",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "686a2abede0acfa4c145aeb1",
             "_tpl": "5ea02bb600685063ec28bfa1",
             "parentId": "f3fdee5c0a803449e2b7ebf2",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "a42cfec0d481218fafaedfd7",
             "_tpl": "5ea034eb5aad6446a939737b",
             "parentId": "hideout",
@@ -4378,7 +4959,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f430ae634bd13deb5793af3b",
             "_tpl": "5d2f213448f0355009199284",
             "parentId": "hideout",
@@ -4389,7 +4971,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "707d0a9feff99f8bb17ddcdc",
             "_tpl": "5998529a86f774647f44f421",
             "parentId": "hideout",
@@ -4400,7 +4983,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "411cd2a6bbf37e7aa9f7e8c5",
             "_tpl": "57f3c6bd24597738e730fa2f",
             "parentId": "hideout",
@@ -4411,27 +4995,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "48c9fae5f6bd49a7dc8bc91b",
             "_tpl": "57d152ec245977144076ccdf",
             "parentId": "411cd2a6bbf37e7aa9f7e8c5",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "fdec9441ae2aca3a8aa552ae",
             "_tpl": "57f3c7e024597738ea4ba286",
             "parentId": "411cd2a6bbf37e7aa9f7e8c5",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "bd15c5a3a94171a19faae50a",
             "_tpl": "57f3c8cc2459773ec4480328",
             "parentId": "fdec9441ae2aca3a8aa552ae",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "9ab4dbf6a3a7854d2c9b6a3f",
             "_tpl": "57d1519e24597714373db79d",
             "parentId": "411cd2a6bbf37e7aa9f7e8c5",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "9bac87edd4ddfd88cd22c4b7",
             "_tpl": "5de7bd7bfd6b4e6e2276dc25",
             "parentId": "hideout",
@@ -4442,42 +5031,50 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "de38ffc8d8fdcbcd6ca4d7c6",
             "_tpl": "5de8eac42a78646d96665d91",
             "parentId": "9bac87edd4ddfd88cd22c4b7",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "6bea3f41d88c5bd18a79edab",
             "_tpl": "5de910da8b6c4240ba2651b5",
             "parentId": "9bac87edd4ddfd88cd22c4b7",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "de1edeab7c69ba50bec698bb",
             "_tpl": "5de8fbad2fbe23140d3ee9c4",
             "parentId": "9bac87edd4ddfd88cd22c4b7",
             "slotId": "mod_foregrip"
-        }, {
+        },
+        {
             "_id": "1f0dbbd650ea43cba5a996e3",
             "_tpl": "5de8e67c4a9f347bc92edbd7",
             "parentId": "9bac87edd4ddfd88cd22c4b7",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "a84abdd73c46fdf81cea293d",
             "_tpl": "5de8fb539f98ac2bc659513a",
             "parentId": "1f0dbbd650ea43cba5a996e3",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "80fbcb7fb2c1b32c7745aa2a",
             "_tpl": "5de8fc0b205ddc616a6bc51b",
             "parentId": "1f0dbbd650ea43cba5a996e3",
             "slotId": "mod_mount"
-        }, {
+        },
+        {
             "_id": "43bbe47ef46d64178507ed3f",
             "_tpl": "5de922d4b11454561e39239f",
             "parentId": "9bac87edd4ddfd88cd22c4b7",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "fdff4ca46bfc60e6fc1a1deb",
             "_tpl": "59984ab886f7743e98271174",
             "parentId": "hideout",
@@ -4488,47 +5085,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "00d9bc9eea175b5dcda43aeb",
             "_tpl": "5998517986f7746017232f7e",
             "parentId": "fdff4ca46bfc60e6fc1a1deb",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "4e9affec9feadcb204234b1a",
             "_tpl": "599851db86f77467372f0a18",
             "parentId": "fdff4ca46bfc60e6fc1a1deb",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "fb4bf3b4c76bbffb44213f07",
             "_tpl": "599860ac86f77436b225ed1a",
             "parentId": "fdff4ca46bfc60e6fc1a1deb",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "bcecd16c8edf956b5a6c9830",
             "_tpl": "5998597786f77414ea6da093",
             "parentId": "fdff4ca46bfc60e6fc1a1deb",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "28ea7f2db2f58c8aab1a2640",
             "_tpl": "59985a8086f77414ec448d1a",
             "parentId": "fdff4ca46bfc60e6fc1a1deb",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "c60e6c1f80efdd81bd06ffed",
             "_tpl": "599860e986f7743bb57573a6",
             "parentId": "fdff4ca46bfc60e6fc1a1deb",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "20f50ef648df8ed1c91e2e40",
             "_tpl": "5648b1504bdc2d9d488b4584",
             "parentId": "fb9bffac099bdfacf2f68be8",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "fb9bffac099bdfacf2f68be8",
             "_tpl": "59ccd11386f77428f24a488f",
             "parentId": "fdff4ca46bfc60e6fc1a1deb",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "1c5bfbedb7bf2eb8db265d4d",
             "_tpl": "57d14e1724597714010c3f4b",
             "parentId": "hideout",
@@ -4539,7 +5145,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ef9f6ab8edda8baf2add0d4d",
             "_tpl": "5de8e8dafd6b4e6e2276dc32",
             "parentId": "hideout",
@@ -4550,7 +5157,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bbb80f3f7abcc46de99adcdd",
             "_tpl": "5c0673fb0db8340023300271",
             "parentId": "hideout",
@@ -4561,7 +5169,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "21e6a3b3abfab4f1dfcbb9fe",
             "_tpl": "58948c8e86f77409493f7266",
             "parentId": "hideout",
@@ -4572,72 +5181,86 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f6be79e12bcbcfb11b3518cc",
             "_tpl": "5894a51286f77426d13baf02",
             "parentId": "21e6a3b3abfab4f1dfcbb9fe",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "de7afe430d36e3ddf6b7c8f8",
             "_tpl": "5894a05586f774094708ef75",
             "parentId": "21e6a3b3abfab4f1dfcbb9fe",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "170c807f1f9eccbdfdca29bd",
             "_tpl": "58949dea86f77409483e16a8",
             "parentId": "75683bf30a6c5ca0cb6cdbdf",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "75683bf30a6c5ca0cb6cdbdf",
             "_tpl": "5894a2c386f77427140b8342",
             "parentId": "dc45fdbcdd4cbff394ae59ba",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "cc81dbdf7914665cfadf29c0",
             "_tpl": "5894a73486f77426d259076c",
             "parentId": "9bdde251ef961cbdd07b96ea",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "b2fc5fadffb4fdbfecb7af21",
             "_tpl": "58a56f8d86f774651579314c",
             "parentId": "9bdde251ef961cbdd07b96ea",
             "slotId": "mod_mount_000"
-        }, {
+        },
+        {
             "_id": "d8306feeca9dc43bbe9121cc",
             "_tpl": "58a5c12e86f7745d585a2b9e",
             "parentId": "9bdde251ef961cbdd07b96ea",
             "slotId": "mod_mount_001"
-        }, {
+        },
+        {
             "_id": "b6951d1cc712a33d281ff285",
             "_tpl": "58a56f8d86f774651579314c",
             "parentId": "9bdde251ef961cbdd07b96ea",
             "slotId": "mod_mount_002"
-        }, {
+        },
+        {
             "_id": "9bdde251ef961cbdd07b96ea",
             "_tpl": "5894a42086f77426d2590762",
             "parentId": "dc45fdbcdd4cbff394ae59ba",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "12ef7ce1a63c0bcdf6fb8364",
             "_tpl": "5894a81786f77427140b8347",
             "parentId": "dc45fdbcdd4cbff394ae59ba",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "dc45fdbcdd4cbff394ae59ba",
             "_tpl": "5894a5b586f77426d2590767",
             "parentId": "21e6a3b3abfab4f1dfcbb9fe",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "75ed8127b4154e972f87bd97",
             "_tpl": "5894a13e86f7742405482982",
             "parentId": "21e6a3b3abfab4f1dfcbb9fe",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "b10b2cc1bde6d8c59d4d7ae9",
             "_tpl": "58949edd86f77409483e16a9",
             "parentId": "21e6a3b3abfab4f1dfcbb9fe",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "89ef642beb27bdf51ffbb4b7",
             "_tpl": "60339954d62c9b14ed777c06",
             "parentId": "hideout",
@@ -4648,57 +5271,68 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c71d8bd697443c4f5dcefa2d",
             "_tpl": "602e71bd53a60014f9705bfa",
             "parentId": "89ef642beb27bdf51ffbb4b7",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "cd8c4e1aacd93a1eb8636ff6",
             "_tpl": "5a7ad2e851dfba0016153692",
             "parentId": "89ef642beb27bdf51ffbb4b7",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "0ebfc5db6539d39fd26a3d3f",
             "_tpl": "602e63fb6335467b0c5ac94d",
             "parentId": "89ef642beb27bdf51ffbb4b7",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "fa8540f3958bbcfcea1d9e42",
             "_tpl": "603372b4da11d6478d5a07ff",
             "parentId": "0ebfc5db6539d39fd26a3d3f",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "c7ec063e5dcbac335fdd689c",
             "_tpl": "60337f5dce399e10262255d1",
             "parentId": "fa8540f3958bbcfcea1d9e42",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "96083d5d229bacecf6bffbcb",
             "_tpl": "6034e3cb0ddce744014cb870",
             "parentId": "0ebfc5db6539d39fd26a3d3f",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "05c761e782cb7348ac3ce4b3",
             "_tpl": "602e3f1254072b51b239f713",
             "parentId": "89ef642beb27bdf51ffbb4b7",
             "slotId": "mod_stock_001"
-        }, {
+        },
+        {
             "_id": "187b05ae4a554224ad2dea35",
             "_tpl": "602e620f9b513876d4338d9a",
             "parentId": "05c761e782cb7348ac3ce4b3",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "8eec8077b3a6b1241cba6594",
             "_tpl": "6033749e88382f4fab3fd2c5",
             "parentId": "89ef642beb27bdf51ffbb4b7",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "92e6cdc8a79bb3a3c5ed86fd",
             "_tpl": "602f85fd9b513876d4338d9c",
             "parentId": "89ef642beb27bdf51ffbb4b7",
             "slotId": "mod_tactical_000"
-        }, {
+        },
+        {
             "_id": "ee2afb8cfb954d413b1ef95a",
             "_tpl": "5fc3e272f8b6a877a729eac5",
             "parentId": "hideout",
@@ -4709,37 +5343,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "aa78dbbcf9f3ce6f20a11bce",
             "_tpl": "5fc3e466187fea44d52eda90",
             "parentId": "ee2afb8cfb954d413b1ef95a",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "ea841184c4129a74daa89abe",
             "_tpl": "5fc3e4ee7283c4046c5814af",
             "parentId": "ee2afb8cfb954d413b1ef95a",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "d8618cb2f7a9d43c2c7e3bfe",
             "_tpl": "5fc3e4a27283c4046c5814ab",
             "parentId": "ee2afb8cfb954d413b1ef95a",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "7688380bc9ceee1fc8fbc7fa",
             "_tpl": "5fc53954f8b6a877a729eaeb",
             "parentId": "ee2afb8cfb954d413b1ef95a",
             "slotId": "mod_mount_000"
-        }, {
+        },
+        {
             "_id": "da31567aa8638b85b059aade",
             "_tpl": "5fc5396e900b1d5091531e72",
             "parentId": "ee2afb8cfb954d413b1ef95a",
             "slotId": "mod_mount_001"
-        }, {
+        },
+        {
             "_id": "47a05fc67aceffdb8af96c78",
             "_tpl": "5fc5396e900b1d5091531e72",
             "parentId": "ee2afb8cfb954d413b1ef95a",
             "slotId": "mod_mount_002"
-        }, {
+        },
+        {
             "_id": "3b599e4fa7eea0fd56c690c9",
             "_tpl": "5fb64bc92b1b027b1f50bcf2",
             "parentId": "hideout",
@@ -4750,52 +5391,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "beceee647becaa3a2aebaecf",
             "_tpl": "5fb651b52b1b027b1f50bcff",
             "parentId": "3b599e4fa7eea0fd56c690c9",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "4adeed6e51bf54c1d6e9f16f",
             "_tpl": "5fb6567747ce63734e3fa1dc",
             "parentId": "3b599e4fa7eea0fd56c690c9",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "2ca2c810dc9c316c3f176e30",
             "_tpl": "5fb6564947ce63734e3fa1da",
             "parentId": "3b599e4fa7eea0fd56c690c9",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "77edbb95fe607be10aba7781",
             "_tpl": "5fb6558ad6f0b2136f2d7eb7",
             "parentId": "3b599e4fa7eea0fd56c690c9",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "2dae6413cefca795faf6eb23",
             "_tpl": "5fb65363d1409e5ca04b54f5",
             "parentId": "3b599e4fa7eea0fd56c690c9",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "164cdaf42d3bdaafda15edb1",
             "_tpl": "5fb6548dd1409e5ca04b54f9",
             "parentId": "2dae6413cefca795faf6eb23",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "244ab203c94d57eb6e7fccb3",
             "_tpl": "5fbb976df9986c4cff3fe5f2",
             "parentId": "3b599e4fa7eea0fd56c690c9",
             "slotId": "mod_mount"
-        }, {
+        },
+        {
             "_id": "e1e53e1a07c6f79bd42b3e21",
             "_tpl": "5fce0f9b55375d18a253eff2",
             "parentId": "3b599e4fa7eea0fd56c690c9",
             "slotId": "mod_mount_001"
-        }, {
+        },
+        {
             "_id": "285305ebac95ca97da804cb5",
             "_tpl": "5fce0f9b55375d18a253eff2",
             "parentId": "3b599e4fa7eea0fd56c690c9",
             "slotId": "mod_mount_002"
-        }, {
+        },
+        {
             "_id": "ac30fc6c8b0fe5c833bf4fd6",
             "_tpl": "5fc3e466187fea44d52eda90",
             "parentId": "hideout",
@@ -4806,7 +5457,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bba2edf2e3af5aa89cfc0cfe",
             "_tpl": "5fb651b52b1b027b1f50bcff",
             "parentId": "hideout",
@@ -4817,7 +5469,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "4c8894693818128cfbde5e7a",
             "_tpl": "5a718da68dc32e000d46d264",
             "parentId": "hideout",
@@ -4828,7 +5481,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ef19a9e9fcef6fcaabc3e3c5",
             "_tpl": "5c5db6552e2216001026119d",
             "parentId": "hideout",
@@ -4839,7 +5493,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "cab3bd2bbcbc04261bcdb2e5",
             "_tpl": "5fc3f2d5900b1d5091531e57",
             "parentId": "hideout",
@@ -4850,52 +5505,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "49dff6a3fda95ddca2fbf78b",
             "_tpl": "5a718b548dc32e000d46d262",
             "parentId": "cab3bd2bbcbc04261bcdb2e5",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "7bfb0de03fad5d0fbe0f2de9",
             "_tpl": "5fb6567747ce63734e3fa1dc",
             "parentId": "cab3bd2bbcbc04261bcdb2e5",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "faaab85f361fdf9cde05ea2b",
             "_tpl": "5fb6564947ce63734e3fa1da",
             "parentId": "cab3bd2bbcbc04261bcdb2e5",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "350ab29babbfeda8ecffff9d",
             "_tpl": "5fb6558ad6f0b2136f2d7eb7",
             "parentId": "cab3bd2bbcbc04261bcdb2e5",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "3aad3e624c6d167cfe95c537",
             "_tpl": "5fbbc366ca32ed67276c1557",
             "parentId": "cab3bd2bbcbc04261bcdb2e5",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "920a8cdf8eb488bfa243da94",
             "_tpl": "5fbbc34106bde7524f03cbe9",
             "parentId": "3aad3e624c6d167cfe95c537",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "6a7bb4d16ddc2f6e475e7b61",
             "_tpl": "5fbb976df9986c4cff3fe5f2",
             "parentId": "cab3bd2bbcbc04261bcdb2e5",
             "slotId": "mod_mount"
-        }, {
+        },
+        {
             "_id": "32abba7ac789bbbb5e1a3c41",
             "_tpl": "5fce0f9b55375d18a253eff2",
             "parentId": "cab3bd2bbcbc04261bcdb2e5",
             "slotId": "mod_mount_001"
-        }, {
+        },
+        {
             "_id": "1ddeebe09e01d3a6fdfea5f3",
             "_tpl": "5fce0f9b55375d18a253eff2",
             "parentId": "cab3bd2bbcbc04261bcdb2e5",
             "slotId": "mod_mount_002"
-        }, {
+        },
+        {
             "_id": "e4389c85c2d0d411e59baba9",
             "_tpl": "5cc82d76e24e8d00134b4b83",
             "parentId": "hideout",
@@ -4906,57 +5571,68 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "848e44fdd8aaafce2dc22ef9",
             "_tpl": "5cc70093e4a949033c734312",
             "parentId": "e4389c85c2d0d411e59baba9",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "4b65d7aaceccdee4616cf6e1",
             "_tpl": "5cc700cae4a949035e43ba72",
             "parentId": "92a523cd61280165fb3035e0",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "92a523cd61280165fb3035e0",
             "_tpl": "5cc700b9e4a949000f0f0f25",
             "parentId": "e4389c85c2d0d411e59baba9",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "35020a6bcabd9e899b5b2af8",
             "_tpl": "5cebec38d7f00c00110a652a",
             "parentId": "b4fe8ec8aee308f56a0ddccf",
             "slotId": "mod_mount_000"
-        }, {
+        },
+        {
             "_id": "efb23774bdb5dccbeaa36e7a",
             "_tpl": "5cc70146e4a949000d73bf6b",
             "parentId": "b4fe8ec8aee308f56a0ddccf",
             "slotId": "mod_mount_001"
-        }, {
+        },
+        {
             "_id": "ef014af521a9c6373acbeace",
             "_tpl": "5cc70146e4a949000d73bf6b",
             "parentId": "b4fe8ec8aee308f56a0ddccf",
             "slotId": "mod_mount_002"
-        }, {
+        },
+        {
             "_id": "b4fe8ec8aee308f56a0ddccf",
             "_tpl": "5cc70102e4a949035e43ba74",
             "parentId": "e4389c85c2d0d411e59baba9",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "8e8b7ece9bc9e2eeae4ec5fa",
             "_tpl": "5cc82796e24e8d000f5859a8",
             "parentId": "c5bdbba61a1a3f57650aeeb0",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "c5bdbba61a1a3f57650aeeb0",
             "_tpl": "5cc701aae4a949000e1ea45c",
             "parentId": "e4389c85c2d0d411e59baba9",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "fca5ac65f0b8a9dd33eecbfd",
             "_tpl": "5cc6ea78e4a949000e1ea3c1",
             "parentId": "e4389c85c2d0d411e59baba9",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "cc4a5f48f7a3a3f164f91fb5",
             "_tpl": "5bd70322209c4d00d7167b8f",
             "parentId": "hideout",
@@ -4967,32 +5643,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bb155bf5b74b4c5c7bd8b790",
             "_tpl": "5ba264f6d4351e0034777d52",
             "parentId": "cc4a5f48f7a3a3f164f91fb5",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "bc99cba2fe088e28ddfffadf",
             "_tpl": "5ba26acdd4351e003562908e",
             "parentId": "cc4a5f48f7a3a3f164f91fb5",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "ceacca86d2fa2a241ee5b7e0",
             "_tpl": "5ba26b01d4351e0085325a51",
             "parentId": "cc4a5f48f7a3a3f164f91fb5",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "82aff9ea691a082b2ef5be94",
             "_tpl": "5ba26b17d4351e00367f9bdd",
             "parentId": "cc4a5f48f7a3a3f164f91fb5",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "fcb7acff15ae9afcb9f7cf8c",
             "_tpl": "5bd704e7209c4d00d7167c31",
             "parentId": "cc4a5f48f7a3a3f164f91fb5",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "9daca13fdf45feffda929ec9",
             "_tpl": "5ba264f6d4351e0034777d52",
             "parentId": "hideout",
@@ -5003,7 +5685,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a5d2b379faf0f2dcdea70b5b",
             "_tpl": "5cc70093e4a949033c734312",
             "parentId": "hideout",
@@ -5014,7 +5697,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "cadfd8d099bf6fbcbe95b33b",
             "_tpl": "5a7ad2e851dfba0016153692",
             "parentId": "hideout",
@@ -5025,7 +5709,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "43bcca99f2e7ceebff948ee1",
             "_tpl": "5926bb2186f7744b1c6c6e60",
             "parentId": "hideout",
@@ -5036,42 +5721,50 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e15eecabe67f2fd62997fa8b",
             "_tpl": "5926c3b286f774640d189b6b",
             "parentId": "43bcca99f2e7ceebff948ee1",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "acbdc3e262e0e973da2eefbc",
             "_tpl": "5926c36d86f77467a92a8629",
             "parentId": "81edb31aa64a6d7d88e98bc1",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "09ca05b5cb1fe6be06533ab1",
             "_tpl": "5926d2be86f774134d668e4e",
             "parentId": "81edb31aa64a6d7d88e98bc1",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "dbdb1e749ba92a8a4709b32f",
             "_tpl": "5926d3c686f77410de68ebc8",
             "parentId": "81edb31aa64a6d7d88e98bc1",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "e3cf9890d37bd3beeefd9eea",
             "_tpl": "5926e16e86f7742f5a0f7ecb",
             "parentId": "81edb31aa64a6d7d88e98bc1",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "81edb31aa64a6d7d88e98bc1",
             "_tpl": "5926c0df86f77462f647f764",
             "parentId": "43bcca99f2e7ceebff948ee1",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "7f1fcb1afe101e76c8c83d64",
             "_tpl": "5926c32286f774616e42de99",
             "parentId": "43bcca99f2e7ceebff948ee1",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "0d4e53f8dde4728245fa4ea7",
             "_tpl": "5d2f0d8048f0356c925bc3b0",
             "parentId": "hideout",
@@ -5082,37 +5775,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "2d76a374b068bb34e51a5b76",
             "_tpl": "5d2f213448f0355009199284",
             "parentId": "0d4e53f8dde4728245fa4ea7",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "a86939e031b01ab1ebeea1cb",
             "_tpl": "5d2f261548f03576f500e7b7",
             "parentId": "0d4e53f8dde4728245fa4ea7",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "9651ad811eee4df8e9c5bbc6",
             "_tpl": "5d2f259b48f0355a844acd74",
             "parentId": "a86939e031b01ab1ebeea1cb",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "a08494ddee500ebab52a50ab",
             "_tpl": "5926d2be86f774134d668e4e",
             "parentId": "a86939e031b01ab1ebeea1cb",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "c1b9bee8cc709bbb4c2cdfc8",
             "_tpl": "5d2f25bc48f03502573e5d85",
             "parentId": "a86939e031b01ab1ebeea1cb",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "76031e5b4f2b04c49fce9806",
             "_tpl": "5d2f2d5748f03572ec0c0139",
             "parentId": "0d4e53f8dde4728245fa4ea7",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "3f4c9d2d18fadcc5aa4d319c",
             "_tpl": "59f9cabd86f7743a10721f46",
             "parentId": "hideout",
@@ -5123,47 +5823,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e5aaad1c9488702f825abb65",
             "_tpl": "5998517986f7746017232f7e",
             "parentId": "3f4c9d2d18fadcc5aa4d319c",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "5e3aa29db39d8cb987aeff6c",
             "_tpl": "599851db86f77467372f0a18",
             "parentId": "3f4c9d2d18fadcc5aa4d319c",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "c6e3db3f4b7c82493cab5108",
             "_tpl": "5998529a86f774647f44f421",
             "parentId": "3f4c9d2d18fadcc5aa4d319c",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "ddd8fb5cdca3a79d0d5add8f",
             "_tpl": "5998598e86f7740b3f498a86",
             "parentId": "3f4c9d2d18fadcc5aa4d319c",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "de9a6c5f14e40ca97dccfa1e",
             "_tpl": "59985a8086f77414ec448d1a",
             "parentId": "3f4c9d2d18fadcc5aa4d319c",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "e9be245cbb59c796cac19acd",
             "_tpl": "599860e986f7743bb57573a6",
             "parentId": "3f4c9d2d18fadcc5aa4d319c",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "2f0baf2e88f163df6d82f967",
             "_tpl": "59ccd11386f77428f24a488f",
             "parentId": "3f4c9d2d18fadcc5aa4d319c",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "b80dbb0c56efe893206f7cd8",
             "_tpl": "5648b1504bdc2d9d488b4584",
             "parentId": "2f0baf2e88f163df6d82f967",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "25afb67abb3fbbce0acaa089",
             "_tpl": "5ea03f7400685063ec28bfa8",
             "parentId": "hideout",
@@ -5174,27 +5883,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "1241ccc7cb389de9cffc9faa",
             "_tpl": "5ea03e9400685063ec28bfa4",
             "parentId": "25afb67abb3fbbce0acaa089",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "e417c2c5b35fafceffe5a9ad",
             "_tpl": "5ea034eb5aad6446a939737b",
             "parentId": "25afb67abb3fbbce0acaa089",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "dd5d8b59b75a234ecb4f936c",
             "_tpl": "5ea03e5009aa976f2e7a514b",
             "parentId": "25afb67abb3fbbce0acaa089",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "e26abea2df7ae3ee7c030796",
             "_tpl": "5ea02bb600685063ec28bfa1",
             "parentId": "25afb67abb3fbbce0acaa089",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "b6aa0aa8dbfd624a530dd9ba",
             "_tpl": "57f3c6bd24597738e730fa2f",
             "parentId": "hideout",
@@ -5205,27 +5919,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "52ce99cedfd8abd3d1a8bd4b",
             "_tpl": "57d152ec245977144076ccdf",
             "parentId": "b6aa0aa8dbfd624a530dd9ba",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "0b78e9e916f90f88fcf3f5e0",
             "_tpl": "57f3c7e024597738ea4ba286",
             "parentId": "b6aa0aa8dbfd624a530dd9ba",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "aeb83d4ad28cda6adda66cbc",
             "_tpl": "57f3c8cc2459773ec4480328",
             "parentId": "0b78e9e916f90f88fcf3f5e0",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "07d94fa87eeac7e1bbdf0ac0",
             "_tpl": "57d1519e24597714373db79d",
             "parentId": "b6aa0aa8dbfd624a530dd9ba",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "1a317ae89abb5bbaf89720cd",
             "_tpl": "57d14d2524597714373db789",
             "parentId": "hideout",
@@ -5236,17 +5955,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "1cd4ebcdd9a4b83d2171ffc5",
             "_tpl": "57d152ec245977144076ccdf",
             "parentId": "1a317ae89abb5bbaf89720cd",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "109fdd49b67375de1e7b0d01",
             "_tpl": "57d1519e24597714373db79d",
             "parentId": "1a317ae89abb5bbaf89720cd",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "5a70a9da8c157810dfebd608",
             "_tpl": "57f4c844245977379d5c14d1",
             "parentId": "hideout",
@@ -5257,17 +5979,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "eb8cf00acfa1fcfe4fcdbccb",
             "_tpl": "57d152ec245977144076ccdf",
             "parentId": "5a70a9da8c157810dfebd608",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "34c5a151ce510cf8aa6cda28",
             "_tpl": "57d1519e24597714373db79d",
             "parentId": "5a70a9da8c157810dfebd608",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "bcafda5baf624ab54c5cf8c5",
             "_tpl": "5de7bd7bfd6b4e6e2276dc25",
             "parentId": "hideout",
@@ -5278,42 +6003,50 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "3f752d082ef3b8d13a4abefe",
             "_tpl": "5de8eac42a78646d96665d91",
             "parentId": "bcafda5baf624ab54c5cf8c5",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "c046047e570ecfa07bbdfecf",
             "_tpl": "5de910da8b6c4240ba2651b5",
             "parentId": "bcafda5baf624ab54c5cf8c5",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "2e5d63ee6fc0c6bb0b9da5b1",
             "_tpl": "5de8fbad2fbe23140d3ee9c4",
             "parentId": "bcafda5baf624ab54c5cf8c5",
             "slotId": "mod_foregrip"
-        }, {
+        },
+        {
             "_id": "4f43d8afeef8e5c2e0b3ed6e",
             "_tpl": "5de8e67c4a9f347bc92edbd7",
             "parentId": "bcafda5baf624ab54c5cf8c5",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "7b7266b7252acadf8b7340fd",
             "_tpl": "5de8fb539f98ac2bc659513a",
             "parentId": "4f43d8afeef8e5c2e0b3ed6e",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "201f7ce7e70a233fbe47feeb",
             "_tpl": "5de8fc0b205ddc616a6bc51b",
             "parentId": "4f43d8afeef8e5c2e0b3ed6e",
             "slotId": "mod_mount"
-        }, {
+        },
+        {
             "_id": "cb3ea1c508dbfdf59eaa7041",
             "_tpl": "5de922d4b11454561e39239f",
             "parentId": "bcafda5baf624ab54c5cf8c5",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "d20fda6f5f13c3f4c827e0ab",
             "_tpl": "5e00903ae9dc277128008b87",
             "parentId": "hideout",
@@ -5324,37 +6057,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "befca8eba99a87c884a0c0bb",
             "_tpl": "5de8eac42a78646d96665d91",
             "parentId": "d20fda6f5f13c3f4c827e0ab",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "18fdcd7fd107f77dbcb4b9fa",
             "_tpl": "5de910da8b6c4240ba2651b5",
             "parentId": "d20fda6f5f13c3f4c827e0ab",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "fdbeeca08bdaf4fff5c8dfcd",
             "_tpl": "5e0090f7e9dc277128008b93",
             "parentId": "d20fda6f5f13c3f4c827e0ab",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "290cd9cf4b6e16f5be5f15ef",
             "_tpl": "5de8fb539f98ac2bc659513a",
             "parentId": "fdbeeca08bdaf4fff5c8dfcd",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "c3ea37bfdfdf0d8a297ecd54",
             "_tpl": "5de922d4b11454561e39239f",
             "parentId": "d20fda6f5f13c3f4c827e0ab",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "9201335bfd2a1bdb81dc1a5a",
             "_tpl": "5de8fbf2b74cd90030650c79",
             "parentId": "d20fda6f5f13c3f4c827e0ab",
             "slotId": "mod_mount_000"
-        }, {
+        },
+        {
             "_id": "0b79d8fc0aeee03ff2d7aaff",
             "_tpl": "59984ab886f7743e98271174",
             "parentId": "hideout",
@@ -5365,47 +6105,56 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c8bcba4ef5bc1da7baefdf79",
             "_tpl": "5998517986f7746017232f7e",
             "parentId": "0b79d8fc0aeee03ff2d7aaff",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "cc8a255de4dd178900f70ef0",
             "_tpl": "599851db86f77467372f0a18",
             "parentId": "0b79d8fc0aeee03ff2d7aaff",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "ea00decf93870cc755890d58",
             "_tpl": "599860ac86f77436b225ed1a",
             "parentId": "0b79d8fc0aeee03ff2d7aaff",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "bc9c7d86eed7e400253cd1f7",
             "_tpl": "5998597786f77414ea6da093",
             "parentId": "0b79d8fc0aeee03ff2d7aaff",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "3f366f691be33a3cea5e47f5",
             "_tpl": "59985a8086f77414ec448d1a",
             "parentId": "0b79d8fc0aeee03ff2d7aaff",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "ec0f41bede619703f663761c",
             "_tpl": "599860e986f7743bb57573a6",
             "parentId": "0b79d8fc0aeee03ff2d7aaff",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "be9ba834abfffad1dfd32af0",
             "_tpl": "5648b1504bdc2d9d488b4584",
             "parentId": "5bdb3f45afe1e852d6decbee",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "5bdb3f45afe1e852d6decbee",
             "_tpl": "59ccd11386f77428f24a488f",
             "parentId": "0b79d8fc0aeee03ff2d7aaff",
             "slotId": "mod_gas_block"
-        }, {
+        },
+        {
             "_id": "2c2cdfcaaedf64f3c33a6bfe",
             "_tpl": "58948c8e86f77409493f7266",
             "parentId": "hideout",
@@ -5416,72 +6165,86 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b1f2dac7dd8ba3d4fd5fbddb",
             "_tpl": "5894a51286f77426d13baf02",
             "parentId": "2c2cdfcaaedf64f3c33a6bfe",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "4abfe9fefdd65643cbd5dbe5",
             "_tpl": "5894a05586f774094708ef75",
             "parentId": "2c2cdfcaaedf64f3c33a6bfe",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "4e89f8742fe7e8ff7dada2ab",
             "_tpl": "58949dea86f77409483e16a8",
             "parentId": "540351af5edcabea1bc5b24a",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "540351af5edcabea1bc5b24a",
             "_tpl": "5894a2c386f77427140b8342",
             "parentId": "75cb7a5aa264c10e2bbae0b5",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "c78e5ca447abc688faedfbec",
             "_tpl": "5894a73486f77426d259076c",
             "parentId": "7e893fbb6fc30cbadf749fd3",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "b2c834b7cfcdaed90b6ff87f",
             "_tpl": "58a56f8d86f774651579314c",
             "parentId": "7e893fbb6fc30cbadf749fd3",
             "slotId": "mod_mount_000"
-        }, {
+        },
+        {
             "_id": "daafe9a2fce7ab3fa125239d",
             "_tpl": "58a5c12e86f7745d585a2b9e",
             "parentId": "7e893fbb6fc30cbadf749fd3",
             "slotId": "mod_mount_001"
-        }, {
+        },
+        {
             "_id": "e965d3dc94ce3e5b597ebbea",
             "_tpl": "58a56f8d86f774651579314c",
             "parentId": "7e893fbb6fc30cbadf749fd3",
             "slotId": "mod_mount_002"
-        }, {
+        },
+        {
             "_id": "7e893fbb6fc30cbadf749fd3",
             "_tpl": "5894a42086f77426d2590762",
             "parentId": "75cb7a5aa264c10e2bbae0b5",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "1d300c5ae3cbae8ad2a8101a",
             "_tpl": "5894a81786f77427140b8347",
             "parentId": "75cb7a5aa264c10e2bbae0b5",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "75cb7a5aa264c10e2bbae0b5",
             "_tpl": "5894a5b586f77426d2590767",
             "parentId": "2c2cdfcaaedf64f3c33a6bfe",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "eac0a7fe1dafdc0ce0a01491",
             "_tpl": "5894a13e86f7742405482982",
             "parentId": "2c2cdfcaaedf64f3c33a6bfe",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "0231555c3d9ac942ca5a2c73",
             "_tpl": "58949edd86f77409483e16a9",
             "parentId": "2c2cdfcaaedf64f3c33a6bfe",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "30d38a39f4ae6338a4128f1f",
             "_tpl": "60339954d62c9b14ed777c06",
             "parentId": "hideout",
@@ -5492,57 +6255,68 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c79c96b4c78053ddcd7c0ebc",
             "_tpl": "602e71bd53a60014f9705bfa",
             "parentId": "30d38a39f4ae6338a4128f1f",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "8e3ccafdfdf30ecc75b17b71",
             "_tpl": "5a7ad2e851dfba0016153692",
             "parentId": "30d38a39f4ae6338a4128f1f",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "af34ff4e4f734c2ffbbf43c7",
             "_tpl": "602e63fb6335467b0c5ac94d",
             "parentId": "30d38a39f4ae6338a4128f1f",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "eebf44d1ce5bae0c0ecbec2b",
             "_tpl": "603372b4da11d6478d5a07ff",
             "parentId": "af34ff4e4f734c2ffbbf43c7",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "fdba9d98a4afaafdebdaaa03",
             "_tpl": "60337f5dce399e10262255d1",
             "parentId": "eebf44d1ce5bae0c0ecbec2b",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "d1efc08e88efdd6cff463ba4",
             "_tpl": "6034e3cb0ddce744014cb870",
             "parentId": "af34ff4e4f734c2ffbbf43c7",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "c7bb057b7abcf3dde9b3d7d4",
             "_tpl": "602e3f1254072b51b239f713",
             "parentId": "30d38a39f4ae6338a4128f1f",
             "slotId": "mod_stock_001"
-        }, {
+        },
+        {
             "_id": "3a5af0aae1dadb1ccaeeadf4",
             "_tpl": "602e620f9b513876d4338d9a",
             "parentId": "c7bb057b7abcf3dde9b3d7d4",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "dd67fe1f1c5dca9c22a2db1c",
             "_tpl": "6033749e88382f4fab3fd2c5",
             "parentId": "30d38a39f4ae6338a4128f1f",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "7b63a2ea76ccadd24a629029",
             "_tpl": "602f85fd9b513876d4338d9c",
             "parentId": "30d38a39f4ae6338a4128f1f",
             "slotId": "mod_tactical_000"
-        }, {
+        },
+        {
             "_id": "8da19e3fc5b0c049798ebccd",
             "_tpl": "5fc3e272f8b6a877a729eac5",
             "parentId": "hideout",
@@ -5553,37 +6327,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "60dcccede54a301655a2748c",
             "_tpl": "5fc3e466187fea44d52eda90",
             "parentId": "8da19e3fc5b0c049798ebccd",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "ebaa2ccaabda7e3ad1f4416c",
             "_tpl": "5fc3e4ee7283c4046c5814af",
             "parentId": "8da19e3fc5b0c049798ebccd",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "adccccc5fba3029db25c3eac",
             "_tpl": "5fc3e4a27283c4046c5814ab",
             "parentId": "8da19e3fc5b0c049798ebccd",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "8341dd8c01a28202145565ad",
             "_tpl": "5fc53954f8b6a877a729eaeb",
             "parentId": "8da19e3fc5b0c049798ebccd",
             "slotId": "mod_mount_000"
-        }, {
+        },
+        {
             "_id": "0decb3ce5a05f4e2a6bd91bc",
             "_tpl": "5fc5396e900b1d5091531e72",
             "parentId": "8da19e3fc5b0c049798ebccd",
             "slotId": "mod_mount_001"
-        }, {
+        },
+        {
             "_id": "ab393d3350cd760f31ebdfcb",
             "_tpl": "5fc5396e900b1d5091531e72",
             "parentId": "8da19e3fc5b0c049798ebccd",
             "slotId": "mod_mount_002"
-        }, {
+        },
+        {
             "_id": "eeba2eb4ddaceeea20ddab1a",
             "_tpl": "5fb64bc92b1b027b1f50bcf2",
             "parentId": "hideout",
@@ -5594,52 +6375,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a5f598956d50c24c0140d6ae",
             "_tpl": "5fb651b52b1b027b1f50bcff",
             "parentId": "eeba2eb4ddaceeea20ddab1a",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "a57a2ffb8ce52bcadbabbe0b",
             "_tpl": "5fb6567747ce63734e3fa1dc",
             "parentId": "eeba2eb4ddaceeea20ddab1a",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "de2a4ba2e7cfaefdd13089c5",
             "_tpl": "5fb6564947ce63734e3fa1da",
             "parentId": "eeba2eb4ddaceeea20ddab1a",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "45af8a1294bad87fdd3527ba",
             "_tpl": "5fb6558ad6f0b2136f2d7eb7",
             "parentId": "eeba2eb4ddaceeea20ddab1a",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "544eb5ad52c1516805f8da7c",
             "_tpl": "5fb65363d1409e5ca04b54f5",
             "parentId": "eeba2eb4ddaceeea20ddab1a",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "ed4a04efd962eaf5ee5edb3a",
             "_tpl": "5fb6548dd1409e5ca04b54f9",
             "parentId": "544eb5ad52c1516805f8da7c",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "8a85df5d3acd5edfafb84747",
             "_tpl": "5fbb976df9986c4cff3fe5f2",
             "parentId": "eeba2eb4ddaceeea20ddab1a",
             "slotId": "mod_mount"
-        }, {
+        },
+        {
             "_id": "76a71da0ffabcbfcb59ae93b",
             "_tpl": "5fce0f9b55375d18a253eff2",
             "parentId": "eeba2eb4ddaceeea20ddab1a",
             "slotId": "mod_mount_001"
-        }, {
+        },
+        {
             "_id": "7ee459889bda92bc8d3d430f",
             "_tpl": "5fce0f9b55375d18a253eff2",
             "parentId": "eeba2eb4ddaceeea20ddab1a",
             "slotId": "mod_mount_002"
-        }, {
+        },
+        {
             "_id": "f56f21853db9b53d4ac5dd5d",
             "_tpl": "5fc3f2d5900b1d5091531e57",
             "parentId": "hideout",
@@ -5650,52 +6441,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d5dc21a01bffabf592dfebe3",
             "_tpl": "5a718b548dc32e000d46d262",
             "parentId": "f56f21853db9b53d4ac5dd5d",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "a1cf3b388b97129b4f21aad5",
             "_tpl": "5fb6567747ce63734e3fa1dc",
             "parentId": "f56f21853db9b53d4ac5dd5d",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "d26d6c56bd6ab0ebf1a77b86",
             "_tpl": "5fb6564947ce63734e3fa1da",
             "parentId": "f56f21853db9b53d4ac5dd5d",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "5cdda5fe18d9e2bfe7cc1cfa",
             "_tpl": "5fb6558ad6f0b2136f2d7eb7",
             "parentId": "f56f21853db9b53d4ac5dd5d",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "92354fcfafc80b163b573f1f",
             "_tpl": "5fbbc366ca32ed67276c1557",
             "parentId": "f56f21853db9b53d4ac5dd5d",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "1f22ef1f419aba2eae134811",
             "_tpl": "5fbbc34106bde7524f03cbe9",
             "parentId": "92354fcfafc80b163b573f1f",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "45361df0f5edd2b7fb03773a",
             "_tpl": "5fbb976df9986c4cff3fe5f2",
             "parentId": "f56f21853db9b53d4ac5dd5d",
             "slotId": "mod_mount"
-        }, {
+        },
+        {
             "_id": "eecfde22a524a8baf4565bae",
             "_tpl": "5fce0f9b55375d18a253eff2",
             "parentId": "f56f21853db9b53d4ac5dd5d",
             "slotId": "mod_mount_001"
-        }, {
+        },
+        {
             "_id": "6e78e89affdb9f1ae07eedb0",
             "_tpl": "5fce0f9b55375d18a253eff2",
             "parentId": "f56f21853db9b53d4ac5dd5d",
             "slotId": "mod_mount_002"
-        }, {
+        },
+        {
             "_id": "5f874db0cbfb83bc7c1dacbc",
             "_tpl": "5cc82d76e24e8d00134b4b83",
             "parentId": "hideout",
@@ -5706,57 +6507,68 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c51dc92d5c5afc5cd1f95cc0",
             "_tpl": "5cc70093e4a949033c734312",
             "parentId": "5f874db0cbfb83bc7c1dacbc",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "a1efc092368f5da590a65ffb",
             "_tpl": "5cc700cae4a949035e43ba72",
             "parentId": "a7b41caabbe1f13000c58bab",
             "slotId": "mod_stock_000"
-        }, {
+        },
+        {
             "_id": "a7b41caabbe1f13000c58bab",
             "_tpl": "5cc700b9e4a949000f0f0f25",
             "parentId": "5f874db0cbfb83bc7c1dacbc",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "8e512c04135cbb67b0efb0cf",
             "_tpl": "5cebec38d7f00c00110a652a",
             "parentId": "2bfa254a91f28df87bed1dee",
             "slotId": "mod_mount_000"
-        }, {
+        },
+        {
             "_id": "a913d8dd464fa9ee355aac12",
             "_tpl": "5cc70146e4a949000d73bf6b",
             "parentId": "2bfa254a91f28df87bed1dee",
             "slotId": "mod_mount_001"
-        }, {
+        },
+        {
             "_id": "a4d564a0bedf2eea9bcc9acf",
             "_tpl": "5cc70146e4a949000d73bf6b",
             "parentId": "2bfa254a91f28df87bed1dee",
             "slotId": "mod_mount_002"
-        }, {
+        },
+        {
             "_id": "2bfa254a91f28df87bed1dee",
             "_tpl": "5cc70102e4a949035e43ba74",
             "parentId": "5f874db0cbfb83bc7c1dacbc",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "4de85ca2530d54a841eaf6fe",
             "_tpl": "5cc82796e24e8d000f5859a8",
             "parentId": "5d7ca60fceadddcef6cee520",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "5d7ca60fceadddcef6cee520",
             "_tpl": "5cc701aae4a949000e1ea45c",
             "parentId": "5f874db0cbfb83bc7c1dacbc",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "8e22abe45a9aaeae1dfc21db",
             "_tpl": "5cc6ea78e4a949000e1ea3c1",
             "parentId": "5f874db0cbfb83bc7c1dacbc",
             "slotId": "mod_charge"
-        }, {
+        },
+        {
             "_id": "a4f4cebdd504df8c6cdd5cbd",
             "_tpl": "5bd70322209c4d00d7167b8f",
             "parentId": "hideout",
@@ -5767,32 +6579,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c9f4be019dd3326f790aef4d",
             "_tpl": "5ba264f6d4351e0034777d52",
             "parentId": "a4f4cebdd504df8c6cdd5cbd",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "41aceb8bebd8ebb38ab0b41e",
             "_tpl": "5ba26acdd4351e003562908e",
             "parentId": "a4f4cebdd504df8c6cdd5cbd",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "fbf827adfd3a14fee10a9a6c",
             "_tpl": "5ba26b01d4351e0085325a51",
             "parentId": "a4f4cebdd504df8c6cdd5cbd",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "0af9c999b0aba1ec3bfac035",
             "_tpl": "5ba26b17d4351e00367f9bdd",
             "parentId": "a4f4cebdd504df8c6cdd5cbd",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "de24f5868e9da4eaca0dff3f",
             "_tpl": "5bd704e7209c4d00d7167c31",
             "parentId": "a4f4cebdd504df8c6cdd5cbd",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "ce16ab92fc2fdedbbce276a0",
             "_tpl": "5ba26383d4351e00334c93d9",
             "parentId": "hideout",
@@ -5803,32 +6621,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "969bef572e30b5c57fcde6b9",
             "_tpl": "5ba264f6d4351e0034777d52",
             "parentId": "ce16ab92fc2fdedbbce276a0",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "519c800f8ec4bac9ac6446bb",
             "_tpl": "5ba26acdd4351e003562908e",
             "parentId": "ce16ab92fc2fdedbbce276a0",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "11f903e8ce21bdc8a8fbd3e5",
             "_tpl": "5ba26b01d4351e0085325a51",
             "parentId": "ce16ab92fc2fdedbbce276a0",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "1ac4cdc14cca733f9c4ad666",
             "_tpl": "5ba26b17d4351e00367f9bdd",
             "parentId": "ce16ab92fc2fdedbbce276a0",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "466bacf093d2ef08e0fe668e",
             "_tpl": "5bcf0213d4351e0085327c17",
             "parentId": "ce16ab92fc2fdedbbce276a0",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "edefbc1e1e81e1c3aee5e0c6",
             "_tpl": "64b6979341772715af0f9c39",
             "parentId": "hideout",
@@ -5839,7 +6663,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "5da63b260eca83e9cefbd1ad",
             "_tpl": "64b6979341772715af0f9c39",
             "parentId": "hideout",
@@ -5850,7 +6675,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "64922cbcebffceeeea5ad7a5",
             "_tpl": "64b7bbb74b75259c590fa897",
             "parentId": "hideout",
@@ -5861,7 +6687,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d3d5ed8e05e02a233770ca06",
             "_tpl": "64b7bbb74b75259c590fa897",
             "parentId": "hideout",
@@ -5872,7 +6699,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fd3af4d1f7c8a28c6d3538b8",
             "_tpl": "64b8725c4b75259c590fa899",
             "parentId": "hideout",
@@ -5883,7 +6711,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bcec0a0eb24c1fbdd7bd1437",
             "_tpl": "64b8725c4b75259c590fa899",
             "parentId": "hideout",
@@ -5894,7 +6723,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d2023daced2c72d8a7d858e7",
             "_tpl": "65719f0775149d62ce0a670b",
             "parentId": "hideout",
@@ -5905,22 +6735,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "41aab1308bb6ca9e4424d53e",
             "_tpl": "657fa0fcd4caf976440afe3e",
             "parentId": "d2023daced2c72d8a7d858e7",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "bf675df5bea85cb0988cfd88",
             "_tpl": "657fa168e9433140ad0baf8e",
             "parentId": "d2023daced2c72d8a7d858e7",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "de2905e8aa2abaad2d7bbfd5",
             "_tpl": "657fa186d4caf976440afe42",
             "parentId": "d2023daced2c72d8a7d858e7",
             "slotId": "Helmet_ears"
-        }, {
+        },
+        {
             "_id": "4a76efbf9ad1ed239033dbeb",
             "_tpl": "65719f0775149d62ce0a670b",
             "parentId": "hideout",
@@ -5931,22 +6765,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "befc547ca8b9c3452adcc66d",
             "_tpl": "657fa0fcd4caf976440afe3e",
             "parentId": "4a76efbf9ad1ed239033dbeb",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "dabeacacf5a1c9398a4dfd4a",
             "_tpl": "657fa168e9433140ad0baf8e",
             "parentId": "4a76efbf9ad1ed239033dbeb",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "1b5bfcfaeeade0ae6e29e59f",
             "_tpl": "657fa186d4caf976440afe42",
             "parentId": "4a76efbf9ad1ed239033dbeb",
             "slotId": "Helmet_ears"
-        }, {
+        },
+        {
             "_id": "4bac8d6dcefb3a0cad419f56",
             "_tpl": "65709d2d21b9f815e208ff95",
             "parentId": "hideout",
@@ -5957,17 +6795,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a387bbc54fdcfb3f2963b9ad",
             "_tpl": "657f9eb7e9433140ad0baf86",
             "parentId": "4bac8d6dcefb3a0cad419f56",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "a5f6ebadc5dd629fcc2b5c20",
             "_tpl": "657f9ef6c6679fefb3051e1f",
             "parentId": "4bac8d6dcefb3a0cad419f56",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "dcb2d8f8d4b5fd2ffb4e96de",
             "_tpl": "65709d2d21b9f815e208ff95",
             "parentId": "hideout",
@@ -5978,17 +6819,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e1c46bd89b7c742c3abf4a9d",
             "_tpl": "657f9eb7e9433140ad0baf86",
             "parentId": "dcb2d8f8d4b5fd2ffb4e96de",
             "slotId": "Helmet_top"
-        }, {
+        },
+        {
             "_id": "9adbab0aaea01ceee2db42fa",
             "_tpl": "657f9ef6c6679fefb3051e1f",
             "parentId": "dcb2d8f8d4b5fd2ffb4e96de",
             "slotId": "Helmet_back"
-        }, {
+        },
+        {
             "_id": "a57e52aefc8ede2ed9eafa1f",
             "_tpl": "62e14904c2699c0ec93adc47",
             "parentId": "hideout",
@@ -5999,42 +6843,50 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a7eecf658ed3ffab70f182d0",
             "_tpl": "633a98eab8b0506e48497c1a",
             "parentId": "a57e52aefc8ede2ed9eafa1f",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "c9b62dcbb9a2ac2f6aaba5ff",
             "_tpl": "62e2a754b6c0ee2f230cee0f",
             "parentId": "a57e52aefc8ede2ed9eafa1f",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "6ecce5cf633f48a2871cecbe",
             "_tpl": "62e292e7b6c0ee2f230cee00",
             "parentId": "a57e52aefc8ede2ed9eafa1f",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "5fafffaa3d6ab3aa1ec28d0a",
             "_tpl": "62e27a7865f0b1592a49e17b",
             "parentId": "a57e52aefc8ede2ed9eafa1f",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "e75daab2457ef7aef9b058f8",
             "_tpl": "62e15547db1a5c41971c1b5e",
             "parentId": "a57e52aefc8ede2ed9eafa1f",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "fdabb622bfacaa2e9525c57f",
             "_tpl": "62ed189fb3608410ef5a2bfc",
             "parentId": "e75daab2457ef7aef9b058f8",
             "slotId": "mod_mount_001"
-        }, {
+        },
+        {
             "_id": "1ecaeea7aada6ed9b9cf5e8b",
             "_tpl": "637b9c37b7e3bc41b21ce71a",
             "parentId": "a57e52aefc8ede2ed9eafa1f",
             "slotId": "mod_pistolgrip"
-        }, {
+        },
+        {
             "_id": "36e6e5da727bcbf1ecfb6ef3",
             "_tpl": "62e14904c2699c0ec93adc47",
             "parentId": "hideout",
@@ -6045,42 +6897,50 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "12d65fdba6c90889dabbd8ed",
             "_tpl": "633a98eab8b0506e48497c1a",
             "parentId": "36e6e5da727bcbf1ecfb6ef3",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "c6dddbffb5d632885e1bfbce",
             "_tpl": "62e2a754b6c0ee2f230cee0f",
             "parentId": "36e6e5da727bcbf1ecfb6ef3",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "9d018b37fc7e0d4febc5bd3a",
             "_tpl": "62e292e7b6c0ee2f230cee00",
             "parentId": "36e6e5da727bcbf1ecfb6ef3",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "6b7bcde964bc2e3e5d933cbf",
             "_tpl": "62e27a7865f0b1592a49e17b",
             "parentId": "36e6e5da727bcbf1ecfb6ef3",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "9cf82708fff57edd7a273efd",
             "_tpl": "62e15547db1a5c41971c1b5e",
             "parentId": "36e6e5da727bcbf1ecfb6ef3",
             "slotId": "mod_handguard"
-        }, {
+        },
+        {
             "_id": "c38e1243dde4ddc65cc632fa",
             "_tpl": "62ed189fb3608410ef5a2bfc",
             "parentId": "9cf82708fff57edd7a273efd",
             "slotId": "mod_mount_001"
-        }, {
+        },
+        {
             "_id": "e93fbc13902c5a42eecb9e4a",
             "_tpl": "637b9c37b7e3bc41b21ce71a",
             "parentId": "36e6e5da727bcbf1ecfb6ef3",
             "slotId": "mod_pistolgrip"
-        }, {
+        },
+        {
             "_id": "099cd41b2f9c849ff68efda7",
             "_tpl": "62e153bcdb1a5c41971c1b5b",
             "parentId": "hideout",
@@ -6091,7 +6951,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c3adac0c4ccf4b56eca2fc50",
             "_tpl": "633a98eab8b0506e48497c1a",
             "parentId": "hideout",

--- a/db/traders/6765fbd20fdc7eb79b00000e/assort.json
+++ b/db/traders/6765fbd20fdc7eb79b00000e/assort.json
@@ -1,1832 +1,1600 @@
 {
     "barter_scheme": {
         "89ff7373b1fb0ec4c705db2d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 25000
                 }
             ]
         ],
         "dfeae76c2aed94ebee2db4e8": [
-            [
-                {
+            [{
                     "_tpl": "57347d90245977448f7b7f65",
                     "count": 5
                 }
             ]
         ],
         "1cce5068f5ddbcaadac3ee4d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 30000
                 }
             ]
         ],
         "ff109e00a8dde480eefa87fb": [
-            [
-                {
+            [{
                     "_tpl": "5c3df7d588a4501f290594e5",
                     "count": 5
                 }
             ]
         ],
         "49cbcb5c5fdbc6790e0a5ada": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 50
                 }
             ]
         ],
         "9c57bd1cd8bfa381ce391fcd": [
-            [
-                {
+            [{
                     "_tpl": "57347c1124597737fb1379e3",
                     "count": 2
                 }
             ]
         ],
         "1a317ae89abb5bbaf89720cd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 20000
                 }
             ]
         ],
         "1c5bfbedb7bf2eb8db265d4d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1300
                 }
             ]
         ],
         "411cd2a6bbf37e7aa9f7e8c5": [
-            [
-                {
+            [{
                     "_tpl": "57e26fc7245977162a14b800",
                     "count": 8
                 }
             ]
         ],
         "b6aa0aa8dbfd624a530dd9ba": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 37000
                 }
             ]
         ],
         "5a70a9da8c157810dfebd608": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24000
                 }
             ]
         ],
         "5513f6c7155b5ed8731abff7": [
-            [
-                {
+            [{
                     "_tpl": "5737201124597760fc4431f1",
                     "count": 2
                 }
             ]
         ],
         "db39e5eba0da6e91ac7d0baf": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 45
                 }
             ]
         ],
         "21e6a3b3abfab4f1dfcbb9fe": [
-            [
-                {
+            [{
                     "_tpl": "57347d7224597744596b4e72",
                     "count": 10
                 }
             ]
         ],
         "2c2cdfcaaedf64f3c33a6bfe": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 44000
                 }
             ]
         ],
         "b629cffeee7365bbbdb4fdf9": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1800
                 }
             ]
         ],
         "70457fc9d9c8d617a11de7c1": [
-            [
-                {
+            [{
                     "_tpl": "590c5f0d86f77413997acfab",
                     "count": 6
                 }
             ]
         ],
         "43bcca99f2e7ceebff948ee1": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 36000
                 }
             ]
         ],
         "aa8cfaf93a0a12f3a61fa33b": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3400
                 }
             ]
         ],
         "fdff4ca46bfc60e6fc1a1deb": [
-            [
-                {
+            [{
                     "_tpl": "575146b724597720a27126d5",
                     "count": 2
-                },
-                {
+                }, {
                     "_tpl": "619cbfeb6b8a1b37a54eebfa",
                     "count": 2
                 }
             ]
         ],
         "0b79d8fc0aeee03ff2d7aaff": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 21000
                 }
             ]
         ],
         "707d0a9feff99f8bb17ddcdc": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1400
                 }
             ]
         ],
         "d5c5a21fb1fcbfcbdbdd4ecf": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2000
                 }
             ]
         ],
         "63cd7aaedb0bbec7e50fbb25": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 4500
                 }
             ]
         ],
         "2c477417ea95eae017c9e01f": [
-            [
-                {
+            [{
                     "_tpl": "5672cb124bdc2d1a0f8b4568",
                     "count": 3
                 }
             ]
         ],
         "1eaaadbbd63ebd7cb88ccc7e": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 7500
                 }
             ]
         ],
         "6bea2af7470a11f1c027bffa": [
-            [
-                {
+            [{
                     "_tpl": "5448ff904bdc2d6f028b456e",
                     "count": 3
                 }
             ]
         ],
         "3f4c9d2d18fadcc5aa4d319c": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 16000
                 }
             ]
         ],
         "8bf71225f5321d4a20ab6e0c": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 25000
                 }
             ]
         ],
         "a4067e1a0ccad3e45acf0f1b": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 57000
                 }
             ]
         ],
         "d4dece77c70ad1dedde21fee": [
-            [
-                {
+            [{
                     "_tpl": "5d403f9186f7743cac3f229b",
                     "count": 2
                 }
             ]
         ],
         "f47e63136d9e2e21d9b9bdfc": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 98000
                 }
             ]
         ],
         "00bb3bd10a94d4dd0edae2b5": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 78000
                 }
             ]
         ],
         "23e630e3ac5c0c0c32fa2fdc": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2800
                 }
             ]
         ],
         "98e0f0c9f9ce788ee52dc05a": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2200
                 }
             ]
         ],
         "afd3a6259deff7df0eb300a4": [
-            [
-                {
+            [{
                     "_tpl": "59e36c6f86f774176c10a2a7",
                     "count": 3
                 }
             ]
         ],
         "9f80addca7aa1dcd0beef6ef": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 18500
                 }
             ]
         ],
         "9d2e7ec756fb719f65440bb1": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 12000
                 }
             ]
         ],
         "a1ceaecdd0ca33ac6ede8fdf": [
-            [
-                {
+            [{
                     "_tpl": "56d59d3ad2720bdb418b4577",
                     "count": 4
                 }
             ]
         ],
         "f07ecb6db63bb03eac6fcfab": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 145
                 }
             ]
         ],
         "4c8894693818128cfbde5e7a": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1500
                 }
             ]
         ],
         "d01ac040ed0e7ec2afaf000f": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 7500
                 }
             ]
         ],
         "cadfd8d099bf6fbcbe95b33b": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3300
                 }
             ]
         ],
         "fd942eafa8b2f18a42cc56d3": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2250
                 }
             ]
         ],
         "134cbe54aabbe3b49ede24fd": [
-            [
-                {
+            [{
                     "_tpl": "5734758f24597738025ee253",
                     "count": 1
                 }
             ]
         ],
         "f1af81dc1dff3ea1b5ac6e4e": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 33000
                 }
             ]
         ],
         "c39ea5eedfd45a72e9b1ffb3": [
-            [
-                {
+            [{
                     "_tpl": "590c311186f77424d1667482",
                     "count": 4
                 }
             ]
         ],
         "f334efa7eed9b05fa4c5f0be": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 27000
                 }
             ]
         ],
         "dbf7e6c04b7b0dd1e90b3e0e": [
-            [
-                {
+            [{
                     "_tpl": "5734773724597737fd047c14",
                     "count": 3
                 }
             ]
         ],
         "ddd6a65fdf9f16d83b318daa": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 30000
                 }
             ]
         ],
         "886d1e5ad9842e5bc40e1143": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 63000
                 }
             ]
         ],
         "3d950b64d16c7c245d6b5f9e": [
-            [
-                {
+            [{
                     "_tpl": "5d0376a486f7747d8050965c",
                     "count": 5
                 }
             ]
         ],
         "68bbbdaee53cad9c6a01d0ac": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 156000
                 }
             ]
         ],
         "7fd3bed1c9fcf118b00cbbea": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 25000
                 }
             ]
         ],
         "cf3a1965f725ecbc81c7545d": [
-            [
-                {
+            [{
                     "_tpl": "590a3b0486f7743954552bdb",
                     "count": 5
                 }
             ]
         ],
         "fdfc68e5aecfe2d355e05df4": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 42000
                 }
             ]
         ],
         "faf2b1d5e543abb9b72966ab": [
-            [
-                {
+            [{
                     "_tpl": "5af0534a86f7743b6f354284",
                     "count": 2
                 }
             ]
         ],
         "fbeaec0f91c1204fac95e7a0": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 88000
                 }
             ]
         ],
         "9e1a1c3faeefb88c67846aaf": [
-            [
-                {
+            [{
                     "_tpl": "5e2af29386f7746d4159f077",
                     "count": 3
                 }
             ]
         ],
         "8f538ebbd5a3ddf1d3b47d62": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 48000
                 }
             ]
         ],
         "fbc0a8d0fc3ac65aa3bba661": [
-            [
-                {
+            [{
                     "_tpl": "590a3c0a86f774385a33c450",
                     "count": 3
-                },
-                {
+                }, {
                     "_tpl": "59e36c6f86f774176c10a2a7",
                     "count": 5
                 }
             ]
         ],
         "df6bde5f07ac961aa9da4b8b": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 52000
                 }
             ]
         ],
         "c03dcd84bec6e0d23dceed92": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 13500
                 }
             ]
         ],
         "da9ca8940d4e39ccec53d5e1": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 9400
                 }
             ]
         ],
         "735805162eaad4267bf6edfa": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 31000
                 }
             ]
         ],
         "0fbee497ded7aa5ead7d3f7a": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 7000
                 }
             ]
         ],
         "d57eed678ae9bfef5d13efab": [
-            [
-                {
+            [{
                     "_tpl": "54491bb74bdc2d09088b4567",
                     "count": 2
                 }
             ]
         ],
         "c96f3e5d2360105f8bebcc9d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 30000
                 }
             ]
         ],
         "ce16ab92fc2fdedbbce276a0": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 45000
                 }
             ]
         ],
         "9daca13fdf45feffda929ec9": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 8455
                 }
             ]
         ],
         "ba0b2efdc707d20a50bcf9ed": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5800
                 }
             ]
         ],
         "b5ec0ccd20e80a520e8ca1ac": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 10200
                 }
             ]
         ],
         "ee685e4dae31cfbb2bf9cdb1": [
-            [
-                {
+            [{
                     "_tpl": "5ba26844d4351e00334c9475",
                     "count": 3
                 }
             ]
         ],
         "b7ba97bed5ae6d3d1eafce2f": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 360
                 }
             ]
         ],
         "c554dccc730ccae2e6fccb0b": [
-            [
-                {
+            [{
                     "_tpl": "56dff216d2720bbd668b4568",
                     "count": 4
                 }
             ]
         ],
         "6445be79d68ff6ac7ac7fc1e": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60
                 }
             ]
         ],
         "dbefe090123ecf1d6a29fab7": [
-            [
-                {
+            [{
                     "_tpl": "5ba2678ad4351e44f824b344",
                     "count": 3
                 }
             ]
         ],
         "3a1fd1a3f34ca2d9f8c3c8ff": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 630
                 }
             ]
         ],
         "762eedaabb6f6ecca9e0edda": [
-            [
-                {
+            [{
                     "_tpl": "5ba26812d4351e003201fef1",
                     "count": 12
                 }
             ]
         ],
         "f5afa9cb6f4e95c4effc5acc": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 90
                 }
             ]
         ],
         "cc4a5f48f7a3a3f164f91fb5": [
-            [
-                {
+            [{
                     "_tpl": "5d235a5986f77443f6329bc6",
                     "count": 2
                 }
             ]
         ],
         "a4f4cebdd504df8c6cdd5cbd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 51000
                 }
             ]
         ],
         "be0f57a8dfcd34bd7dfe5803": [
-            [
-                {
+            [{
                     "_tpl": "590a386e86f77429692b27ab",
                     "count": 5
                 }
             ]
         ],
         "5d9d636c1faa4c42df6d97d5": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60000
                 }
             ]
         ],
         "72fdb7f3a277dfd6eabfafe3": [
-            [
-                {
+            [{
                     "_tpl": "5d1b392c86f77425243e98fe",
                     "count": 5
                 }
             ]
         ],
         "a7fa1a09e49cf4d42dbc4d7c": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 18000
                 }
             ]
         ],
         "4f71eccb9884c69a1c1a2538": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2800
                 }
             ]
         ],
         "bbb80f3f7abcc46de99adcdd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1600
                 }
             ]
         ],
         "cfc41c8b0ad9d8f2ea8e8e6a": [
-            [
-                {
+            [{
                     "_tpl": "590c5f0d86f77413997acfab",
                     "count": 5
                 }
             ]
         ],
         "ccccfde8dbcaec0cdaecbe47": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24000
                 }
             ]
         ],
         "685b7bdaf4ab7190803721d0": [
-            [
-                {
+            [{
                     "_tpl": "5c06782b86f77426df5407d2",
                     "count": 3
                 }
             ]
         ],
         "8bcea9cbaa2f75ff22abafe7": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 8800
                 }
             ]
         ],
         "db3939bbe8bd0b4b678d7aed": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 67500
                 }
             ]
         ],
         "1da5efc9bd2954b0ffd862c8": [
-            [
-                {
+            [{
                     "_tpl": "5b43575a86f77424f443fe62",
                     "count": 5
                 }
             ]
         ],
         "ecde82bb1f509f9bb9dabd38": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 58000
                 }
             ]
         ],
         "4f4ebc0fbba3a49c6c5fb461": [
-            [
-                {
+            [{
                     "_tpl": "59e35ef086f7741777737012",
                     "count": 4
                 }
             ]
         ],
         "d69977a2fdb1cc6c4d771bee": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 9500
                 }
             ]
         ],
         "3bcca6aacfafdb6edf1025ab": [
-            [
-                {
+            [{
                     "_tpl": "5efb0e16aeb21837e749c7ff",
                     "count": 2
                 }
             ]
         ],
         "dfacfe909d6558de7ced5138": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 360
                 }
             ]
         ],
         "b8aa67394c3c826a5c20b8c4": [
-            [
-                {
+            [{
                     "_tpl": "590a358486f77429692b2790",
                     "count": 1
                 }
             ]
         ],
         "4c185bc28fa79ef071e7a73c": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 55000
                 }
             ]
         ],
         "3cee7d223e197b0dad7adbb3": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 45000
                 }
             ]
         ],
         "e83ddc049dee9f799566c41a": [
-            [
-                {
+            [{
                     "_tpl": "5d235b4d86f7742e017bc88a",
                     "count": 4
                 }
             ]
         ],
         "f0afb4c0c05bfd31ce85e0ea": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 81000
                 }
             ]
         ],
         "4db52961fe841e07df9cf7eb": [
-            [
-                {
+            [{
                     "_tpl": "58864a4f2459770fcc257101",
                     "count": 2
                 }
             ]
         ],
         "0c01ae762a3d31f9d3faadef": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60
                 }
             ]
         ],
         "ef19a9e9fcef6fcaabc3e3c5": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1250
                 }
             ]
         ],
         "fbedd2b04e2ae33febbd7ebc": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5000
                 }
             ]
         ],
         "4c12bbc8f9d4cb99c5dbbca8": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 13500
                 }
             ]
         ],
         "bcff76cf2f12963e14cc6ba0": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 200
                 }
             ]
         ],
         "acc0590e51abf65d0be5dcee": [
-            [
-                {
+            [{
                     "_tpl": "5c0d56a986f774449d5de529",
                     "count": 2
                 }
             ]
         ],
         "03842e3abd93bda4bcd836cb": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 180
                 }
             ]
         ],
         "a00ea4e635aca7242c3ca430": [
-            [
-                {
+            [{
                     "_tpl": "569668774bdc2da2298b4568",
                     "count": 200
-                },
-                {
+                }, {
                     "_tpl": "5696686a4bdc2da3298b456a",
                     "count": 200
                 }
             ]
         ],
         "d8fe280b7eddf7cdea85fbbc": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 58000
                 }
             ]
         ],
         "6aae6b7bb7b4312faabefc51": [
-            [
-                {
+            [{
                     "_tpl": "5d1b317c86f7742523398392",
                     "count": 2
                 }
             ]
         ],
         "bafb4f2becff3fa1edd0c9df": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 153000
                 }
             ]
         ],
         "a5d2b379faf0f2dcdea70b5b": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 10000
                 }
             ]
         ],
         "e4389c85c2d0d411e59baba9": [
-            [
-                {
+            [{
                     "_tpl": "5d403f9186f7743cac3f229b",
                     "count": 3
                 }
             ]
         ],
         "5f874db0cbfb83bc7c1dacbc": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 90000
                 }
             ]
         ],
         "0d4e53f8dde4728245fa4ea7": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 21000
                 }
             ]
         ],
         "f430ae634bd13deb5793af3b": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2400
                 }
             ]
         ],
         "a4fd56c04d6f0c1f0c8e1ebc": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1800
                 }
             ]
         ],
         "b15a46448abeb15a8066e1e4": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24000
                 }
             ]
         ],
         "19311f9cdd8b19dc4af8de71": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 105000
                 }
             ]
         ],
         "fd5dc6c29021fbfcdd29bce2": [
-            [
-                {
+            [{
                     "_tpl": "59e36c6f86f774176c10a2a7",
                     "count": 5
                 }
             ]
         ],
         "8bcc62f3374c3a29696f40e8": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 48000
                 }
             ]
         ],
         "e0efb555332fde2bdeb1bc7a": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1000000
                 }
             ]
         ],
         "d5bba9bd21b779abfdddbe9e": [
-            [
-                {
+            [{
                     "_tpl": "5c1265fc86f7743f896a21c2",
                     "count": 1
                 }
             ]
         ],
         "133526a998c8ba1c22c5e8f8": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 45000
                 }
             ]
         ],
         "f1dcaf138aba4de379da1efe": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 31000
                 }
             ]
         ],
         "f556c7af8ac720eb0e21d3e0": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1500
                 }
             ]
         ],
         "358832f6bcdb70ab7c84bb91": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 31000
                 }
             ]
         ],
         "a3760f2fe7af2ced96fdda0f": [
-            [
-                {
+            [{
                     "_tpl": "5d235a5986f77443f6329bc6",
                     "count": 1
                 }
             ]
         ],
         "86add03867ecbb5adc6ad520": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 73000
                 }
             ]
         ],
         "9bac87edd4ddfd88cd22c4b7": [
-            [
-                {
+            [{
                     "_tpl": "5c10c8fd86f7743d7d706df3",
                     "count": 2
-                },
-                {
+                }, {
                     "_tpl": "5d1b392c86f77425243e98fe",
                     "count": 3
                 }
             ]
         ],
         "bcafda5baf624ab54c5cf8c5": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 33000
                 }
             ]
         ],
         "ef9f6ab8edda8baf2add0d4d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1500
                 }
             ]
         ],
         "4dfa00005451cb7add4284ac": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1600
                 }
             ]
         ],
         "ead40fcbfed6589bb4d5bfe5": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2150
                 }
             ]
         ],
         "6e0a2ab073bb0f04b7e7bc19": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3400
                 }
             ]
         ],
         "3c4f321dc26ddfdade21e1fa": [
-            [
-                {
+            [{
                     "_tpl": "5d4042a986f7743185265463",
                     "count": 2
                 }
             ]
         ],
         "1f416a7c5a7c6ddeaeebd5ff": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5500
                 }
             ]
         ],
         "d20fda6f5f13c3f4c827e0ab": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 33000
                 }
             ]
         ],
         "5207bc9fcaf7cf96a7aa1d7f": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 45000
                 }
             ]
         ],
         "eef3c5cda00670a1ef8cbafb": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 45000
                 }
             ]
         ],
         "db4dcfca7c812792be3dfdcd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 45000
                 }
             ]
         ],
         "d8d19cb46c2ff2933ba26063": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 45000
                 }
             ]
         ],
         "1ecbdfb87cb0ffca0c546c62": [
-            [
-                {
+            [{
                     "_tpl": "59e3639286f7741777737013",
                     "count": 1
                 }
             ]
         ],
         "6a28a2a53e78d37ea166e2e3": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 105000
                 }
             ]
         ],
         "6afcbe2a67c6fb9e424da5de": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 37000
                 }
             ]
         ],
         "bfd8de56d5a8ccc0bb708520": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 145000
                 }
             ]
         ],
         "8fa9494e26ae6b5c68fccd20": [
-            [
-                {
+            [{
                     "_tpl": "5d1b2ffd86f77425243e8d17",
                     "count": 2
-                },
-                {
+                }, {
                     "_tpl": "5d1b2fa286f77425227d1674",
                     "count": 1
                 }
             ]
         ],
         "64156ef7a70e700a91fa1b8a": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 51000
                 }
             ]
         ],
         "d8164c716ada59d45f408efe": [
-            [
-                {
+            [{
                     "_tpl": "5737201124597760fc4431f1",
                     "count": 6
                 }
             ]
         ],
         "63bfefcf3ba0e6fdfe9e218a": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 75
                 }
             ]
         ],
         "a42cfec0d481218fafaedfd7": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2200
                 }
             ]
         ],
         "f3fdee5c0a803449e2b7ebf2": [
-            [
-                {
+            [{
                     "_tpl": "590c5d4b86f774784e1b9c45",
                     "count": 3
                 }
             ]
         ],
         "25afb67abb3fbbce0acaa089": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 21000
                 }
             ]
         ],
         "cb4acecde9baec539a62da71": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3300
                 }
             ]
         ],
         "9fb2fbaede7ffc0d75fefade": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5200
                 }
             ]
         ],
         "5eb4baf778cc3de2e4b3a655": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 12500
                 }
             ]
         ],
         "3da4fd75e2ff9cef10dbb93d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5200
                 }
             ]
         ],
         "cdaca450e6bb3d8c34a34e77": [
-            [
-                {
+            [{
                     "_tpl": "5d6d2ef3a4b93618084f58bd",
                     "count": 1
                 }
             ]
         ],
         "637eace9ce063ef4905bfe1b": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 10500
                 }
             ]
         ],
         "ede0c041f1745b50d6aeee8c": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 113000
                 }
             ]
         ],
         "dcbe6dd65b0fad9af9613ebc": [
-            [
-                {
+            [{
                     "_tpl": "5d4042a986f7743185265463",
                     "count": 5
                 }
             ]
         ],
         "a455ef9e2c766cc4eadce8b6": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 55500
                 }
             ]
         ],
         "bbabbbcbadc33f5d4fbfbaac": [
-            [
-                {
+            [{
                     "_tpl": "5efb0fc6aeb21837e749c801",
                     "count": 3
                 }
             ]
         ],
         "a21a702f3f459ee2ed8fecb8": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 360
                 }
             ]
         ],
         "5f8ddbc9d1ef0e979b4bf6ae": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1800
                 }
             ]
         ],
         "5ce84d8f4d1cb6439b3f2f43": [
-            [
-                {
+            [{
                     "_tpl": "5ea2a8e200685063ec28c05a",
                     "count": 4
                 }
             ]
         ],
         "d51efbffa21acf695dffbdfd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 600
                 }
             ]
         ],
         "a3addf8d2ff7fcbabbe41fac": [
-            [
-                {
+            [{
                     "_tpl": "5e81f423763d9f754677bf2e",
                     "count": 3
                 }
             ]
         ],
         "6dfcc3abbc72eacca9d876e0": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 65
                 }
             ]
         ],
         "fd4ea54bb4faedcd1534cc91": [
-            [
-                {
+            [{
                     "_tpl": "5c925fa22e221601da359b7b",
                     "count": 3
                 }
             ]
         ],
         "c7c89cceb7784ba782ebdab2": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 520
                 }
             ]
         ],
         "360436dadb8e7ae7791cae75": [
-            [
-                {
+            [{
                     "_tpl": "5a3c16fe86f77452b62de32a",
                     "count": 3
                 }
             ]
         ],
         "fb2abbccdfeb412605e07fe2": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 270
                 }
             ]
         ],
         "c9bbc0eb1bab34bb7eb82fba": [
-            [
-                {
+            [{
                     "_tpl": "5efb0d4f4bc50b58e81710f3",
                     "count": 4
                 }
             ]
         ],
         "c7e5ec38ab530f97e251ef78": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 135
                 }
             ]
         ],
         "54d28a12e773aeef1a0ebd4a": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 63000
                 }
             ]
         ],
         "fdd72a909dc6bb25a43a27b2": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 21000
                 }
             ]
         ],
         "0f60b93c29a52aaa6d1aadb2": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 22500
                 }
             ]
         ],
         "7f8f9e5befc5c2301aacf31d": [
-            [
-                {
+            [{
                     "_tpl": "5d1b33a686f7742523398398",
                     "count": 2
                 }
             ]
         ],
         "055f0b1adae017b34e200261": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 48000
                 }
             ]
         ],
         "b9cc2b686082dd7875d7eef4": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 75000
                 }
             ]
         ],
         "1254d5ccefdaf9a3d3bd1a32": [
-            [
-                {
+            [{
                     "_tpl": "59faff1d86f7746c51718c9c",
                     "count": 1
                 }
             ]
         ],
         "706bbc2e7e6f0aa5cbb739d6": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 165000
                 }
             ]
         ],
         "3b599e4fa7eea0fd56c690c9": [
-            [
-                {
+            [{
                     "_tpl": "5734773724597737fd047c14",
                     "count": 6
                 }
             ]
         ],
         "eeba2eb4ddaceeea20ddab1a": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 54000
                 }
             ]
         ],
         "bba2edf2e3af5aa89cfc0cfe": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1300
                 }
             ]
         ],
         "a44dfffc36fde586f68fe2c1": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 4000
                 }
             ]
         ],
         "2ab5a3ea6c9865161ae7bf1b": [
-            [
-                {
+            [{
                     "_tpl": "6196364158ef8c428c287d9f",
                     "count": 3
                 }
             ]
         ],
         "a8d6e6f6cdffcae177bf4834": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 240
                 }
             ]
         ],
         "ee2afb8cfb954d413b1ef95a": [
-            [
-                {
+            [{
                     "_tpl": "544fb3f34bdc2d03748b456a",
                     "count": 5
                 }
             ]
         ],
         "8da19e3fc5b0c049798ebccd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 40000
                 }
             ]
         ],
         "ac30fc6c8b0fe5c833bf4fd6": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1900
                 }
             ]
         ],
         "cab3bd2bbcbc04261bcdb2e5": [
-            [
-                {
+            [{
                     "_tpl": "59e3577886f774176a362503",
                     "count": 6
                 }
             ]
         ],
         "f56f21853db9b53d4ac5dd5d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 50000
                 }
             ]
         ],
         "48eefecd10abc2fb87c6522e": [
-            [
-                {
+            [{
                     "_tpl": "619636be6db0f2477964e710",
                     "count": 10
                 }
             ]
         ],
         "fc7bdc3fedf43f8c9fc88fd2": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 725
                 }
             ]
         ],
         "89ef642beb27bdf51ffbb4b7": [
-            [
-                {
+            [{
                     "_tpl": "5d235b4d86f7742e017bc88a",
                     "count": 3
                 }
             ]
         ],
         "30d38a39f4ae6338a4128f1f": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 55000
                 }
             ]
         ],
         "3bf2186faab1aa8fe38fdb7e": [
-            [
-                {
+            [{
                     "_tpl": "6196365d58ef8c428c287da1",
                     "count": 3
                 }
             ]
         ],
         "f2471030b1ac6bf06b2aac1b": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 135
                 }
             ]
         ],
         "0ab0cd246a7e3a38c2ad6b4d": [
-            [
-                {
+            [{
                     "_tpl": "5d6e6911a4b9361bd5780d52",
                     "count": 2
                 }
             ]
         ],
         "0a7bcdb53e27eec9fb318f0a": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 105
                 }
             ]
         ],
         "8a193beffcdce75b82ffcc37": [
-            [
-                {
+            [{
                     "_tpl": "5fbe3ffdf8b6a877a729ea82",
                     "count": 3
                 }
             ]
         ],
         "fba15a623c779d1cafc09088": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 360
                 }
             ]
         ],
         "ddc32da7abafdeaca4e62c74": [
-            [
-                {
+            [{
                     "_tpl": "590a3c0a86f774385a33c450",
                     "count": 3
-                },
-                {
+                }, {
                     "_tpl": "59e36c6f86f774176c10a2a7",
                     "count": 5
                 }
             ]
         ],
         "df41faf3dec812bb69aece6d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 54000
                 }
             ]
         ],
         "edefbc1e1e81e1c3aee5e0c6": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "5da63b260eca83e9cefbd1ad": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 230
                 }
             ]
         ],
         "64922cbcebffceeeea5ad7a5": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "d3d5ed8e05e02a233770ca06": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 100
                 }
             ]
         ],
         "fd3af4d1f7c8a28c6d3538b8": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "bcec0a0eb24c1fbdd7bd1437": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 460
                 }
             ]
         ],
         "d2023daced2c72d8a7d858e7": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "4a76efbf9ad1ed239033dbeb": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 49000
                 }
             ]
         ],
         "4bac8d6dcefb3a0cad419f56": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "dcb2d8f8d4b5fd2ffb4e96de": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 61000
                 }
             ]
         ],
         "a57e52aefc8ede2ed9eafa1f": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "36e6e5da727bcbf1ecfb6ef3": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 37000
                 }
             ]
         ],
         "099cd41b2f9c849ff68efda7": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3000
                 }
             ]
         ],
         "c3adac0c4ccf4b56eca2fc50": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2400
                 }
             ]
         ]
     },
-    "items": [
-        {
+    "items": [{
             "_id": "d8164c716ada59d45f408efe",
             "_tpl": "5e81f423763d9f754677bf2e",
             "parentId": "hideout",
@@ -1837,8 +1605,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a3addf8d2ff7fcbabbe41fac",
             "_tpl": "5efb0d4f4bc50b58e81710f3",
             "parentId": "hideout",
@@ -1849,8 +1616,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c9bbc0eb1bab34bb7eb82fba",
             "_tpl": "5efb0fc6aeb21837e749c801",
             "parentId": "hideout",
@@ -1861,8 +1627,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "5f8ddbc9d1ef0e979b4bf6ae",
             "_tpl": "5ef3448ab37dfd6af863525c",
             "parentId": "hideout",
@@ -1873,8 +1638,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bbabbbcbadc33f5d4fbfbaac",
             "_tpl": "5ea2a8e200685063ec28c05a",
             "parentId": "hideout",
@@ -1885,8 +1649,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a44dfffc36fde586f68fe2c1",
             "_tpl": "5fb651dc85f90547f674b6f4",
             "parentId": "hideout",
@@ -1897,8 +1660,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "5ce84d8f4d1cb6439b3f2f43",
             "_tpl": "5efb0cabfb3e451d70735af5",
             "parentId": "hideout",
@@ -1909,8 +1671,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "63bfefcf3ba0e6fdfe9e218a",
             "_tpl": "5e81f423763d9f754677bf2e",
             "parentId": "hideout",
@@ -1921,8 +1682,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "6dfcc3abbc72eacca9d876e0",
             "_tpl": "5efb0d4f4bc50b58e81710f3",
             "parentId": "hideout",
@@ -1933,8 +1693,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c7e5ec38ab530f97e251ef78",
             "_tpl": "5efb0fc6aeb21837e749c801",
             "parentId": "hideout",
@@ -1945,8 +1704,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a21a702f3f459ee2ed8fecb8",
             "_tpl": "5ea2a8e200685063ec28c05a",
             "parentId": "hideout",
@@ -1957,8 +1715,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d51efbffa21acf695dffbdfd",
             "_tpl": "5efb0cabfb3e451d70735af5",
             "parentId": "hideout",
@@ -1969,8 +1726,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c554dccc730ccae2e6fccb0b",
             "_tpl": "5ba26812d4351e003201fef1",
             "parentId": "hideout",
@@ -1981,8 +1737,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "762eedaabb6f6ecca9e0edda",
             "_tpl": "5ba26844d4351e00334c9475",
             "parentId": "hideout",
@@ -1993,8 +1748,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ba0b2efdc707d20a50bcf9ed",
             "_tpl": "5ba2657ed4351e0035628ff2",
             "parentId": "hideout",
@@ -2005,8 +1759,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ee685e4dae31cfbb2bf9cdb1",
             "_tpl": "5ba2678ad4351e44f824b344",
             "parentId": "hideout",
@@ -2017,8 +1770,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "dbefe090123ecf1d6a29fab7",
             "_tpl": "5ba26835d4351e0035628ff5",
             "parentId": "hideout",
@@ -2029,8 +1781,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b5ec0ccd20e80a520e8ca1ac",
             "_tpl": "5ba26586d4351e44f824b340",
             "parentId": "hideout",
@@ -2041,8 +1792,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "6445be79d68ff6ac7ac7fc1e",
             "_tpl": "5ba26812d4351e003201fef1",
             "parentId": "hideout",
@@ -2053,8 +1803,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f5afa9cb6f4e95c4effc5acc",
             "_tpl": "5ba26844d4351e00334c9475",
             "parentId": "hideout",
@@ -2065,8 +1814,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b7ba97bed5ae6d3d1eafce2f",
             "_tpl": "5ba2678ad4351e44f824b344",
             "parentId": "hideout",
@@ -2077,8 +1825,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "3a1fd1a3f34ca2d9f8c3c8ff",
             "_tpl": "5ba26835d4351e0035628ff5",
             "parentId": "hideout",
@@ -2089,8 +1836,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "0ab0cd246a7e3a38c2ad6b4d",
             "_tpl": "6196365d58ef8c428c287da1",
             "parentId": "hideout",
@@ -2101,8 +1847,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "3bf2186faab1aa8fe38fdb7e",
             "_tpl": "6196364158ef8c428c287d9f",
             "parentId": "hideout",
@@ -2113,8 +1858,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "2ab5a3ea6c9865161ae7bf1b",
             "_tpl": "5fbe3ffdf8b6a877a729ea82",
             "parentId": "hideout",
@@ -2125,8 +1869,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "8a193beffcdce75b82ffcc37",
             "_tpl": "619636be6db0f2477964e710",
             "parentId": "hideout",
@@ -2137,8 +1880,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "48eefecd10abc2fb87c6522e",
             "_tpl": "5fd20ff893a8961fc660a954",
             "parentId": "hideout",
@@ -2149,8 +1891,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "0a7bcdb53e27eec9fb318f0a",
             "_tpl": "6196365d58ef8c428c287da1",
             "parentId": "hideout",
@@ -2161,8 +1902,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f2471030b1ac6bf06b2aac1b",
             "_tpl": "6196364158ef8c428c287d9f",
             "parentId": "hideout",
@@ -2173,8 +1913,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a8d6e6f6cdffcae177bf4834",
             "_tpl": "5fbe3ffdf8b6a877a729ea82",
             "parentId": "hideout",
@@ -2185,8 +1924,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fba15a623c779d1cafc09088",
             "_tpl": "619636be6db0f2477964e710",
             "parentId": "hideout",
@@ -2197,8 +1935,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fc7bdc3fedf43f8c9fc88fd2",
             "_tpl": "5fd20ff893a8961fc660a954",
             "parentId": "hideout",
@@ -2209,8 +1946,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "5513f6c7155b5ed8731abff7",
             "_tpl": "58864a4f2459770fcc257101",
             "parentId": "hideout",
@@ -2221,8 +1957,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "4db52961fe841e07df9cf7eb",
             "_tpl": "5c3df7d588a4501f290594e5",
             "parentId": "hideout",
@@ -2233,8 +1968,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "4dfa00005451cb7add4284ac",
             "_tpl": "5de8ea8ffd6b4e6e2276dc35",
             "parentId": "hideout",
@@ -2245,8 +1979,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b629cffeee7365bbbdb4fdf9",
             "_tpl": "5894a05586f774094708ef75",
             "parentId": "hideout",
@@ -2257,8 +1990,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ff109e00a8dde480eefa87fb",
             "_tpl": "56d59d3ad2720bdb418b4577",
             "parentId": "hideout",
@@ -2269,8 +2001,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "9c57bd1cd8bfa381ce391fcd",
             "_tpl": "5739d41224597779c3645501",
             "parentId": "hideout",
@@ -2281,14 +2012,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "364bcd572edfcc0eede35b82",
             "_tpl": "56d59d3ad2720bdb418b4577",
             "parentId": "9c57bd1cd8bfa381ce391fcd",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 16
+            }
+        }, {
             "_id": "aa8cfaf93a0a12f3a61fa33b",
             "_tpl": "5926c3b286f774640d189b6b",
             "parentId": "hideout",
@@ -2299,8 +2032,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a1ceaecdd0ca33ac6ede8fdf",
             "_tpl": "5a3c16fe86f77452b62de32a",
             "parentId": "hideout",
@@ -2311,8 +2043,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ead40fcbfed6589bb4d5bfe5",
             "_tpl": "5de8eaadbbaf010b10528a6d",
             "parentId": "hideout",
@@ -2323,8 +2054,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "360436dadb8e7ae7791cae75",
             "_tpl": "5efb0e16aeb21837e749c7ff",
             "parentId": "hideout",
@@ -2335,8 +2065,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bcff76cf2f12963e14cc6ba0",
             "_tpl": "5c920e902e221644f31c3c99",
             "parentId": "hideout",
@@ -2347,8 +2076,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "4f71eccb9884c69a1c1a2538",
             "_tpl": "5c0672ed0db834001b7353f3",
             "parentId": "hideout",
@@ -2359,8 +2087,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d5c5a21fb1fcbfcbdbdd4ecf",
             "_tpl": "599860ac86f77436b225ed1a",
             "parentId": "hideout",
@@ -2371,8 +2098,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fbedd2b04e2ae33febbd7ebc",
             "_tpl": "5c5db6652e221600113fba51",
             "parentId": "hideout",
@@ -2383,8 +2109,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "3bcca6aacfafdb6edf1025ab",
             "_tpl": "5c0d56a986f774449d5de529",
             "parentId": "hideout",
@@ -2395,8 +2120,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b8aa67394c3c826a5c20b8c4",
             "_tpl": "5c1127bdd174af44217ab8b9",
             "parentId": "hideout",
@@ -2407,14 +2131,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "00983daaac2acfdb2c45be0d",
             "_tpl": "5c0d56a986f774449d5de529",
             "parentId": "b8aa67394c3c826a5c20b8c4",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 20
+            }
+        }, {
             "_id": "9d2e7ec756fb719f65440bb1",
             "_tpl": "5a351711c4a282000b1521a4",
             "parentId": "hideout",
@@ -2425,8 +2151,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "acc0590e51abf65d0be5dcee",
             "_tpl": "5c925fa22e221601da359b7b",
             "parentId": "hideout",
@@ -2437,8 +2162,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "6e0a2ab073bb0f04b7e7bc19",
             "_tpl": "5de8eac42a78646d96665d91",
             "parentId": "hideout",
@@ -2449,8 +2173,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "4c12bbc8f9d4cb99c5dbbca8",
             "_tpl": "5c5db6742e2216000f1b2852",
             "parentId": "hideout",
@@ -2461,8 +2184,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fd4ea54bb4faedcd1534cc91",
             "_tpl": "5efb0da7a29a85116f6ea05f",
             "parentId": "hideout",
@@ -2473,8 +2195,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d01ac040ed0e7ec2afaf000f",
             "_tpl": "5a718f958dc32e00094b97e7",
             "parentId": "hideout",
@@ -2485,8 +2206,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "db39e5eba0da6e91ac7d0baf",
             "_tpl": "58864a4f2459770fcc257101",
             "parentId": "hideout",
@@ -2497,8 +2217,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "0c01ae762a3d31f9d3faadef",
             "_tpl": "5c3df7d588a4501f290594e5",
             "parentId": "hideout",
@@ -2509,8 +2228,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "49cbcb5c5fdbc6790e0a5ada",
             "_tpl": "56d59d3ad2720bdb418b4577",
             "parentId": "hideout",
@@ -2521,8 +2239,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f07ecb6db63bb03eac6fcfab",
             "_tpl": "5a3c16fe86f77452b62de32a",
             "parentId": "hideout",
@@ -2533,8 +2250,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fb2abbccdfeb412605e07fe2",
             "_tpl": "5efb0e16aeb21837e749c7ff",
             "parentId": "hideout",
@@ -2545,8 +2261,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "dfacfe909d6558de7ced5138",
             "_tpl": "5c0d56a986f774449d5de529",
             "parentId": "hideout",
@@ -2557,8 +2272,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "03842e3abd93bda4bcd836cb",
             "_tpl": "5c925fa22e221601da359b7b",
             "parentId": "hideout",
@@ -2569,8 +2283,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c7c89cceb7784ba782ebdab2",
             "_tpl": "5efb0da7a29a85116f6ea05f",
             "parentId": "hideout",
@@ -2581,8 +2294,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "2c477417ea95eae017c9e01f",
             "_tpl": "59e7711e86f7746cae05fbe1",
             "parentId": "hideout",
@@ -2593,26 +2305,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666fad3005a4eac710002b21",
             "_tpl": "657ba50c23918923cb0df56c",
             "parentId": "2c477417ea95eae017c9e01f",
             "slotId": "Helmet_top"
-        },
-        {
+        }, {
             "_id": "666fad3005a4eac710002b22",
             "_tpl": "657ba5439ba22f103e08139f",
             "parentId": "2c477417ea95eae017c9e01f",
             "slotId": "Helmet_back"
-        },
-        {
+        }, {
             "_id": "666fad3005a4eac710002b23",
             "_tpl": "657ba57af58ba5a62501079e",
             "parentId": "2c477417ea95eae017c9e01f",
             "slotId": "Helmet_ears"
-        },
-        {
+        }, {
             "_id": "685b7bdaf4ab7190803721d0",
             "_tpl": "5c08f87c0db8340019124324",
             "parentId": "hideout",
@@ -2623,32 +2331,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666fad3005a4eac710002b24",
             "_tpl": "657ba85ecfcf63c951052da7",
             "parentId": "685b7bdaf4ab7190803721d0",
             "slotId": "Helmet_top"
-        },
-        {
+        }, {
             "_id": "666fad3005a4eac710002b25",
             "_tpl": "657ba8bccfcf63c951052dab",
             "parentId": "685b7bdaf4ab7190803721d0",
             "slotId": "Helmet_back"
-        },
-        {
+        }, {
             "_id": "666fad3005a4eac710002b26",
             "_tpl": "65818e4e566d2de69901b1b1",
             "parentId": "685b7bdaf4ab7190803721d0",
             "slotId": "helmet_eyes"
-        },
-        {
+        }, {
             "_id": "666fad3005a4eac710002b27",
             "_tpl": "657ba8eab7e9ca9a02045bfd",
             "parentId": "685b7bdaf4ab7190803721d0",
             "slotId": "Helmet_ears"
-        },
-        {
+        }, {
             "_id": "4f4ebc0fbba3a49c6c5fb461",
             "_tpl": "5c0d2727d174af02a012cf58",
             "parentId": "hideout",
@@ -2659,32 +2362,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666fad3005a4eac710002b28",
             "_tpl": "657ba6c3c6f689d3a205b857",
             "parentId": "4f4ebc0fbba3a49c6c5fb461",
             "slotId": "Helmet_top"
-        },
-        {
+        }, {
             "_id": "666fad3005a4eac710002b29",
             "_tpl": "657ba737b7e9ca9a02045bf6",
             "parentId": "4f4ebc0fbba3a49c6c5fb461",
             "slotId": "Helmet_back"
-        },
-        {
+        }, {
             "_id": "666fad3005a4eac710002b2a",
             "_tpl": "658188edf026a90c1708c827",
             "parentId": "4f4ebc0fbba3a49c6c5fb461",
             "slotId": "helmet_eyes"
-        },
-        {
+        }, {
             "_id": "666fad3005a4eac710002b2b",
             "_tpl": "657ba75e23918923cb0df573",
             "parentId": "4f4ebc0fbba3a49c6c5fb461",
             "slotId": "Helmet_ears"
-        },
-        {
+        }, {
             "_id": "afd3a6259deff7df0eb300a4",
             "_tpl": "5a16bb52fcdbcb001a3b00dc",
             "parentId": "hideout",
@@ -2695,8 +2393,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "3c4f321dc26ddfdade21e1fa",
             "_tpl": "5df8a58286f77412631087ed",
             "parentId": "hideout",
@@ -2707,26 +2404,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666fad3005a4eac710002b2c",
             "_tpl": "657ba096e57570b7f80a17fb",
             "parentId": "3c4f321dc26ddfdade21e1fa",
             "slotId": "Helmet_top"
-        },
-        {
+        }, {
             "_id": "666fad3005a4eac710002b2d",
             "_tpl": "657ba145e57570b7f80a17ff",
             "parentId": "3c4f321dc26ddfdade21e1fa",
             "slotId": "Helmet_back"
-        },
-        {
+        }, {
             "_id": "666fad3005a4eac710002b2e",
             "_tpl": "657ba18923918923cb0df568",
             "parentId": "3c4f321dc26ddfdade21e1fa",
             "slotId": "Helmet_ears"
-        },
-        {
+        }, {
             "_id": "cdaca450e6bb3d8c34a34e77",
             "_tpl": "5ea05cf85ad9772e6624305d",
             "parentId": "hideout",
@@ -2737,20 +2430,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "666fad3005a4eac710002b2f",
             "_tpl": "657ba2eef58ba5a625010798",
             "parentId": "cdaca450e6bb3d8c34a34e77",
             "slotId": "Helmet_top"
-        },
-        {
+        }, {
             "_id": "666fad3005a4eac710002b30",
             "_tpl": "657ba34b9ba22f103e08139b",
             "parentId": "cdaca450e6bb3d8c34a34e77",
             "slotId": "Helmet_back"
-        },
-        {
+        }, {
             "_id": "cfc41c8b0ad9d8f2ea8e8e6a",
             "_tpl": "5c06c6a80db834001b735491",
             "parentId": "hideout",
@@ -2761,26 +2451,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b31",
-          "_tpl": "6571199565daf6aa960c9b10",
-          "parentId": "cfc41c8b0ad9d8f2ea8e8e6a",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b32",
-          "_tpl": "657119d49eb8c145180dbb95",
-          "parentId": "cfc41c8b0ad9d8f2ea8e8e6a",
-          "slotId": "Helmet_back"
-        },
-        {
-          "_id": "666fad3005a4eac710002b33",
-          "_tpl": "657119fea330b8c9060f7afc",
-          "parentId": "cfc41c8b0ad9d8f2ea8e8e6a",
-          "slotId": "Helmet_ears"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b31",
+            "_tpl": "6571199565daf6aa960c9b10",
+            "parentId": "cfc41c8b0ad9d8f2ea8e8e6a",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b32",
+            "_tpl": "657119d49eb8c145180dbb95",
+            "parentId": "cfc41c8b0ad9d8f2ea8e8e6a",
+            "slotId": "Helmet_back"
+        }, {
+            "_id": "666fad3005a4eac710002b33",
+            "_tpl": "657119fea330b8c9060f7afc",
+            "parentId": "cfc41c8b0ad9d8f2ea8e8e6a",
+            "slotId": "Helmet_ears"
+        }, {
             "_id": "dfeae76c2aed94ebee2db4e8",
             "_tpl": "5645bc214bdc2d363b8b4571",
             "parentId": "hideout",
@@ -2791,26 +2477,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b34",
-          "_tpl": "657bae18b7e9ca9a02045c0a",
-          "parentId": "dfeae76c2aed94ebee2db4e8",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b35",
-          "_tpl": "657baeaacfcf63c951052db3",
-          "parentId": "dfeae76c2aed94ebee2db4e8",
-          "slotId": "Helmet_back"
-        },
-        {
-          "_id": "666fad3005a4eac710002b36",
-          "_tpl": "657baecbc6f689d3a205b863",
-          "parentId": "dfeae76c2aed94ebee2db4e8",
-          "slotId": "Helmet_ears"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b34",
+            "_tpl": "657bae18b7e9ca9a02045c0a",
+            "parentId": "dfeae76c2aed94ebee2db4e8",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b35",
+            "_tpl": "657baeaacfcf63c951052db3",
+            "parentId": "dfeae76c2aed94ebee2db4e8",
+            "slotId": "Helmet_back"
+        }, {
+            "_id": "666fad3005a4eac710002b36",
+            "_tpl": "657baecbc6f689d3a205b863",
+            "parentId": "dfeae76c2aed94ebee2db4e8",
+            "slotId": "Helmet_ears"
+        }, {
             "_id": "d57eed678ae9bfef5d13efab",
             "_tpl": "5b432d215acfc4771e1c6624",
             "parentId": "hideout",
@@ -2821,20 +2503,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b37",
-          "_tpl": "657bb92fa1c61ee0c303631f",
-          "parentId": "d57eed678ae9bfef5d13efab",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b38",
-          "_tpl": "657bb99db30eca976305117f",
-          "parentId": "d57eed678ae9bfef5d13efab",
-          "slotId": "Helmet_back"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b37",
+            "_tpl": "657bb92fa1c61ee0c303631f",
+            "parentId": "d57eed678ae9bfef5d13efab",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b38",
+            "_tpl": "657bb99db30eca976305117f",
+            "parentId": "d57eed678ae9bfef5d13efab",
+            "slotId": "Helmet_back"
+        }, {
             "_id": "dbf7e6c04b7b0dd1e90b3e0e",
             "_tpl": "5aa7d193e5b5b000171d063f",
             "parentId": "hideout",
@@ -2845,26 +2524,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b39",
-          "_tpl": "657bb70486c7f9ef7a009936",
-          "parentId": "dbf7e6c04b7b0dd1e90b3e0e",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b3a",
-          "_tpl": "657bb79ba1c61ee0c303631a",
-          "parentId": "dbf7e6c04b7b0dd1e90b3e0e",
-          "slotId": "Helmet_back"
-        },
-        {
-          "_id": "666fad3005a4eac710002b3b",
-          "_tpl": "657bb7d7b30eca9763051176",
-          "parentId": "dbf7e6c04b7b0dd1e90b3e0e",
-          "slotId": "Helmet_ears"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b39",
+            "_tpl": "657bb70486c7f9ef7a009936",
+            "parentId": "dbf7e6c04b7b0dd1e90b3e0e",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b3a",
+            "_tpl": "657bb79ba1c61ee0c303631a",
+            "parentId": "dbf7e6c04b7b0dd1e90b3e0e",
+            "slotId": "Helmet_back"
+        }, {
+            "_id": "666fad3005a4eac710002b3b",
+            "_tpl": "657bb7d7b30eca9763051176",
+            "parentId": "dbf7e6c04b7b0dd1e90b3e0e",
+            "slotId": "Helmet_ears"
+        }, {
             "_id": "c39ea5eedfd45a72e9b1ffb3",
             "_tpl": "5aa7d03ae5b5b00016327db5",
             "parentId": "hideout",
@@ -2875,26 +2550,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b3c",
-          "_tpl": "654a90aff4f81a421b0a7c86",
-          "parentId": "c39ea5eedfd45a72e9b1ffb3",
-          "slotId": "helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b3d",
-          "_tpl": "654a91068e1ce698150fd1e2",
-          "parentId": "c39ea5eedfd45a72e9b1ffb3",
-          "slotId": "helmet_back"
-        },
-        {
-          "_id": "666fad3005a4eac710002b3e",
-          "_tpl": "654a9189bcc67a392b056c79",
-          "parentId": "c39ea5eedfd45a72e9b1ffb3",
-          "slotId": "helmet_ears"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b3c",
+            "_tpl": "654a90aff4f81a421b0a7c86",
+            "parentId": "c39ea5eedfd45a72e9b1ffb3",
+            "slotId": "helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b3d",
+            "_tpl": "654a91068e1ce698150fd1e2",
+            "parentId": "c39ea5eedfd45a72e9b1ffb3",
+            "slotId": "helmet_back"
+        }, {
+            "_id": "666fad3005a4eac710002b3e",
+            "_tpl": "654a9189bcc67a392b056c79",
+            "parentId": "c39ea5eedfd45a72e9b1ffb3",
+            "slotId": "helmet_ears"
+        }, {
             "_id": "134cbe54aabbe3b49ede24fd",
             "_tpl": "5a7c4850e899ef00150be885",
             "parentId": "hideout",
@@ -2905,26 +2576,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b3f",
-          "_tpl": "657baaf0b7e9ca9a02045c02",
-          "parentId": "134cbe54aabbe3b49ede24fd",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b40",
-          "_tpl": "657bab6ec6f689d3a205b85f",
-          "parentId": "134cbe54aabbe3b49ede24fd",
-          "slotId": "Helmet_back"
-        },
-        {
-          "_id": "666fad3005a4eac710002b41",
-          "_tpl": "657babc6f58ba5a6250107a2",
-          "parentId": "134cbe54aabbe3b49ede24fd",
-          "slotId": "Helmet_ears"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b3f",
+            "_tpl": "657baaf0b7e9ca9a02045c02",
+            "parentId": "134cbe54aabbe3b49ede24fd",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b40",
+            "_tpl": "657bab6ec6f689d3a205b85f",
+            "parentId": "134cbe54aabbe3b49ede24fd",
+            "slotId": "Helmet_back"
+        }, {
+            "_id": "666fad3005a4eac710002b41",
+            "_tpl": "657babc6f58ba5a6250107a2",
+            "parentId": "134cbe54aabbe3b49ede24fd",
+            "slotId": "Helmet_ears"
+        }, {
             "_id": "ddc32da7abafdeaca4e62c74",
             "_tpl": "61bca7cda0eae612383adf57",
             "parentId": "hideout",
@@ -2935,20 +2602,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b42",
-          "_tpl": "657bbcc9a1c61ee0c3036327",
-          "parentId": "ddc32da7abafdeaca4e62c74",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b43",
-          "_tpl": "657bbcffbbd440df880b2dd5",
-          "parentId": "ddc32da7abafdeaca4e62c74",
-          "slotId": "Helmet_back"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b42",
+            "_tpl": "657bbcc9a1c61ee0c3036327",
+            "parentId": "ddc32da7abafdeaca4e62c74",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b43",
+            "_tpl": "657bbcffbbd440df880b2dd5",
+            "parentId": "ddc32da7abafdeaca4e62c74",
+            "slotId": "Helmet_back"
+        }, {
             "_id": "fbc0a8d0fc3ac65aa3bba661",
             "_tpl": "5b4329f05acfc47a86086aa1",
             "parentId": "hideout",
@@ -2959,38 +2623,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b44",
-          "_tpl": "65711b07a330b8c9060f7b01",
-          "parentId": "fbc0a8d0fc3ac65aa3bba661",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b45",
-          "_tpl": "65711b489eb8c145180dbb9d",
-          "parentId": "fbc0a8d0fc3ac65aa3bba661",
-          "slotId": "Helmet_back"
-        },
-        {
-          "_id": "666fad3005a4eac710002b46",
-          "_tpl": "65711b9b65daf6aa960c9b1b",
-          "parentId": "fbc0a8d0fc3ac65aa3bba661",
-          "slotId": "helmet_eyes"
-        },
-        {
-          "_id": "666fad3005a4eac710002b47",
-          "_tpl": "65711bc79eb8c145180dbba1",
-          "parentId": "fbc0a8d0fc3ac65aa3bba661",
-          "slotId": "helmet_jaw"
-        },
-        {
-          "_id": "666fad3005a4eac710002b48",
-          "_tpl": "65711b706d197c216005b31c",
-          "parentId": "fbc0a8d0fc3ac65aa3bba661",
-          "slotId": "Helmet_ears"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b44",
+            "_tpl": "65711b07a330b8c9060f7b01",
+            "parentId": "fbc0a8d0fc3ac65aa3bba661",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b45",
+            "_tpl": "65711b489eb8c145180dbb9d",
+            "parentId": "fbc0a8d0fc3ac65aa3bba661",
+            "slotId": "Helmet_back"
+        }, {
+            "_id": "666fad3005a4eac710002b46",
+            "_tpl": "65711b9b65daf6aa960c9b1b",
+            "parentId": "fbc0a8d0fc3ac65aa3bba661",
+            "slotId": "helmet_eyes"
+        }, {
+            "_id": "666fad3005a4eac710002b47",
+            "_tpl": "65711bc79eb8c145180dbba1",
+            "parentId": "fbc0a8d0fc3ac65aa3bba661",
+            "slotId": "helmet_jaw"
+        }, {
+            "_id": "666fad3005a4eac710002b48",
+            "_tpl": "65711b706d197c216005b31c",
+            "parentId": "fbc0a8d0fc3ac65aa3bba661",
+            "slotId": "Helmet_ears"
+        }, {
             "_id": "cf3a1965f725ecbc81c7545d",
             "_tpl": "5aa7e4a4e5b5b000137b76f2",
             "parentId": "hideout",
@@ -3001,26 +2659,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b49",
-          "_tpl": "657f925dada5fadd1f07a57a",
-          "parentId": "cf3a1965f725ecbc81c7545d",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b4a",
-          "_tpl": "657f92acada5fadd1f07a57e",
-          "parentId": "cf3a1965f725ecbc81c7545d",
-          "slotId": "Helmet_back"
-        },
-        {
-          "_id": "666fad3005a4eac710002b4b",
-          "_tpl": "657f92e7f4c82973640b2354",
-          "parentId": "cf3a1965f725ecbc81c7545d",
-          "slotId": "Helmet_ears"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b49",
+            "_tpl": "657f925dada5fadd1f07a57a",
+            "parentId": "cf3a1965f725ecbc81c7545d",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b4a",
+            "_tpl": "657f92acada5fadd1f07a57e",
+            "parentId": "cf3a1965f725ecbc81c7545d",
+            "slotId": "Helmet_back"
+        }, {
+            "_id": "666fad3005a4eac710002b4b",
+            "_tpl": "657f92e7f4c82973640b2354",
+            "parentId": "cf3a1965f725ecbc81c7545d",
+            "slotId": "Helmet_ears"
+        }, {
             "_id": "fd5dc6c29021fbfcdd29bce2",
             "_tpl": "5d5e7d28a4b936645d161203",
             "parentId": "hideout",
@@ -3031,20 +2685,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b4c",
-          "_tpl": "657f8a8d7db258e5600fe33d",
-          "parentId": "fd5dc6c29021fbfcdd29bce2",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b4d",
-          "_tpl": "657f8b05f4c82973640b2348",
-          "parentId": "fd5dc6c29021fbfcdd29bce2",
-          "slotId": "Helmet_back"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b4c",
+            "_tpl": "657f8a8d7db258e5600fe33d",
+            "parentId": "fd5dc6c29021fbfcdd29bce2",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b4d",
+            "_tpl": "657f8b05f4c82973640b2348",
+            "parentId": "fd5dc6c29021fbfcdd29bce2",
+            "slotId": "Helmet_back"
+        }, {
             "_id": "d5bba9bd21b779abfdddbe9e",
             "_tpl": "5d5e9c74a4b9364855191c40",
             "parentId": "hideout",
@@ -3055,20 +2706,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b4e",
-          "_tpl": "657f8b94f92cd718b70154ff",
-          "parentId": "d5bba9bd21b779abfdddbe9e",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b4f",
-          "_tpl": "657f8b43f92cd718b70154fb",
-          "parentId": "d5bba9bd21b779abfdddbe9e",
-          "slotId": "Helmet_back"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b4e",
+            "_tpl": "657f8b94f92cd718b70154ff",
+            "parentId": "d5bba9bd21b779abfdddbe9e",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b4f",
+            "_tpl": "657f8b43f92cd718b70154fb",
+            "parentId": "d5bba9bd21b779abfdddbe9e",
+            "slotId": "Helmet_back"
+        }, {
             "_id": "9e1a1c3faeefb88c67846aaf",
             "_tpl": "5b40e3f35acfc40016388218",
             "parentId": "hideout",
@@ -3079,20 +2727,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b50",
-          "_tpl": "657f95bff92cd718b701550c",
-          "parentId": "9e1a1c3faeefb88c67846aaf",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b51",
-          "_tpl": "657f9605f4c82973640b2358",
-          "parentId": "9e1a1c3faeefb88c67846aaf",
-          "slotId": "Helmet_back"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b50",
+            "_tpl": "657f95bff92cd718b701550c",
+            "parentId": "9e1a1c3faeefb88c67846aaf",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b51",
+            "_tpl": "657f9605f4c82973640b2358",
+            "parentId": "9e1a1c3faeefb88c67846aaf",
+            "slotId": "Helmet_back"
+        }, {
             "_id": "8fa9494e26ae6b5c68fccd20",
             "_tpl": "5e4bfc1586f774264f7582d3",
             "parentId": "hideout",
@@ -3103,20 +2748,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b52",
-          "_tpl": "657f9c78ada5fadd1f07a58d",
-          "parentId": "8fa9494e26ae6b5c68fccd20",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b53",
-          "_tpl": "657f9cb587e11c61f70bfaca",
-          "parentId": "8fa9494e26ae6b5c68fccd20",
-          "slotId": "Helmet_back"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b52",
+            "_tpl": "657f9c78ada5fadd1f07a58d",
+            "parentId": "8fa9494e26ae6b5c68fccd20",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b53",
+            "_tpl": "657f9cb587e11c61f70bfaca",
+            "parentId": "8fa9494e26ae6b5c68fccd20",
+            "slotId": "Helmet_back"
+        }, {
             "_id": "72fdb7f3a277dfd6eabfafe3",
             "_tpl": "5c066ef40db834001966a595",
             "parentId": "hideout",
@@ -3127,8 +2769,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "be0f57a8dfcd34bd7dfe5803",
             "_tpl": "5c066e3a0db834001b7353f0",
             "parentId": "hideout",
@@ -3139,8 +2780,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a3760f2fe7af2ced96fdda0f",
             "_tpl": "5d6d3716a4b9361bc8618872",
             "parentId": "hideout",
@@ -3151,26 +2791,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b54",
-          "_tpl": "657fa009d4caf976440afe3a",
-          "parentId": "a3760f2fe7af2ced96fdda0f",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b55",
-          "_tpl": "657fa04ac6679fefb3051e24",
-          "parentId": "a3760f2fe7af2ced96fdda0f",
-          "slotId": "Helmet_back"
-        },
-        {
-          "_id": "666fad3005a4eac710002b56",
-          "_tpl": "657fa07387e11c61f70bface",
-          "parentId": "a3760f2fe7af2ced96fdda0f",
-          "slotId": "Helmet_ears"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b54",
+            "_tpl": "657fa009d4caf976440afe3a",
+            "parentId": "a3760f2fe7af2ced96fdda0f",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b55",
+            "_tpl": "657fa04ac6679fefb3051e24",
+            "parentId": "a3760f2fe7af2ced96fdda0f",
+            "slotId": "Helmet_back"
+        }, {
+            "_id": "666fad3005a4eac710002b56",
+            "_tpl": "657fa07387e11c61f70bface",
+            "parentId": "a3760f2fe7af2ced96fdda0f",
+            "slotId": "Helmet_ears"
+        }, {
             "_id": "1da5efc9bd2954b0ffd862c8",
             "_tpl": "5c091a4e0db834001d5addc8",
             "parentId": "hideout",
@@ -3181,26 +2817,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b57",
-          "_tpl": "6571133d22996eaf11088200",
-          "parentId": "1da5efc9bd2954b0ffd862c8",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b58",
-          "_tpl": "6571138e818110db4600aa71",
-          "parentId": "1da5efc9bd2954b0ffd862c8",
-          "slotId": "Helmet_back"
-        },
-        {
-          "_id": "666fad3005a4eac710002b59",
-          "_tpl": "657112fa818110db4600aa6b",
-          "parentId": "1da5efc9bd2954b0ffd862c8",
-          "slotId": "Helmet_ears"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b57",
+            "_tpl": "6571133d22996eaf11088200",
+            "parentId": "1da5efc9bd2954b0ffd862c8",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b58",
+            "_tpl": "6571138e818110db4600aa71",
+            "parentId": "1da5efc9bd2954b0ffd862c8",
+            "slotId": "Helmet_back"
+        }, {
+            "_id": "666fad3005a4eac710002b59",
+            "_tpl": "657112fa818110db4600aa6b",
+            "parentId": "1da5efc9bd2954b0ffd862c8",
+            "slotId": "Helmet_ears"
+        }, {
             "_id": "dcbe6dd65b0fad9af9613ebc",
             "_tpl": "5ea17ca01412a1425304d1c0",
             "parentId": "hideout",
@@ -3211,20 +2843,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b5a",
-          "_tpl": "657f9a55c6679fefb3051e19",
-          "parentId": "dcbe6dd65b0fad9af9613ebc",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b5b",
-          "_tpl": "657f9a94ada5fadd1f07a589",
-          "parentId": "dcbe6dd65b0fad9af9613ebc",
-          "slotId": "Helmet_back"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b5a",
+            "_tpl": "657f9a55c6679fefb3051e19",
+            "parentId": "dcbe6dd65b0fad9af9613ebc",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b5b",
+            "_tpl": "657f9a94ada5fadd1f07a589",
+            "parentId": "dcbe6dd65b0fad9af9613ebc",
+            "slotId": "Helmet_back"
+        }, {
             "_id": "faf2b1d5e543abb9b72966ab",
             "_tpl": "5b40e1525acfc4771e1c6611",
             "parentId": "hideout",
@@ -3235,26 +2864,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b5c",
-          "_tpl": "657112234269e9a568089eac",
-          "parentId": "faf2b1d5e543abb9b72966ab",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b5d",
-          "_tpl": "657112a4818110db4600aa66",
-          "parentId": "faf2b1d5e543abb9b72966ab",
-          "slotId": "Helmet_back"
-        },
-        {
-          "_id": "666fad3005a4eac710002b5e",
-          "_tpl": "657112ce22996eaf110881fb",
-          "parentId": "faf2b1d5e543abb9b72966ab",
-          "slotId": "Helmet_ears"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b5c",
+            "_tpl": "657112234269e9a568089eac",
+            "parentId": "faf2b1d5e543abb9b72966ab",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b5d",
+            "_tpl": "657112a4818110db4600aa66",
+            "parentId": "faf2b1d5e543abb9b72966ab",
+            "slotId": "Helmet_back"
+        }, {
+            "_id": "666fad3005a4eac710002b5e",
+            "_tpl": "657112ce22996eaf110881fb",
+            "parentId": "faf2b1d5e543abb9b72966ab",
+            "slotId": "Helmet_ears"
+        }, {
             "_id": "7f8f9e5befc5c2301aacf31d",
             "_tpl": "5f60b34a41e30a4ab12a6947",
             "parentId": "hideout",
@@ -3265,20 +2890,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b5f",
-          "_tpl": "657bbad7a1c61ee0c3036323",
-          "parentId": "7f8f9e5befc5c2301aacf31d",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b60",
-          "_tpl": "657bbb31b30eca9763051183",
-          "parentId": "7f8f9e5befc5c2301aacf31d",
-          "slotId": "Helmet_back"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b5f",
+            "_tpl": "657bbad7a1c61ee0c3036323",
+            "parentId": "7f8f9e5befc5c2301aacf31d",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b60",
+            "_tpl": "657bbb31b30eca9763051183",
+            "parentId": "7f8f9e5befc5c2301aacf31d",
+            "slotId": "Helmet_back"
+        }, {
             "_id": "d4dece77c70ad1dedde21fee",
             "_tpl": "5a154d5cfcdbcb001a3b00da",
             "parentId": "hideout",
@@ -3289,20 +2911,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b61",
-          "_tpl": "657f8ec5f4c82973640b234c",
-          "parentId": "d4dece77c70ad1dedde21fee",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b62",
-          "_tpl": "657f8f10f4c82973640b2350",
-          "parentId": "d4dece77c70ad1dedde21fee",
-          "slotId": "Helmet_back"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b61",
+            "_tpl": "657f8ec5f4c82973640b234c",
+            "parentId": "d4dece77c70ad1dedde21fee",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b62",
+            "_tpl": "657f8f10f4c82973640b2350",
+            "parentId": "d4dece77c70ad1dedde21fee",
+            "slotId": "Helmet_back"
+        }, {
             "_id": "e83ddc049dee9f799566c41a",
             "_tpl": "5c17a7ed2e2216152142459c",
             "parentId": "hideout",
@@ -3313,20 +2932,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b63",
-          "_tpl": "657f9897f4c82973640b235e",
-          "parentId": "e83ddc049dee9f799566c41a",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b64",
-          "_tpl": "657f98fbada5fadd1f07a585",
-          "parentId": "e83ddc049dee9f799566c41a",
-          "slotId": "Helmet_back"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b63",
+            "_tpl": "657f9897f4c82973640b235e",
+            "parentId": "e83ddc049dee9f799566c41a",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b64",
+            "_tpl": "657f98fbada5fadd1f07a585",
+            "parentId": "e83ddc049dee9f799566c41a",
+            "slotId": "Helmet_back"
+        }, {
             "_id": "3d950b64d16c7c245d6b5f9e",
             "_tpl": "5aa7e276e5b5b000171d0647",
             "parentId": "hideout",
@@ -3337,26 +2953,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b65",
-          "_tpl": "657bc06daab96fccee08be9b",
-          "parentId": "3d950b64d16c7c245d6b5f9e",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b66",
-          "_tpl": "657bc0d8a1c61ee0c303632f",
-          "parentId": "3d950b64d16c7c245d6b5f9e",
-          "slotId": "Helmet_back"
-        },
-        {
-          "_id": "666fad3005a4eac710002b67",
-          "_tpl": "657bc107aab96fccee08be9f",
-          "parentId": "3d950b64d16c7c245d6b5f9e",
-          "slotId": "Helmet_ears"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b65",
+            "_tpl": "657bc06daab96fccee08be9b",
+            "parentId": "3d950b64d16c7c245d6b5f9e",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b66",
+            "_tpl": "657bc0d8a1c61ee0c303632f",
+            "parentId": "3d950b64d16c7c245d6b5f9e",
+            "slotId": "Helmet_back"
+        }, {
+            "_id": "666fad3005a4eac710002b67",
+            "_tpl": "657bc107aab96fccee08be9f",
+            "parentId": "3d950b64d16c7c245d6b5f9e",
+            "slotId": "Helmet_ears"
+        }, {
             "_id": "1254d5ccefdaf9a3d3bd1a32",
             "_tpl": "5f60c74e3b85f6263c145586",
             "parentId": "hideout",
@@ -3367,26 +2979,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b68",
-          "_tpl": "657bc285aab96fccee08bea3",
-          "parentId": "1254d5ccefdaf9a3d3bd1a32",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b69",
-          "_tpl": "657bc2c5a1c61ee0c3036333",
-          "parentId": "1254d5ccefdaf9a3d3bd1a32",
-          "slotId": "Helmet_back"
-        },
-        {
-          "_id": "666fad3005a4eac710002b6a",
-          "_tpl": "657bc2e7b30eca976305118d",
-          "parentId": "1254d5ccefdaf9a3d3bd1a32",
-          "slotId": "Helmet_ears"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b68",
+            "_tpl": "657bc285aab96fccee08bea3",
+            "parentId": "1254d5ccefdaf9a3d3bd1a32",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b69",
+            "_tpl": "657bc2c5a1c61ee0c3036333",
+            "parentId": "1254d5ccefdaf9a3d3bd1a32",
+            "slotId": "Helmet_back"
+        }, {
+            "_id": "666fad3005a4eac710002b6a",
+            "_tpl": "657bc2e7b30eca976305118d",
+            "parentId": "1254d5ccefdaf9a3d3bd1a32",
+            "slotId": "Helmet_ears"
+        }, {
             "_id": "1ecbdfb87cb0ffca0c546c62",
             "_tpl": "5e00c1ad86f774747333222c",
             "parentId": "hideout",
@@ -3397,20 +3005,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b6b",
-          "_tpl": "6551fec55d0cf82e51014288",
-          "parentId": "1ecbdfb87cb0ffca0c546c62",
-          "slotId": "helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b6c",
-          "_tpl": "655200ba0ef76cf7be09d528",
-          "parentId": "1ecbdfb87cb0ffca0c546c62",
-          "slotId": "helmet_back"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b6b",
+            "_tpl": "6551fec55d0cf82e51014288",
+            "parentId": "1ecbdfb87cb0ffca0c546c62",
+            "slotId": "helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b6c",
+            "_tpl": "655200ba0ef76cf7be09d528",
+            "parentId": "1ecbdfb87cb0ffca0c546c62",
+            "slotId": "helmet_back"
+        }, {
             "_id": "6aae6b7bb7b4312faabefc51",
             "_tpl": "5ca20ee186f774799474abc2",
             "parentId": "hideout",
@@ -3421,26 +3026,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b6d",
-          "_tpl": "657bbe73a1c61ee0c303632b",
-          "parentId": "6aae6b7bb7b4312faabefc51",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b6e",
-          "_tpl": "657bbed0aab96fccee08be96",
-          "parentId": "6aae6b7bb7b4312faabefc51",
-          "slotId": "Helmet_back"
-        },
-        {
-          "_id": "666fad3005a4eac710002b6f",
-          "_tpl": "657bbefeb30eca9763051189",
-          "parentId": "6aae6b7bb7b4312faabefc51",
-          "slotId": "Helmet_ears"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b6d",
+            "_tpl": "657bbe73a1c61ee0c303632b",
+            "parentId": "6aae6b7bb7b4312faabefc51",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b6e",
+            "_tpl": "657bbed0aab96fccee08be96",
+            "parentId": "6aae6b7bb7b4312faabefc51",
+            "slotId": "Helmet_back"
+        }, {
+            "_id": "666fad3005a4eac710002b6f",
+            "_tpl": "657bbefeb30eca9763051189",
+            "parentId": "6aae6b7bb7b4312faabefc51",
+            "slotId": "Helmet_ears"
+        }, {
             "_id": "1eaaadbbd63ebd7cb88ccc7e",
             "_tpl": "59e7711e86f7746cae05fbe1",
             "parentId": "hideout",
@@ -3451,26 +3052,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b70",
-          "_tpl": "657ba50c23918923cb0df56c",
-          "parentId": "1eaaadbbd63ebd7cb88ccc7e",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b71",
-          "_tpl": "657ba5439ba22f103e08139f",
-          "parentId": "1eaaadbbd63ebd7cb88ccc7e",
-          "slotId": "Helmet_back"
-        },
-        {
-          "_id": "666fad3005a4eac710002b72",
-          "_tpl": "657ba57af58ba5a62501079e",
-          "parentId": "1eaaadbbd63ebd7cb88ccc7e",
-          "slotId": "Helmet_ears"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b70",
+            "_tpl": "657ba50c23918923cb0df56c",
+            "parentId": "1eaaadbbd63ebd7cb88ccc7e",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b71",
+            "_tpl": "657ba5439ba22f103e08139f",
+            "parentId": "1eaaadbbd63ebd7cb88ccc7e",
+            "slotId": "Helmet_back"
+        }, {
+            "_id": "666fad3005a4eac710002b72",
+            "_tpl": "657ba57af58ba5a62501079e",
+            "parentId": "1eaaadbbd63ebd7cb88ccc7e",
+            "slotId": "Helmet_ears"
+        }, {
             "_id": "63cd7aaedb0bbec7e50fbb25",
             "_tpl": "5ac4c50d5acfc40019262e87",
             "parentId": "hideout",
@@ -3481,8 +3078,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "8bcea9cbaa2f75ff22abafe7",
             "_tpl": "5c08f87c0db8340019124324",
             "parentId": "hideout",
@@ -3493,32 +3089,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b73",
-          "_tpl": "657ba85ecfcf63c951052da7",
-          "parentId": "8bcea9cbaa2f75ff22abafe7",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b74",
-          "_tpl": "657ba8bccfcf63c951052dab",
-          "parentId": "8bcea9cbaa2f75ff22abafe7",
-          "slotId": "Helmet_back"
-        },
-        {
-          "_id": "666fad3005a4eac710002b75",
-          "_tpl": "65818e4e566d2de69901b1b1",
-          "parentId": "8bcea9cbaa2f75ff22abafe7",
-          "slotId": "helmet_eyes"
-        },
-        {
-          "_id": "666fad3005a4eac710002b76",
-          "_tpl": "657ba8eab7e9ca9a02045bfd",
-          "parentId": "8bcea9cbaa2f75ff22abafe7",
-          "slotId": "Helmet_ears"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b73",
+            "_tpl": "657ba85ecfcf63c951052da7",
+            "parentId": "8bcea9cbaa2f75ff22abafe7",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b74",
+            "_tpl": "657ba8bccfcf63c951052dab",
+            "parentId": "8bcea9cbaa2f75ff22abafe7",
+            "slotId": "Helmet_back"
+        }, {
+            "_id": "666fad3005a4eac710002b75",
+            "_tpl": "65818e4e566d2de69901b1b1",
+            "parentId": "8bcea9cbaa2f75ff22abafe7",
+            "slotId": "helmet_eyes"
+        }, {
+            "_id": "666fad3005a4eac710002b76",
+            "_tpl": "657ba8eab7e9ca9a02045bfd",
+            "parentId": "8bcea9cbaa2f75ff22abafe7",
+            "slotId": "Helmet_ears"
+        }, {
             "_id": "d69977a2fdb1cc6c4d771bee",
             "_tpl": "5c0d2727d174af02a012cf58",
             "parentId": "hideout",
@@ -3529,32 +3120,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b77",
-          "_tpl": "657ba6c3c6f689d3a205b857",
-          "parentId": "d69977a2fdb1cc6c4d771bee",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b78",
-          "_tpl": "657ba737b7e9ca9a02045bf6",
-          "parentId": "d69977a2fdb1cc6c4d771bee",
-          "slotId": "Helmet_back"
-        },
-        {
-          "_id": "666fad3005a4eac710002b79",
-          "_tpl": "658188edf026a90c1708c827",
-          "parentId": "d69977a2fdb1cc6c4d771bee",
-          "slotId": "helmet_eyes"
-        },
-        {
-          "_id": "666fad3005a4eac710002b7a",
-          "_tpl": "657ba75e23918923cb0df573",
-          "parentId": "d69977a2fdb1cc6c4d771bee",
-          "slotId": "Helmet_ears"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b77",
+            "_tpl": "657ba6c3c6f689d3a205b857",
+            "parentId": "d69977a2fdb1cc6c4d771bee",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b78",
+            "_tpl": "657ba737b7e9ca9a02045bf6",
+            "parentId": "d69977a2fdb1cc6c4d771bee",
+            "slotId": "Helmet_back"
+        }, {
+            "_id": "666fad3005a4eac710002b79",
+            "_tpl": "658188edf026a90c1708c827",
+            "parentId": "d69977a2fdb1cc6c4d771bee",
+            "slotId": "helmet_eyes"
+        }, {
+            "_id": "666fad3005a4eac710002b7a",
+            "_tpl": "657ba75e23918923cb0df573",
+            "parentId": "d69977a2fdb1cc6c4d771bee",
+            "slotId": "Helmet_ears"
+        }, {
             "_id": "9f80addca7aa1dcd0beef6ef",
             "_tpl": "5a16bb52fcdbcb001a3b00dc",
             "parentId": "hideout",
@@ -3565,8 +3151,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "23e630e3ac5c0c0c32fa2fdc",
             "_tpl": "5a16b8a9fcdbcb00165aa6ca",
             "parentId": "hideout",
@@ -3577,8 +3162,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "98e0f0c9f9ce788ee52dc05a",
             "_tpl": "5a16b93dfcdbcbcae6687261",
             "parentId": "hideout",
@@ -3589,8 +3173,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "00bb3bd10a94d4dd0edae2b5",
             "_tpl": "57235b6f24597759bf5a30f1",
             "parentId": "hideout",
@@ -3601,8 +3184,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "1f416a7c5a7c6ddeaeebd5ff",
             "_tpl": "5df8a58286f77412631087ed",
             "parentId": "hideout",
@@ -3613,26 +3195,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b7b",
-          "_tpl": "657ba096e57570b7f80a17fb",
-          "parentId": "1f416a7c5a7c6ddeaeebd5ff",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b7c",
-          "_tpl": "657ba145e57570b7f80a17ff",
-          "parentId": "1f416a7c5a7c6ddeaeebd5ff",
-          "slotId": "Helmet_back"
-        },
-        {
-          "_id": "666fad3005a4eac710002b7d",
-          "_tpl": "657ba18923918923cb0df568",
-          "parentId": "1f416a7c5a7c6ddeaeebd5ff",
-          "slotId": "Helmet_ears"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b7b",
+            "_tpl": "657ba096e57570b7f80a17fb",
+            "parentId": "1f416a7c5a7c6ddeaeebd5ff",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b7c",
+            "_tpl": "657ba145e57570b7f80a17ff",
+            "parentId": "1f416a7c5a7c6ddeaeebd5ff",
+            "slotId": "Helmet_back"
+        }, {
+            "_id": "666fad3005a4eac710002b7d",
+            "_tpl": "657ba18923918923cb0df568",
+            "parentId": "1f416a7c5a7c6ddeaeebd5ff",
+            "slotId": "Helmet_ears"
+        }, {
             "_id": "637eace9ce063ef4905bfe1b",
             "_tpl": "5ea05cf85ad9772e6624305d",
             "parentId": "hideout",
@@ -3643,20 +3221,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b7e",
-          "_tpl": "657ba2eef58ba5a625010798",
-          "parentId": "637eace9ce063ef4905bfe1b",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b7f",
-          "_tpl": "657ba34b9ba22f103e08139b",
-          "parentId": "637eace9ce063ef4905bfe1b",
-          "slotId": "Helmet_back"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b7e",
+            "_tpl": "657ba2eef58ba5a625010798",
+            "parentId": "637eace9ce063ef4905bfe1b",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b7f",
+            "_tpl": "657ba34b9ba22f103e08139b",
+            "parentId": "637eace9ce063ef4905bfe1b",
+            "slotId": "Helmet_back"
+        }, {
             "_id": "5eb4baf778cc3de2e4b3a655",
             "_tpl": "5a16b672fcdbcb001912fa83",
             "parentId": "hideout",
@@ -3667,8 +3242,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "3da4fd75e2ff9cef10dbb93d",
             "_tpl": "5a398ab9c4a282000c5a9842",
             "parentId": "hideout",
@@ -3679,8 +3253,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "9fb2fbaede7ffc0d75fefade",
             "_tpl": "59d790f486f77403cb06aec6",
             "parentId": "hideout",
@@ -3691,8 +3264,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "cb4acecde9baec539a62da71",
             "_tpl": "57d17c5e2459775a5c57d17d",
             "parentId": "hideout",
@@ -3703,8 +3275,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ccccfde8dbcaec0cdaecbe47",
             "_tpl": "5c06c6a80db834001b735491",
             "parentId": "hideout",
@@ -3715,26 +3286,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b80",
-          "_tpl": "6571199565daf6aa960c9b10",
-          "parentId": "ccccfde8dbcaec0cdaecbe47",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b81",
-          "_tpl": "657119d49eb8c145180dbb95",
-          "parentId": "ccccfde8dbcaec0cdaecbe47",
-          "slotId": "Helmet_back"
-        },
-        {
-          "_id": "666fad3005a4eac710002b82",
-          "_tpl": "657119fea330b8c9060f7afc",
-          "parentId": "ccccfde8dbcaec0cdaecbe47",
-          "slotId": "Helmet_ears"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b80",
+            "_tpl": "6571199565daf6aa960c9b10",
+            "parentId": "ccccfde8dbcaec0cdaecbe47",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b81",
+            "_tpl": "657119d49eb8c145180dbb95",
+            "parentId": "ccccfde8dbcaec0cdaecbe47",
+            "slotId": "Helmet_back"
+        }, {
+            "_id": "666fad3005a4eac710002b82",
+            "_tpl": "657119fea330b8c9060f7afc",
+            "parentId": "ccccfde8dbcaec0cdaecbe47",
+            "slotId": "Helmet_ears"
+        }, {
             "_id": "1cce5068f5ddbcaadac3ee4d",
             "_tpl": "5645bc214bdc2d363b8b4571",
             "parentId": "hideout",
@@ -3745,26 +3312,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b83",
-          "_tpl": "657bae18b7e9ca9a02045c0a",
-          "parentId": "1cce5068f5ddbcaadac3ee4d",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b84",
-          "_tpl": "657baeaacfcf63c951052db3",
-          "parentId": "1cce5068f5ddbcaadac3ee4d",
-          "slotId": "Helmet_back"
-        },
-        {
-          "_id": "666fad3005a4eac710002b85",
-          "_tpl": "657baecbc6f689d3a205b863",
-          "parentId": "1cce5068f5ddbcaadac3ee4d",
-          "slotId": "Helmet_ears"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b83",
+            "_tpl": "657bae18b7e9ca9a02045c0a",
+            "parentId": "1cce5068f5ddbcaadac3ee4d",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b84",
+            "_tpl": "657baeaacfcf63c951052db3",
+            "parentId": "1cce5068f5ddbcaadac3ee4d",
+            "slotId": "Helmet_back"
+        }, {
+            "_id": "666fad3005a4eac710002b85",
+            "_tpl": "657baecbc6f689d3a205b863",
+            "parentId": "1cce5068f5ddbcaadac3ee4d",
+            "slotId": "Helmet_ears"
+        }, {
             "_id": "89ff7373b1fb0ec4c705db2d",
             "_tpl": "5b46238386f7741a693bcf9c",
             "parentId": "hideout",
@@ -3775,8 +3338,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c96f3e5d2360105f8bebcc9d",
             "_tpl": "5b432d215acfc4771e1c6624",
             "parentId": "hideout",
@@ -3787,20 +3349,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b86",
-          "_tpl": "657bb92fa1c61ee0c303631f",
-          "parentId": "c96f3e5d2360105f8bebcc9d",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b87",
-          "_tpl": "657bb99db30eca976305117f",
-          "parentId": "c96f3e5d2360105f8bebcc9d",
-          "slotId": "Helmet_back"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b86",
+            "_tpl": "657bb92fa1c61ee0c303631f",
+            "parentId": "c96f3e5d2360105f8bebcc9d",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b87",
+            "_tpl": "657bb99db30eca976305117f",
+            "parentId": "c96f3e5d2360105f8bebcc9d",
+            "slotId": "Helmet_back"
+        }, {
             "_id": "735805162eaad4267bf6edfa",
             "_tpl": "5a16badafcdbcb001865f72d",
             "parentId": "hideout",
@@ -3811,8 +3370,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "0fbee497ded7aa5ead7d3f7a",
             "_tpl": "5a398b75c4a282000a51a266",
             "parentId": "hideout",
@@ -3823,8 +3381,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c03dcd84bec6e0d23dceed92",
             "_tpl": "560d657b4bdc2da74d8b4572",
             "parentId": "hideout",
@@ -3835,8 +3392,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "da9ca8940d4e39ccec53d5e1",
             "_tpl": "56def37dd2720bec348b456a",
             "parentId": "hideout",
@@ -3847,8 +3403,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ddd6a65fdf9f16d83b318daa",
             "_tpl": "5aa7d193e5b5b000171d063f",
             "parentId": "hideout",
@@ -3859,26 +3414,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b88",
-          "_tpl": "657bb70486c7f9ef7a009936",
-          "parentId": "ddd6a65fdf9f16d83b318daa",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b89",
-          "_tpl": "657bb79ba1c61ee0c303631a",
-          "parentId": "ddd6a65fdf9f16d83b318daa",
-          "slotId": "Helmet_back"
-        },
-        {
-          "_id": "666fad3005a4eac710002b8a",
-          "_tpl": "657bb7d7b30eca9763051176",
-          "parentId": "ddd6a65fdf9f16d83b318daa",
-          "slotId": "Helmet_ears"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b88",
+            "_tpl": "657bb70486c7f9ef7a009936",
+            "parentId": "ddd6a65fdf9f16d83b318daa",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b89",
+            "_tpl": "657bb79ba1c61ee0c303631a",
+            "parentId": "ddd6a65fdf9f16d83b318daa",
+            "slotId": "Helmet_back"
+        }, {
+            "_id": "666fad3005a4eac710002b8a",
+            "_tpl": "657bb7d7b30eca9763051176",
+            "parentId": "ddd6a65fdf9f16d83b318daa",
+            "slotId": "Helmet_ears"
+        }, {
             "_id": "f334efa7eed9b05fa4c5f0be",
             "_tpl": "5aa7d03ae5b5b00016327db5",
             "parentId": "hideout",
@@ -3889,26 +3440,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b8b",
-          "_tpl": "654a90aff4f81a421b0a7c86",
-          "parentId": "f334efa7eed9b05fa4c5f0be",
-          "slotId": "helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b8c",
-          "_tpl": "654a91068e1ce698150fd1e2",
-          "parentId": "f334efa7eed9b05fa4c5f0be",
-          "slotId": "helmet_back"
-        },
-        {
-          "_id": "666fad3005a4eac710002b8d",
-          "_tpl": "654a9189bcc67a392b056c79",
-          "parentId": "f334efa7eed9b05fa4c5f0be",
-          "slotId": "helmet_ears"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b8b",
+            "_tpl": "654a90aff4f81a421b0a7c86",
+            "parentId": "f334efa7eed9b05fa4c5f0be",
+            "slotId": "helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b8c",
+            "_tpl": "654a91068e1ce698150fd1e2",
+            "parentId": "f334efa7eed9b05fa4c5f0be",
+            "slotId": "helmet_back"
+        }, {
+            "_id": "666fad3005a4eac710002b8d",
+            "_tpl": "654a9189bcc67a392b056c79",
+            "parentId": "f334efa7eed9b05fa4c5f0be",
+            "slotId": "helmet_ears"
+        }, {
             "_id": "f1af81dc1dff3ea1b5ac6e4e",
             "_tpl": "5a7c4850e899ef00150be885",
             "parentId": "hideout",
@@ -3919,26 +3466,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b8e",
-          "_tpl": "657baaf0b7e9ca9a02045c02",
-          "parentId": "f1af81dc1dff3ea1b5ac6e4e",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b8f",
-          "_tpl": "657bab6ec6f689d3a205b85f",
-          "parentId": "f1af81dc1dff3ea1b5ac6e4e",
-          "slotId": "Helmet_back"
-        },
-        {
-          "_id": "666fad3005a4eac710002b90",
-          "_tpl": "657babc6f58ba5a6250107a2",
-          "parentId": "f1af81dc1dff3ea1b5ac6e4e",
-          "slotId": "Helmet_ears"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b8e",
+            "_tpl": "657baaf0b7e9ca9a02045c02",
+            "parentId": "f1af81dc1dff3ea1b5ac6e4e",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b8f",
+            "_tpl": "657bab6ec6f689d3a205b85f",
+            "parentId": "f1af81dc1dff3ea1b5ac6e4e",
+            "slotId": "Helmet_back"
+        }, {
+            "_id": "666fad3005a4eac710002b90",
+            "_tpl": "657babc6f58ba5a6250107a2",
+            "parentId": "f1af81dc1dff3ea1b5ac6e4e",
+            "slotId": "Helmet_ears"
+        }, {
             "_id": "fd942eafa8b2f18a42cc56d3",
             "_tpl": "5c11046cd174af02a012e42b",
             "parentId": "hideout",
@@ -3949,8 +3492,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "df41faf3dec812bb69aece6d",
             "_tpl": "61bca7cda0eae612383adf57",
             "parentId": "hideout",
@@ -3961,20 +3503,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b91",
-          "_tpl": "657bbcc9a1c61ee0c3036327",
-          "parentId": "df41faf3dec812bb69aece6d",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b92",
-          "_tpl": "657bbcffbbd440df880b2dd5",
-          "parentId": "df41faf3dec812bb69aece6d",
-          "slotId": "Helmet_back"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b91",
+            "_tpl": "657bbcc9a1c61ee0c3036327",
+            "parentId": "df41faf3dec812bb69aece6d",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b92",
+            "_tpl": "657bbcffbbd440df880b2dd5",
+            "parentId": "df41faf3dec812bb69aece6d",
+            "slotId": "Helmet_back"
+        }, {
             "_id": "df6bde5f07ac961aa9da4b8b",
             "_tpl": "5b4329f05acfc47a86086aa1",
             "parentId": "hideout",
@@ -3985,38 +3524,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b93",
-          "_tpl": "65711b07a330b8c9060f7b01",
-          "parentId": "df6bde5f07ac961aa9da4b8b",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b94",
-          "_tpl": "65711b489eb8c145180dbb9d",
-          "parentId": "df6bde5f07ac961aa9da4b8b",
-          "slotId": "Helmet_back"
-        },
-        {
-          "_id": "666fad3005a4eac710002b95",
-          "_tpl": "65711b9b65daf6aa960c9b1b",
-          "parentId": "df6bde5f07ac961aa9da4b8b",
-          "slotId": "helmet_eyes"
-        },
-        {
-          "_id": "666fad3005a4eac710002b96",
-          "_tpl": "65711bc79eb8c145180dbba1",
-          "parentId": "df6bde5f07ac961aa9da4b8b",
-          "slotId": "helmet_jaw"
-        },
-        {
-          "_id": "666fad3005a4eac710002b97",
-          "_tpl": "65711b706d197c216005b31c",
-          "parentId": "df6bde5f07ac961aa9da4b8b",
-          "slotId": "Helmet_ears"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b93",
+            "_tpl": "65711b07a330b8c9060f7b01",
+            "parentId": "df6bde5f07ac961aa9da4b8b",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b94",
+            "_tpl": "65711b489eb8c145180dbb9d",
+            "parentId": "df6bde5f07ac961aa9da4b8b",
+            "slotId": "Helmet_back"
+        }, {
+            "_id": "666fad3005a4eac710002b95",
+            "_tpl": "65711b9b65daf6aa960c9b1b",
+            "parentId": "df6bde5f07ac961aa9da4b8b",
+            "slotId": "helmet_eyes"
+        }, {
+            "_id": "666fad3005a4eac710002b96",
+            "_tpl": "65711bc79eb8c145180dbba1",
+            "parentId": "df6bde5f07ac961aa9da4b8b",
+            "slotId": "helmet_jaw"
+        }, {
+            "_id": "666fad3005a4eac710002b97",
+            "_tpl": "65711b706d197c216005b31c",
+            "parentId": "df6bde5f07ac961aa9da4b8b",
+            "slotId": "Helmet_ears"
+        }, {
             "_id": "fdfc68e5aecfe2d355e05df4",
             "_tpl": "5aa7e4a4e5b5b000137b76f2",
             "parentId": "hideout",
@@ -4027,26 +3560,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b98",
-          "_tpl": "657f925dada5fadd1f07a57a",
-          "parentId": "fdfc68e5aecfe2d355e05df4",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b99",
-          "_tpl": "657f92acada5fadd1f07a57e",
-          "parentId": "fdfc68e5aecfe2d355e05df4",
-          "slotId": "Helmet_back"
-        },
-        {
-          "_id": "666fad3005a4eac710002b9a",
-          "_tpl": "657f92e7f4c82973640b2354",
-          "parentId": "fdfc68e5aecfe2d355e05df4",
-          "slotId": "Helmet_ears"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b98",
+            "_tpl": "657f925dada5fadd1f07a57a",
+            "parentId": "fdfc68e5aecfe2d355e05df4",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b99",
+            "_tpl": "657f92acada5fadd1f07a57e",
+            "parentId": "fdfc68e5aecfe2d355e05df4",
+            "slotId": "Helmet_back"
+        }, {
+            "_id": "666fad3005a4eac710002b9a",
+            "_tpl": "657f92e7f4c82973640b2354",
+            "parentId": "fdfc68e5aecfe2d355e05df4",
+            "slotId": "Helmet_ears"
+        }, {
             "_id": "7fd3bed1c9fcf118b00cbbea",
             "_tpl": "5aa7e3abe5b5b000171d064d",
             "parentId": "hideout",
@@ -4057,8 +3586,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "8bcc62f3374c3a29696f40e8",
             "_tpl": "5d5e7d28a4b936645d161203",
             "parentId": "hideout",
@@ -4069,20 +3597,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b9b",
-          "_tpl": "657f8a8d7db258e5600fe33d",
-          "parentId": "8bcc62f3374c3a29696f40e8",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b9c",
-          "_tpl": "657f8b05f4c82973640b2348",
-          "parentId": "8bcc62f3374c3a29696f40e8",
-          "slotId": "Helmet_back"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b9b",
+            "_tpl": "657f8a8d7db258e5600fe33d",
+            "parentId": "8bcc62f3374c3a29696f40e8",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b9c",
+            "_tpl": "657f8b05f4c82973640b2348",
+            "parentId": "8bcc62f3374c3a29696f40e8",
+            "slotId": "Helmet_back"
+        }, {
             "_id": "19311f9cdd8b19dc4af8de71",
             "_tpl": "5c0e66e2d174af02a96252f4",
             "parentId": "hideout",
@@ -4093,8 +3618,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a4fd56c04d6f0c1f0c8e1ebc",
             "_tpl": "5c0695860db834001b735461",
             "parentId": "hideout",
@@ -4105,8 +3629,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b15a46448abeb15a8066e1e4",
             "_tpl": "5c0696830db834001d23f5da",
             "parentId": "hideout",
@@ -4117,8 +3640,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "133526a998c8ba1c22c5e8f8",
             "_tpl": "5d5e9c74a4b9364855191c40",
             "parentId": "hideout",
@@ -4129,20 +3651,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002b9d",
-          "_tpl": "657f8b94f92cd718b70154ff",
-          "parentId": "133526a998c8ba1c22c5e8f8",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002b9e",
-          "_tpl": "657f8b43f92cd718b70154fb",
-          "parentId": "133526a998c8ba1c22c5e8f8",
-          "slotId": "Helmet_back"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002b9d",
+            "_tpl": "657f8b94f92cd718b70154ff",
+            "parentId": "133526a998c8ba1c22c5e8f8",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002b9e",
+            "_tpl": "657f8b43f92cd718b70154fb",
+            "parentId": "133526a998c8ba1c22c5e8f8",
+            "slotId": "Helmet_back"
+        }, {
             "_id": "e0efb555332fde2bdeb1bc7a",
             "_tpl": "5c110624d174af029e69734c",
             "parentId": "hideout",
@@ -4153,8 +3672,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "8f538ebbd5a3ddf1d3b47d62",
             "_tpl": "5b40e3f35acfc40016388218",
             "parentId": "hideout",
@@ -4165,20 +3683,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002bc0",
-          "_tpl": "657f95bff92cd718b701550c",
-          "parentId": "8f538ebbd5a3ddf1d3b47d62",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002bc1",
-          "_tpl": "657f9605f4c82973640b2358",
-          "parentId": "8f538ebbd5a3ddf1d3b47d62",
-          "slotId": "Helmet_back"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002bc0",
+            "_tpl": "657f95bff92cd718b701550c",
+            "parentId": "8f538ebbd5a3ddf1d3b47d62",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002bc1",
+            "_tpl": "657f9605f4c82973640b2358",
+            "parentId": "8f538ebbd5a3ddf1d3b47d62",
+            "slotId": "Helmet_back"
+        }, {
             "_id": "64156ef7a70e700a91fa1b8a",
             "_tpl": "5e4bfc1586f774264f7582d3",
             "parentId": "hideout",
@@ -4189,20 +3704,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002ba2",
-          "_tpl": "657f9c78ada5fadd1f07a58d",
-          "parentId": "64156ef7a70e700a91fa1b8a",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002ba3",
-          "_tpl": "657f9cb587e11c61f70bfaca",
-          "parentId": "64156ef7a70e700a91fa1b8a",
-          "slotId": "Helmet_back"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002ba2",
+            "_tpl": "657f9c78ada5fadd1f07a58d",
+            "parentId": "64156ef7a70e700a91fa1b8a",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002ba3",
+            "_tpl": "657f9cb587e11c61f70bfaca",
+            "parentId": "64156ef7a70e700a91fa1b8a",
+            "slotId": "Helmet_back"
+        }, {
             "_id": "6afcbe2a67c6fb9e424da5de",
             "_tpl": "5a16b7e1fcdbcb00165aa6c9",
             "parentId": "hideout",
@@ -4213,8 +3725,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bfd8de56d5a8ccc0bb708520",
             "_tpl": "5c0558060db834001b735271",
             "parentId": "hideout",
@@ -4225,8 +3736,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a7fa1a09e49cf4d42dbc4d7c",
             "_tpl": "5c066ef40db834001966a595",
             "parentId": "hideout",
@@ -4237,8 +3747,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "5d9d636c1faa4c42df6d97d5",
             "_tpl": "5c066e3a0db834001b7353f0",
             "parentId": "hideout",
@@ -4249,8 +3758,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "86add03867ecbb5adc6ad520",
             "_tpl": "5d6d3716a4b9361bc8618872",
             "parentId": "hideout",
@@ -4261,26 +3769,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002ba4",
-          "_tpl": "657fa009d4caf976440afe3a",
-          "parentId": "86add03867ecbb5adc6ad520",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002ba5",
-          "_tpl": "657fa04ac6679fefb3051e24",
-          "parentId": "86add03867ecbb5adc6ad520",
-          "slotId": "Helmet_back"
-        },
-        {
-          "_id": "666fad3005a4eac710002ba6",
-          "_tpl": "657fa07387e11c61f70bface",
-          "parentId": "86add03867ecbb5adc6ad520",
-          "slotId": "Helmet_ears"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002ba4",
+            "_tpl": "657fa009d4caf976440afe3a",
+            "parentId": "86add03867ecbb5adc6ad520",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002ba5",
+            "_tpl": "657fa04ac6679fefb3051e24",
+            "parentId": "86add03867ecbb5adc6ad520",
+            "slotId": "Helmet_back"
+        }, {
+            "_id": "666fad3005a4eac710002ba6",
+            "_tpl": "657fa07387e11c61f70bface",
+            "parentId": "86add03867ecbb5adc6ad520",
+            "slotId": "Helmet_ears"
+        }, {
             "_id": "f556c7af8ac720eb0e21d3e0",
             "_tpl": "5d6d3943a4b9360dbc46d0cc",
             "parentId": "hideout",
@@ -4291,8 +3795,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "358832f6bcdb70ab7c84bb91",
             "_tpl": "5d6d3be5a4b9361bc73bc763",
             "parentId": "hideout",
@@ -4303,8 +3806,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f1dcaf138aba4de379da1efe",
             "_tpl": "5d6d3829a4b9361bc8618943",
             "parentId": "hideout",
@@ -4315,8 +3817,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ecde82bb1f509f9bb9dabd38",
             "_tpl": "5c091a4e0db834001d5addc8",
             "parentId": "hideout",
@@ -4327,26 +3828,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002ba7",
-          "_tpl": "6571133d22996eaf11088200",
-          "parentId": "ecde82bb1f509f9bb9dabd38",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002ba8",
-          "_tpl": "6571138e818110db4600aa71",
-          "parentId": "ecde82bb1f509f9bb9dabd38",
-          "slotId": "Helmet_back"
-        },
-        {
-          "_id": "666fad3005a4eac710002ba9",
-          "_tpl": "657112fa818110db4600aa6b",
-          "parentId": "ecde82bb1f509f9bb9dabd38",
-          "slotId": "Helmet_ears"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002ba7",
+            "_tpl": "6571133d22996eaf11088200",
+            "parentId": "ecde82bb1f509f9bb9dabd38",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002ba8",
+            "_tpl": "6571138e818110db4600aa71",
+            "parentId": "ecde82bb1f509f9bb9dabd38",
+            "slotId": "Helmet_back"
+        }, {
+            "_id": "666fad3005a4eac710002ba9",
+            "_tpl": "657112fa818110db4600aa6b",
+            "parentId": "ecde82bb1f509f9bb9dabd38",
+            "slotId": "Helmet_ears"
+        }, {
             "_id": "db3939bbe8bd0b4b678d7aed",
             "_tpl": "5c0919b50db834001b7ce3b9",
             "parentId": "hideout",
@@ -4357,8 +3854,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a455ef9e2c766cc4eadce8b6",
             "_tpl": "5ea17ca01412a1425304d1c0",
             "parentId": "hideout",
@@ -4369,20 +3865,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002baa",
-          "_tpl": "657f9a55c6679fefb3051e19",
-          "parentId": "a455ef9e2c766cc4eadce8b6",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002bab",
-          "_tpl": "657f9a94ada5fadd1f07a589",
-          "parentId": "a455ef9e2c766cc4eadce8b6",
-          "slotId": "Helmet_back"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002baa",
+            "_tpl": "657f9a55c6679fefb3051e19",
+            "parentId": "a455ef9e2c766cc4eadce8b6",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002bab",
+            "_tpl": "657f9a94ada5fadd1f07a589",
+            "parentId": "a455ef9e2c766cc4eadce8b6",
+            "slotId": "Helmet_back"
+        }, {
             "_id": "ede0c041f1745b50d6aeee8c",
             "_tpl": "5ea18c84ecf1982c7712d9a2",
             "parentId": "hideout",
@@ -4393,8 +3886,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fbeaec0f91c1204fac95e7a0",
             "_tpl": "5b40e1525acfc4771e1c6611",
             "parentId": "hideout",
@@ -4405,26 +3897,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002bac",
-          "_tpl": "657112234269e9a568089eac",
-          "parentId": "fbeaec0f91c1204fac95e7a0",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002bad",
-          "_tpl": "657112a4818110db4600aa66",
-          "parentId": "fbeaec0f91c1204fac95e7a0",
-          "slotId": "Helmet_back"
-        },
-        {
-          "_id": "666fad3005a4eac710002bae",
-          "_tpl": "657112ce22996eaf110881fb",
-          "parentId": "fbeaec0f91c1204fac95e7a0",
-          "slotId": "Helmet_ears"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002bac",
+            "_tpl": "657112234269e9a568089eac",
+            "parentId": "fbeaec0f91c1204fac95e7a0",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002bad",
+            "_tpl": "657112a4818110db4600aa66",
+            "parentId": "fbeaec0f91c1204fac95e7a0",
+            "slotId": "Helmet_back"
+        }, {
+            "_id": "666fad3005a4eac710002bae",
+            "_tpl": "657112ce22996eaf110881fb",
+            "parentId": "fbeaec0f91c1204fac95e7a0",
+            "slotId": "Helmet_ears"
+        }, {
             "_id": "055f0b1adae017b34e200261",
             "_tpl": "5f60b34a41e30a4ab12a6947",
             "parentId": "hideout",
@@ -4435,20 +3923,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002baf",
-          "_tpl": "657bbad7a1c61ee0c3036323",
-          "parentId": "055f0b1adae017b34e200261",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002bb0",
-          "_tpl": "657bbb31b30eca9763051183",
-          "parentId": "055f0b1adae017b34e200261",
-          "slotId": "Helmet_back"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002baf",
+            "_tpl": "657bbad7a1c61ee0c3036323",
+            "parentId": "055f0b1adae017b34e200261",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002bb0",
+            "_tpl": "657bbb31b30eca9763051183",
+            "parentId": "055f0b1adae017b34e200261",
+            "slotId": "Helmet_back"
+        }, {
             "_id": "0f60b93c29a52aaa6d1aadb2",
             "_tpl": "5f60c076f2bcbb675b00dac2",
             "parentId": "hideout",
@@ -4459,8 +3944,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "54d28a12e773aeef1a0ebd4a",
             "_tpl": "5f60b85bbdb8e27dee3dc985",
             "parentId": "hideout",
@@ -4471,8 +3955,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fdd72a909dc6bb25a43a27b2",
             "_tpl": "5f60bf4558eff926626a60f2",
             "parentId": "hideout",
@@ -4483,8 +3966,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f47e63136d9e2e21d9b9bdfc",
             "_tpl": "5a154d5cfcdbcb001a3b00da",
             "parentId": "hideout",
@@ -4495,20 +3977,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002bb1",
-          "_tpl": "657f8ec5f4c82973640b234c",
-          "parentId": "f47e63136d9e2e21d9b9bdfc",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002bb2",
-          "_tpl": "657f8f10f4c82973640b2350",
-          "parentId": "f47e63136d9e2e21d9b9bdfc",
-          "slotId": "Helmet_back"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002bb1",
+            "_tpl": "657f8ec5f4c82973640b234c",
+            "parentId": "f47e63136d9e2e21d9b9bdfc",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002bb2",
+            "_tpl": "657f8f10f4c82973640b2350",
+            "parentId": "f47e63136d9e2e21d9b9bdfc",
+            "slotId": "Helmet_back"
+        }, {
             "_id": "8bf71225f5321d4a20ab6e0c",
             "_tpl": "5a16ba61fcdbcb098008728a",
             "parentId": "hideout",
@@ -4519,8 +3998,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a4067e1a0ccad3e45acf0f1b",
             "_tpl": "5ea058e01dbce517f324b3e2",
             "parentId": "hideout",
@@ -4531,8 +4009,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f0afb4c0c05bfd31ce85e0ea",
             "_tpl": "5c17a7ed2e2216152142459c",
             "parentId": "hideout",
@@ -4543,20 +4020,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002bb3",
-          "_tpl": "657f9897f4c82973640b235e",
-          "parentId": "f0afb4c0c05bfd31ce85e0ea",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002bb4",
-          "_tpl": "657f98fbada5fadd1f07a585",
-          "parentId": "f0afb4c0c05bfd31ce85e0ea",
-          "slotId": "Helmet_back"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002bb3",
+            "_tpl": "657f9897f4c82973640b235e",
+            "parentId": "f0afb4c0c05bfd31ce85e0ea",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002bb4",
+            "_tpl": "657f98fbada5fadd1f07a585",
+            "parentId": "f0afb4c0c05bfd31ce85e0ea",
+            "slotId": "Helmet_back"
+        }, {
             "_id": "4c185bc28fa79ef071e7a73c",
             "_tpl": "5c178a942e22164bef5ceca3",
             "parentId": "hideout",
@@ -4567,8 +4041,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "3cee7d223e197b0dad7adbb3",
             "_tpl": "5c1793902e221602b21d3de2",
             "parentId": "hideout",
@@ -4579,8 +4052,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "68bbbdaee53cad9c6a01d0ac",
             "_tpl": "5aa7e276e5b5b000171d0647",
             "parentId": "hideout",
@@ -4591,26 +4063,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002bb5",
-          "_tpl": "657bc06daab96fccee08be9b",
-          "parentId": "68bbbdaee53cad9c6a01d0ac",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002bb6",
-          "_tpl": "657bc0d8a1c61ee0c303632f",
-          "parentId": "68bbbdaee53cad9c6a01d0ac",
-          "slotId": "Helmet_back"
-        },
-        {
-          "_id": "666fad3005a4eac710002bb7",
-          "_tpl": "657bc107aab96fccee08be9f",
-          "parentId": "68bbbdaee53cad9c6a01d0ac",
-          "slotId": "Helmet_ears"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002bb5",
+            "_tpl": "657bc06daab96fccee08be9b",
+            "parentId": "68bbbdaee53cad9c6a01d0ac",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002bb6",
+            "_tpl": "657bc0d8a1c61ee0c303632f",
+            "parentId": "68bbbdaee53cad9c6a01d0ac",
+            "slotId": "Helmet_back"
+        }, {
+            "_id": "666fad3005a4eac710002bb7",
+            "_tpl": "657bc107aab96fccee08be9f",
+            "parentId": "68bbbdaee53cad9c6a01d0ac",
+            "slotId": "Helmet_ears"
+        }, {
             "_id": "886d1e5ad9842e5bc40e1143",
             "_tpl": "5aa7e373e5b5b000137b76f0",
             "parentId": "hideout",
@@ -4621,8 +4089,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "706bbc2e7e6f0aa5cbb739d6",
             "_tpl": "5f60c74e3b85f6263c145586",
             "parentId": "hideout",
@@ -4633,26 +4100,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002bb8",
-          "_tpl": "657bc285aab96fccee08bea3",
-          "parentId": "706bbc2e7e6f0aa5cbb739d6",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002bb9",
-          "_tpl": "657bc2c5a1c61ee0c3036333",
-          "parentId": "706bbc2e7e6f0aa5cbb739d6",
-          "slotId": "Helmet_back"
-        },
-        {
-          "_id": "666fad3005a4eac710002bba",
-          "_tpl": "657bc2e7b30eca976305118d",
-          "parentId": "706bbc2e7e6f0aa5cbb739d6",
-          "slotId": "Helmet_ears"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002bb8",
+            "_tpl": "657bc285aab96fccee08bea3",
+            "parentId": "706bbc2e7e6f0aa5cbb739d6",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002bb9",
+            "_tpl": "657bc2c5a1c61ee0c3036333",
+            "parentId": "706bbc2e7e6f0aa5cbb739d6",
+            "slotId": "Helmet_back"
+        }, {
+            "_id": "666fad3005a4eac710002bba",
+            "_tpl": "657bc2e7b30eca976305118d",
+            "parentId": "706bbc2e7e6f0aa5cbb739d6",
+            "slotId": "Helmet_ears"
+        }, {
             "_id": "b9cc2b686082dd7875d7eef4",
             "_tpl": "5f60c85b58eff926626a60f7",
             "parentId": "hideout",
@@ -4663,8 +4126,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "6a28a2a53e78d37ea166e2e3",
             "_tpl": "5e00c1ad86f774747333222c",
             "parentId": "hideout",
@@ -4675,20 +4137,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002bbb",
-          "_tpl": "6551fec55d0cf82e51014288",
-          "parentId": "6a28a2a53e78d37ea166e2e3",
-          "slotId": "helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002bbc",
-          "_tpl": "655200ba0ef76cf7be09d528",
-          "parentId": "6a28a2a53e78d37ea166e2e3",
-          "slotId": "helmet_back"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002bbb",
+            "_tpl": "6551fec55d0cf82e51014288",
+            "parentId": "6a28a2a53e78d37ea166e2e3",
+            "slotId": "helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002bbc",
+            "_tpl": "655200ba0ef76cf7be09d528",
+            "parentId": "6a28a2a53e78d37ea166e2e3",
+            "slotId": "helmet_back"
+        }, {
             "_id": "5207bc9fcaf7cf96a7aa1d7f",
             "_tpl": "5e00cdd986f7747473332240",
             "parentId": "hideout",
@@ -4699,8 +4158,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d8d19cb46c2ff2933ba26063",
             "_tpl": "5e01f37686f774773c6f6c15",
             "parentId": "hideout",
@@ -4711,8 +4169,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "eef3c5cda00670a1ef8cbafb",
             "_tpl": "5e00cfa786f77469dc6e5685",
             "parentId": "hideout",
@@ -4723,8 +4180,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "db4dcfca7c812792be3dfdcd",
             "_tpl": "5e01f31d86f77465cf261343",
             "parentId": "hideout",
@@ -4735,8 +4191,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bafb4f2becff3fa1edd0c9df",
             "_tpl": "5ca20ee186f774799474abc2",
             "parentId": "hideout",
@@ -4747,26 +4202,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "666fad3005a4eac710002bbd",
-          "_tpl": "657bbe73a1c61ee0c303632b",
-          "parentId": "bafb4f2becff3fa1edd0c9df",
-          "slotId": "Helmet_top"
-        },
-        {
-          "_id": "666fad3005a4eac710002bbe",
-          "_tpl": "657bbed0aab96fccee08be96",
-          "parentId": "bafb4f2becff3fa1edd0c9df",
-          "slotId": "Helmet_back"
-        },
-        {
-          "_id": "666fad3005a4eac710002bbf",
-          "_tpl": "657bbefeb30eca9763051189",
-          "parentId": "bafb4f2becff3fa1edd0c9df",
-          "slotId": "Helmet_ears"
-        },
-        {
+        }, {
+            "_id": "666fad3005a4eac710002bbd",
+            "_tpl": "657bbe73a1c61ee0c303632b",
+            "parentId": "bafb4f2becff3fa1edd0c9df",
+            "slotId": "Helmet_top"
+        }, {
+            "_id": "666fad3005a4eac710002bbe",
+            "_tpl": "657bbed0aab96fccee08be96",
+            "parentId": "bafb4f2becff3fa1edd0c9df",
+            "slotId": "Helmet_back"
+        }, {
+            "_id": "666fad3005a4eac710002bbf",
+            "_tpl": "657bbefeb30eca9763051189",
+            "parentId": "bafb4f2becff3fa1edd0c9df",
+            "slotId": "Helmet_ears"
+        }, {
             "_id": "d8fe280b7eddf7cdea85fbbc",
             "_tpl": "5ca2113f86f7740b2547e1d2",
             "parentId": "hideout",
@@ -4777,8 +4228,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a00ea4e635aca7242c3ca430",
             "_tpl": "59ef13ca86f77445fd0e2483",
             "parentId": "hideout",
@@ -4789,8 +4239,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "70457fc9d9c8d617a11de7c1",
             "_tpl": "5926bb2186f7744b1c6c6e60",
             "parentId": "hideout",
@@ -4801,50 +4250,42 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "5df600181ebbcecab3dfe32e",
             "_tpl": "5926c3b286f774640d189b6b",
             "parentId": "70457fc9d9c8d617a11de7c1",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "f154cba1fca2af4bef44be36",
             "_tpl": "5926c36d86f77467a92a8629",
             "parentId": "bafb11cbefb08aa23ff8c45f",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "e0526ad2cbbae4e4fbfa6aa1",
             "_tpl": "5926d2be86f774134d668e4e",
             "parentId": "bafb11cbefb08aa23ff8c45f",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "eaadb7b56241f3eaf2a56b7b",
             "_tpl": "5926d3c686f77410de68ebc8",
             "parentId": "bafb11cbefb08aa23ff8c45f",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "8f38227a95c9e4c4a3abe1db",
             "_tpl": "5926e16e86f7742f5a0f7ecb",
             "parentId": "bafb11cbefb08aa23ff8c45f",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "bafb11cbefb08aa23ff8c45f",
             "_tpl": "5926c0df86f77462f647f764",
             "parentId": "70457fc9d9c8d617a11de7c1",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "19f5fcc57c52b6eaa83d9ba6",
             "_tpl": "5926c32286f774616e42de99",
             "parentId": "70457fc9d9c8d617a11de7c1",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "6bea2af7470a11f1c027bffa",
             "_tpl": "59f9cabd86f7743a10721f46",
             "parentId": "hideout",
@@ -4855,56 +4296,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ba1bff1a7158ee3ddcdbde5e",
             "_tpl": "5998517986f7746017232f7e",
             "parentId": "6bea2af7470a11f1c027bffa",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "5bab5bcadceaecfbf6c48f09",
             "_tpl": "599851db86f77467372f0a18",
             "parentId": "6bea2af7470a11f1c027bffa",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "dbebec43ad90bda1dfc6e6ce",
             "_tpl": "5998529a86f774647f44f421",
             "parentId": "6bea2af7470a11f1c027bffa",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "0deff70eeadc0dfd77987cc7",
             "_tpl": "5998598e86f7740b3f498a86",
             "parentId": "6bea2af7470a11f1c027bffa",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "e75481f028b98fcc4251406b",
             "_tpl": "59985a8086f77414ec448d1a",
             "parentId": "6bea2af7470a11f1c027bffa",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "4ebf16fade86fc7b03e01ce1",
             "_tpl": "599860e986f7743bb57573a6",
             "parentId": "6bea2af7470a11f1c027bffa",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "a3cfbef7c9dccea0b2f8c2b6",
             "_tpl": "59ccd11386f77428f24a488f",
             "parentId": "6bea2af7470a11f1c027bffa",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "09b410af5b8cb7e4813b3cff",
             "_tpl": "5648b1504bdc2d9d488b4584",
             "parentId": "a3cfbef7c9dccea0b2f8c2b6",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "f3fdee5c0a803449e2b7ebf2",
             "_tpl": "5ea03f7400685063ec28bfa8",
             "parentId": "hideout",
@@ -4915,32 +4347,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "78c26ec1ec2c7dae9e7cb6a6",
             "_tpl": "5ea03e9400685063ec28bfa4",
             "parentId": "f3fdee5c0a803449e2b7ebf2",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "f06491aa0d9ee1eb0f1bb4fb",
             "_tpl": "5ea034eb5aad6446a939737b",
             "parentId": "f3fdee5c0a803449e2b7ebf2",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "bdac8a2cdb5eb4fbf704eb65",
             "_tpl": "5ea03e5009aa976f2e7a514b",
             "parentId": "f3fdee5c0a803449e2b7ebf2",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "686a2abede0acfa4c145aeb1",
             "_tpl": "5ea02bb600685063ec28bfa1",
             "parentId": "f3fdee5c0a803449e2b7ebf2",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "a42cfec0d481218fafaedfd7",
             "_tpl": "5ea034eb5aad6446a939737b",
             "parentId": "hideout",
@@ -4951,8 +4378,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f430ae634bd13deb5793af3b",
             "_tpl": "5d2f213448f0355009199284",
             "parentId": "hideout",
@@ -4963,8 +4389,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "707d0a9feff99f8bb17ddcdc",
             "_tpl": "5998529a86f774647f44f421",
             "parentId": "hideout",
@@ -4975,8 +4400,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "411cd2a6bbf37e7aa9f7e8c5",
             "_tpl": "57f3c6bd24597738e730fa2f",
             "parentId": "hideout",
@@ -4987,32 +4411,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "48c9fae5f6bd49a7dc8bc91b",
             "_tpl": "57d152ec245977144076ccdf",
             "parentId": "411cd2a6bbf37e7aa9f7e8c5",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "fdec9441ae2aca3a8aa552ae",
             "_tpl": "57f3c7e024597738ea4ba286",
             "parentId": "411cd2a6bbf37e7aa9f7e8c5",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "bd15c5a3a94171a19faae50a",
             "_tpl": "57f3c8cc2459773ec4480328",
             "parentId": "fdec9441ae2aca3a8aa552ae",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "9ab4dbf6a3a7854d2c9b6a3f",
             "_tpl": "57d1519e24597714373db79d",
             "parentId": "411cd2a6bbf37e7aa9f7e8c5",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "9bac87edd4ddfd88cd22c4b7",
             "_tpl": "5de7bd7bfd6b4e6e2276dc25",
             "parentId": "hideout",
@@ -5023,50 +4442,42 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "de38ffc8d8fdcbcd6ca4d7c6",
             "_tpl": "5de8eac42a78646d96665d91",
             "parentId": "9bac87edd4ddfd88cd22c4b7",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "6bea3f41d88c5bd18a79edab",
             "_tpl": "5de910da8b6c4240ba2651b5",
             "parentId": "9bac87edd4ddfd88cd22c4b7",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "de1edeab7c69ba50bec698bb",
             "_tpl": "5de8fbad2fbe23140d3ee9c4",
             "parentId": "9bac87edd4ddfd88cd22c4b7",
             "slotId": "mod_foregrip"
-        },
-        {
+        }, {
             "_id": "1f0dbbd650ea43cba5a996e3",
             "_tpl": "5de8e67c4a9f347bc92edbd7",
             "parentId": "9bac87edd4ddfd88cd22c4b7",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "a84abdd73c46fdf81cea293d",
             "_tpl": "5de8fb539f98ac2bc659513a",
             "parentId": "1f0dbbd650ea43cba5a996e3",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "80fbcb7fb2c1b32c7745aa2a",
             "_tpl": "5de8fc0b205ddc616a6bc51b",
             "parentId": "1f0dbbd650ea43cba5a996e3",
             "slotId": "mod_mount"
-        },
-        {
+        }, {
             "_id": "43bbe47ef46d64178507ed3f",
             "_tpl": "5de922d4b11454561e39239f",
             "parentId": "9bac87edd4ddfd88cd22c4b7",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "fdff4ca46bfc60e6fc1a1deb",
             "_tpl": "59984ab886f7743e98271174",
             "parentId": "hideout",
@@ -5077,56 +4488,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "00d9bc9eea175b5dcda43aeb",
             "_tpl": "5998517986f7746017232f7e",
             "parentId": "fdff4ca46bfc60e6fc1a1deb",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "4e9affec9feadcb204234b1a",
             "_tpl": "599851db86f77467372f0a18",
             "parentId": "fdff4ca46bfc60e6fc1a1deb",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "fb4bf3b4c76bbffb44213f07",
             "_tpl": "599860ac86f77436b225ed1a",
             "parentId": "fdff4ca46bfc60e6fc1a1deb",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "bcecd16c8edf956b5a6c9830",
             "_tpl": "5998597786f77414ea6da093",
             "parentId": "fdff4ca46bfc60e6fc1a1deb",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "28ea7f2db2f58c8aab1a2640",
             "_tpl": "59985a8086f77414ec448d1a",
             "parentId": "fdff4ca46bfc60e6fc1a1deb",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "c60e6c1f80efdd81bd06ffed",
             "_tpl": "599860e986f7743bb57573a6",
             "parentId": "fdff4ca46bfc60e6fc1a1deb",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "20f50ef648df8ed1c91e2e40",
             "_tpl": "5648b1504bdc2d9d488b4584",
             "parentId": "fb9bffac099bdfacf2f68be8",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "fb9bffac099bdfacf2f68be8",
             "_tpl": "59ccd11386f77428f24a488f",
             "parentId": "fdff4ca46bfc60e6fc1a1deb",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "1c5bfbedb7bf2eb8db265d4d",
             "_tpl": "57d14e1724597714010c3f4b",
             "parentId": "hideout",
@@ -5137,8 +4539,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ef9f6ab8edda8baf2add0d4d",
             "_tpl": "5de8e8dafd6b4e6e2276dc32",
             "parentId": "hideout",
@@ -5149,8 +4550,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bbb80f3f7abcc46de99adcdd",
             "_tpl": "5c0673fb0db8340023300271",
             "parentId": "hideout",
@@ -5161,8 +4561,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "21e6a3b3abfab4f1dfcbb9fe",
             "_tpl": "58948c8e86f77409493f7266",
             "parentId": "hideout",
@@ -5173,86 +4572,72 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f6be79e12bcbcfb11b3518cc",
             "_tpl": "5894a51286f77426d13baf02",
             "parentId": "21e6a3b3abfab4f1dfcbb9fe",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "de7afe430d36e3ddf6b7c8f8",
             "_tpl": "5894a05586f774094708ef75",
             "parentId": "21e6a3b3abfab4f1dfcbb9fe",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "170c807f1f9eccbdfdca29bd",
             "_tpl": "58949dea86f77409483e16a8",
             "parentId": "75683bf30a6c5ca0cb6cdbdf",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "75683bf30a6c5ca0cb6cdbdf",
             "_tpl": "5894a2c386f77427140b8342",
             "parentId": "dc45fdbcdd4cbff394ae59ba",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "cc81dbdf7914665cfadf29c0",
             "_tpl": "5894a73486f77426d259076c",
             "parentId": "9bdde251ef961cbdd07b96ea",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "b2fc5fadffb4fdbfecb7af21",
             "_tpl": "58a56f8d86f774651579314c",
             "parentId": "9bdde251ef961cbdd07b96ea",
             "slotId": "mod_mount_000"
-        },
-        {
+        }, {
             "_id": "d8306feeca9dc43bbe9121cc",
             "_tpl": "58a5c12e86f7745d585a2b9e",
             "parentId": "9bdde251ef961cbdd07b96ea",
             "slotId": "mod_mount_001"
-        },
-        {
+        }, {
             "_id": "b6951d1cc712a33d281ff285",
             "_tpl": "58a56f8d86f774651579314c",
             "parentId": "9bdde251ef961cbdd07b96ea",
             "slotId": "mod_mount_002"
-        },
-        {
+        }, {
             "_id": "9bdde251ef961cbdd07b96ea",
             "_tpl": "5894a42086f77426d2590762",
             "parentId": "dc45fdbcdd4cbff394ae59ba",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "12ef7ce1a63c0bcdf6fb8364",
             "_tpl": "5894a81786f77427140b8347",
             "parentId": "dc45fdbcdd4cbff394ae59ba",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "dc45fdbcdd4cbff394ae59ba",
             "_tpl": "5894a5b586f77426d2590767",
             "parentId": "21e6a3b3abfab4f1dfcbb9fe",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "75ed8127b4154e972f87bd97",
             "_tpl": "5894a13e86f7742405482982",
             "parentId": "21e6a3b3abfab4f1dfcbb9fe",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "b10b2cc1bde6d8c59d4d7ae9",
             "_tpl": "58949edd86f77409483e16a9",
             "parentId": "21e6a3b3abfab4f1dfcbb9fe",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "89ef642beb27bdf51ffbb4b7",
             "_tpl": "60339954d62c9b14ed777c06",
             "parentId": "hideout",
@@ -5263,68 +4648,57 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c71d8bd697443c4f5dcefa2d",
             "_tpl": "602e71bd53a60014f9705bfa",
             "parentId": "89ef642beb27bdf51ffbb4b7",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "cd8c4e1aacd93a1eb8636ff6",
             "_tpl": "5a7ad2e851dfba0016153692",
             "parentId": "89ef642beb27bdf51ffbb4b7",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "0ebfc5db6539d39fd26a3d3f",
             "_tpl": "602e63fb6335467b0c5ac94d",
             "parentId": "89ef642beb27bdf51ffbb4b7",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "fa8540f3958bbcfcea1d9e42",
             "_tpl": "603372b4da11d6478d5a07ff",
             "parentId": "0ebfc5db6539d39fd26a3d3f",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "c7ec063e5dcbac335fdd689c",
             "_tpl": "60337f5dce399e10262255d1",
             "parentId": "fa8540f3958bbcfcea1d9e42",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "96083d5d229bacecf6bffbcb",
             "_tpl": "6034e3cb0ddce744014cb870",
             "parentId": "0ebfc5db6539d39fd26a3d3f",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "05c761e782cb7348ac3ce4b3",
             "_tpl": "602e3f1254072b51b239f713",
             "parentId": "89ef642beb27bdf51ffbb4b7",
             "slotId": "mod_stock_001"
-        },
-        {
+        }, {
             "_id": "187b05ae4a554224ad2dea35",
             "_tpl": "602e620f9b513876d4338d9a",
             "parentId": "05c761e782cb7348ac3ce4b3",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "8eec8077b3a6b1241cba6594",
             "_tpl": "6033749e88382f4fab3fd2c5",
             "parentId": "89ef642beb27bdf51ffbb4b7",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "92e6cdc8a79bb3a3c5ed86fd",
             "_tpl": "602f85fd9b513876d4338d9c",
             "parentId": "89ef642beb27bdf51ffbb4b7",
             "slotId": "mod_tactical_000"
-        },
-        {
+        }, {
             "_id": "ee2afb8cfb954d413b1ef95a",
             "_tpl": "5fc3e272f8b6a877a729eac5",
             "parentId": "hideout",
@@ -5335,44 +4709,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "aa78dbbcf9f3ce6f20a11bce",
             "_tpl": "5fc3e466187fea44d52eda90",
             "parentId": "ee2afb8cfb954d413b1ef95a",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "ea841184c4129a74daa89abe",
             "_tpl": "5fc3e4ee7283c4046c5814af",
             "parentId": "ee2afb8cfb954d413b1ef95a",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "d8618cb2f7a9d43c2c7e3bfe",
             "_tpl": "5fc3e4a27283c4046c5814ab",
             "parentId": "ee2afb8cfb954d413b1ef95a",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "7688380bc9ceee1fc8fbc7fa",
             "_tpl": "5fc53954f8b6a877a729eaeb",
             "parentId": "ee2afb8cfb954d413b1ef95a",
             "slotId": "mod_mount_000"
-        },
-        {
+        }, {
             "_id": "da31567aa8638b85b059aade",
             "_tpl": "5fc5396e900b1d5091531e72",
             "parentId": "ee2afb8cfb954d413b1ef95a",
             "slotId": "mod_mount_001"
-        },
-        {
+        }, {
             "_id": "47a05fc67aceffdb8af96c78",
             "_tpl": "5fc5396e900b1d5091531e72",
             "parentId": "ee2afb8cfb954d413b1ef95a",
             "slotId": "mod_mount_002"
-        },
-        {
+        }, {
             "_id": "3b599e4fa7eea0fd56c690c9",
             "_tpl": "5fb64bc92b1b027b1f50bcf2",
             "parentId": "hideout",
@@ -5383,62 +4750,52 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "beceee647becaa3a2aebaecf",
             "_tpl": "5fb651b52b1b027b1f50bcff",
             "parentId": "3b599e4fa7eea0fd56c690c9",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "4adeed6e51bf54c1d6e9f16f",
             "_tpl": "5fb6567747ce63734e3fa1dc",
             "parentId": "3b599e4fa7eea0fd56c690c9",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "2ca2c810dc9c316c3f176e30",
             "_tpl": "5fb6564947ce63734e3fa1da",
             "parentId": "3b599e4fa7eea0fd56c690c9",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "77edbb95fe607be10aba7781",
             "_tpl": "5fb6558ad6f0b2136f2d7eb7",
             "parentId": "3b599e4fa7eea0fd56c690c9",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "2dae6413cefca795faf6eb23",
             "_tpl": "5fb65363d1409e5ca04b54f5",
             "parentId": "3b599e4fa7eea0fd56c690c9",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "164cdaf42d3bdaafda15edb1",
             "_tpl": "5fb6548dd1409e5ca04b54f9",
             "parentId": "2dae6413cefca795faf6eb23",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "244ab203c94d57eb6e7fccb3",
             "_tpl": "5fbb976df9986c4cff3fe5f2",
             "parentId": "3b599e4fa7eea0fd56c690c9",
             "slotId": "mod_mount"
-        },
-        {
+        }, {
             "_id": "e1e53e1a07c6f79bd42b3e21",
             "_tpl": "5fce0f9b55375d18a253eff2",
             "parentId": "3b599e4fa7eea0fd56c690c9",
             "slotId": "mod_mount_001"
-        },
-        {
+        }, {
             "_id": "285305ebac95ca97da804cb5",
             "_tpl": "5fce0f9b55375d18a253eff2",
             "parentId": "3b599e4fa7eea0fd56c690c9",
             "slotId": "mod_mount_002"
-        },
-        {
+        }, {
             "_id": "ac30fc6c8b0fe5c833bf4fd6",
             "_tpl": "5fc3e466187fea44d52eda90",
             "parentId": "hideout",
@@ -5449,8 +4806,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bba2edf2e3af5aa89cfc0cfe",
             "_tpl": "5fb651b52b1b027b1f50bcff",
             "parentId": "hideout",
@@ -5461,8 +4817,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "4c8894693818128cfbde5e7a",
             "_tpl": "5a718da68dc32e000d46d264",
             "parentId": "hideout",
@@ -5473,8 +4828,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ef19a9e9fcef6fcaabc3e3c5",
             "_tpl": "5c5db6552e2216001026119d",
             "parentId": "hideout",
@@ -5485,8 +4839,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "cab3bd2bbcbc04261bcdb2e5",
             "_tpl": "5fc3f2d5900b1d5091531e57",
             "parentId": "hideout",
@@ -5497,62 +4850,52 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "49dff6a3fda95ddca2fbf78b",
             "_tpl": "5a718b548dc32e000d46d262",
             "parentId": "cab3bd2bbcbc04261bcdb2e5",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "7bfb0de03fad5d0fbe0f2de9",
             "_tpl": "5fb6567747ce63734e3fa1dc",
             "parentId": "cab3bd2bbcbc04261bcdb2e5",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "faaab85f361fdf9cde05ea2b",
             "_tpl": "5fb6564947ce63734e3fa1da",
             "parentId": "cab3bd2bbcbc04261bcdb2e5",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "350ab29babbfeda8ecffff9d",
             "_tpl": "5fb6558ad6f0b2136f2d7eb7",
             "parentId": "cab3bd2bbcbc04261bcdb2e5",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "3aad3e624c6d167cfe95c537",
             "_tpl": "5fbbc366ca32ed67276c1557",
             "parentId": "cab3bd2bbcbc04261bcdb2e5",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "920a8cdf8eb488bfa243da94",
             "_tpl": "5fbbc34106bde7524f03cbe9",
             "parentId": "3aad3e624c6d167cfe95c537",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "6a7bb4d16ddc2f6e475e7b61",
             "_tpl": "5fbb976df9986c4cff3fe5f2",
             "parentId": "cab3bd2bbcbc04261bcdb2e5",
             "slotId": "mod_mount"
-        },
-        {
+        }, {
             "_id": "32abba7ac789bbbb5e1a3c41",
             "_tpl": "5fce0f9b55375d18a253eff2",
             "parentId": "cab3bd2bbcbc04261bcdb2e5",
             "slotId": "mod_mount_001"
-        },
-        {
+        }, {
             "_id": "1ddeebe09e01d3a6fdfea5f3",
             "_tpl": "5fce0f9b55375d18a253eff2",
             "parentId": "cab3bd2bbcbc04261bcdb2e5",
             "slotId": "mod_mount_002"
-        },
-        {
+        }, {
             "_id": "e4389c85c2d0d411e59baba9",
             "_tpl": "5cc82d76e24e8d00134b4b83",
             "parentId": "hideout",
@@ -5563,68 +4906,57 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "848e44fdd8aaafce2dc22ef9",
             "_tpl": "5cc70093e4a949033c734312",
             "parentId": "e4389c85c2d0d411e59baba9",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "4b65d7aaceccdee4616cf6e1",
             "_tpl": "5cc700cae4a949035e43ba72",
             "parentId": "92a523cd61280165fb3035e0",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "92a523cd61280165fb3035e0",
             "_tpl": "5cc700b9e4a949000f0f0f25",
             "parentId": "e4389c85c2d0d411e59baba9",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "35020a6bcabd9e899b5b2af8",
             "_tpl": "5cebec38d7f00c00110a652a",
             "parentId": "b4fe8ec8aee308f56a0ddccf",
             "slotId": "mod_mount_000"
-        },
-        {
+        }, {
             "_id": "efb23774bdb5dccbeaa36e7a",
             "_tpl": "5cc70146e4a949000d73bf6b",
             "parentId": "b4fe8ec8aee308f56a0ddccf",
             "slotId": "mod_mount_001"
-        },
-        {
+        }, {
             "_id": "ef014af521a9c6373acbeace",
             "_tpl": "5cc70146e4a949000d73bf6b",
             "parentId": "b4fe8ec8aee308f56a0ddccf",
             "slotId": "mod_mount_002"
-        },
-        {
+        }, {
             "_id": "b4fe8ec8aee308f56a0ddccf",
             "_tpl": "5cc70102e4a949035e43ba74",
             "parentId": "e4389c85c2d0d411e59baba9",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "8e8b7ece9bc9e2eeae4ec5fa",
             "_tpl": "5cc82796e24e8d000f5859a8",
             "parentId": "c5bdbba61a1a3f57650aeeb0",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "c5bdbba61a1a3f57650aeeb0",
             "_tpl": "5cc701aae4a949000e1ea45c",
             "parentId": "e4389c85c2d0d411e59baba9",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "fca5ac65f0b8a9dd33eecbfd",
             "_tpl": "5cc6ea78e4a949000e1ea3c1",
             "parentId": "e4389c85c2d0d411e59baba9",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "cc4a5f48f7a3a3f164f91fb5",
             "_tpl": "5bd70322209c4d00d7167b8f",
             "parentId": "hideout",
@@ -5635,38 +4967,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bb155bf5b74b4c5c7bd8b790",
             "_tpl": "5ba264f6d4351e0034777d52",
             "parentId": "cc4a5f48f7a3a3f164f91fb5",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "bc99cba2fe088e28ddfffadf",
             "_tpl": "5ba26acdd4351e003562908e",
             "parentId": "cc4a5f48f7a3a3f164f91fb5",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "ceacca86d2fa2a241ee5b7e0",
             "_tpl": "5ba26b01d4351e0085325a51",
             "parentId": "cc4a5f48f7a3a3f164f91fb5",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "82aff9ea691a082b2ef5be94",
             "_tpl": "5ba26b17d4351e00367f9bdd",
             "parentId": "cc4a5f48f7a3a3f164f91fb5",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "fcb7acff15ae9afcb9f7cf8c",
             "_tpl": "5bd704e7209c4d00d7167c31",
             "parentId": "cc4a5f48f7a3a3f164f91fb5",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "9daca13fdf45feffda929ec9",
             "_tpl": "5ba264f6d4351e0034777d52",
             "parentId": "hideout",
@@ -5677,8 +5003,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a5d2b379faf0f2dcdea70b5b",
             "_tpl": "5cc70093e4a949033c734312",
             "parentId": "hideout",
@@ -5689,8 +5014,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "cadfd8d099bf6fbcbe95b33b",
             "_tpl": "5a7ad2e851dfba0016153692",
             "parentId": "hideout",
@@ -5701,8 +5025,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "43bcca99f2e7ceebff948ee1",
             "_tpl": "5926bb2186f7744b1c6c6e60",
             "parentId": "hideout",
@@ -5713,50 +5036,42 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e15eecabe67f2fd62997fa8b",
             "_tpl": "5926c3b286f774640d189b6b",
             "parentId": "43bcca99f2e7ceebff948ee1",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "acbdc3e262e0e973da2eefbc",
             "_tpl": "5926c36d86f77467a92a8629",
             "parentId": "81edb31aa64a6d7d88e98bc1",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "09ca05b5cb1fe6be06533ab1",
             "_tpl": "5926d2be86f774134d668e4e",
             "parentId": "81edb31aa64a6d7d88e98bc1",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "dbdb1e749ba92a8a4709b32f",
             "_tpl": "5926d3c686f77410de68ebc8",
             "parentId": "81edb31aa64a6d7d88e98bc1",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "e3cf9890d37bd3beeefd9eea",
             "_tpl": "5926e16e86f7742f5a0f7ecb",
             "parentId": "81edb31aa64a6d7d88e98bc1",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "81edb31aa64a6d7d88e98bc1",
             "_tpl": "5926c0df86f77462f647f764",
             "parentId": "43bcca99f2e7ceebff948ee1",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "7f1fcb1afe101e76c8c83d64",
             "_tpl": "5926c32286f774616e42de99",
             "parentId": "43bcca99f2e7ceebff948ee1",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "0d4e53f8dde4728245fa4ea7",
             "_tpl": "5d2f0d8048f0356c925bc3b0",
             "parentId": "hideout",
@@ -5767,44 +5082,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "2d76a374b068bb34e51a5b76",
             "_tpl": "5d2f213448f0355009199284",
             "parentId": "0d4e53f8dde4728245fa4ea7",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "a86939e031b01ab1ebeea1cb",
             "_tpl": "5d2f261548f03576f500e7b7",
             "parentId": "0d4e53f8dde4728245fa4ea7",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "9651ad811eee4df8e9c5bbc6",
             "_tpl": "5d2f259b48f0355a844acd74",
             "parentId": "a86939e031b01ab1ebeea1cb",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "a08494ddee500ebab52a50ab",
             "_tpl": "5926d2be86f774134d668e4e",
             "parentId": "a86939e031b01ab1ebeea1cb",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "c1b9bee8cc709bbb4c2cdfc8",
             "_tpl": "5d2f25bc48f03502573e5d85",
             "parentId": "a86939e031b01ab1ebeea1cb",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "76031e5b4f2b04c49fce9806",
             "_tpl": "5d2f2d5748f03572ec0c0139",
             "parentId": "0d4e53f8dde4728245fa4ea7",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "3f4c9d2d18fadcc5aa4d319c",
             "_tpl": "59f9cabd86f7743a10721f46",
             "parentId": "hideout",
@@ -5815,56 +5123,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e5aaad1c9488702f825abb65",
             "_tpl": "5998517986f7746017232f7e",
             "parentId": "3f4c9d2d18fadcc5aa4d319c",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "5e3aa29db39d8cb987aeff6c",
             "_tpl": "599851db86f77467372f0a18",
             "parentId": "3f4c9d2d18fadcc5aa4d319c",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "c6e3db3f4b7c82493cab5108",
             "_tpl": "5998529a86f774647f44f421",
             "parentId": "3f4c9d2d18fadcc5aa4d319c",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "ddd8fb5cdca3a79d0d5add8f",
             "_tpl": "5998598e86f7740b3f498a86",
             "parentId": "3f4c9d2d18fadcc5aa4d319c",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "de9a6c5f14e40ca97dccfa1e",
             "_tpl": "59985a8086f77414ec448d1a",
             "parentId": "3f4c9d2d18fadcc5aa4d319c",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "e9be245cbb59c796cac19acd",
             "_tpl": "599860e986f7743bb57573a6",
             "parentId": "3f4c9d2d18fadcc5aa4d319c",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "2f0baf2e88f163df6d82f967",
             "_tpl": "59ccd11386f77428f24a488f",
             "parentId": "3f4c9d2d18fadcc5aa4d319c",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "b80dbb0c56efe893206f7cd8",
             "_tpl": "5648b1504bdc2d9d488b4584",
             "parentId": "2f0baf2e88f163df6d82f967",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "25afb67abb3fbbce0acaa089",
             "_tpl": "5ea03f7400685063ec28bfa8",
             "parentId": "hideout",
@@ -5875,32 +5174,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "1241ccc7cb389de9cffc9faa",
             "_tpl": "5ea03e9400685063ec28bfa4",
             "parentId": "25afb67abb3fbbce0acaa089",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "e417c2c5b35fafceffe5a9ad",
             "_tpl": "5ea034eb5aad6446a939737b",
             "parentId": "25afb67abb3fbbce0acaa089",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "dd5d8b59b75a234ecb4f936c",
             "_tpl": "5ea03e5009aa976f2e7a514b",
             "parentId": "25afb67abb3fbbce0acaa089",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "e26abea2df7ae3ee7c030796",
             "_tpl": "5ea02bb600685063ec28bfa1",
             "parentId": "25afb67abb3fbbce0acaa089",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "b6aa0aa8dbfd624a530dd9ba",
             "_tpl": "57f3c6bd24597738e730fa2f",
             "parentId": "hideout",
@@ -5911,32 +5205,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "52ce99cedfd8abd3d1a8bd4b",
             "_tpl": "57d152ec245977144076ccdf",
             "parentId": "b6aa0aa8dbfd624a530dd9ba",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "0b78e9e916f90f88fcf3f5e0",
             "_tpl": "57f3c7e024597738ea4ba286",
             "parentId": "b6aa0aa8dbfd624a530dd9ba",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "aeb83d4ad28cda6adda66cbc",
             "_tpl": "57f3c8cc2459773ec4480328",
             "parentId": "0b78e9e916f90f88fcf3f5e0",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "07d94fa87eeac7e1bbdf0ac0",
             "_tpl": "57d1519e24597714373db79d",
             "parentId": "b6aa0aa8dbfd624a530dd9ba",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "1a317ae89abb5bbaf89720cd",
             "_tpl": "57d14d2524597714373db789",
             "parentId": "hideout",
@@ -5947,20 +5236,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "1cd4ebcdd9a4b83d2171ffc5",
             "_tpl": "57d152ec245977144076ccdf",
             "parentId": "1a317ae89abb5bbaf89720cd",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "109fdd49b67375de1e7b0d01",
             "_tpl": "57d1519e24597714373db79d",
             "parentId": "1a317ae89abb5bbaf89720cd",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "5a70a9da8c157810dfebd608",
             "_tpl": "57f4c844245977379d5c14d1",
             "parentId": "hideout",
@@ -5971,20 +5257,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "eb8cf00acfa1fcfe4fcdbccb",
             "_tpl": "57d152ec245977144076ccdf",
             "parentId": "5a70a9da8c157810dfebd608",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "34c5a151ce510cf8aa6cda28",
             "_tpl": "57d1519e24597714373db79d",
             "parentId": "5a70a9da8c157810dfebd608",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "bcafda5baf624ab54c5cf8c5",
             "_tpl": "5de7bd7bfd6b4e6e2276dc25",
             "parentId": "hideout",
@@ -5995,50 +5278,42 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "3f752d082ef3b8d13a4abefe",
             "_tpl": "5de8eac42a78646d96665d91",
             "parentId": "bcafda5baf624ab54c5cf8c5",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "c046047e570ecfa07bbdfecf",
             "_tpl": "5de910da8b6c4240ba2651b5",
             "parentId": "bcafda5baf624ab54c5cf8c5",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "2e5d63ee6fc0c6bb0b9da5b1",
             "_tpl": "5de8fbad2fbe23140d3ee9c4",
             "parentId": "bcafda5baf624ab54c5cf8c5",
             "slotId": "mod_foregrip"
-        },
-        {
+        }, {
             "_id": "4f43d8afeef8e5c2e0b3ed6e",
             "_tpl": "5de8e67c4a9f347bc92edbd7",
             "parentId": "bcafda5baf624ab54c5cf8c5",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "7b7266b7252acadf8b7340fd",
             "_tpl": "5de8fb539f98ac2bc659513a",
             "parentId": "4f43d8afeef8e5c2e0b3ed6e",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "201f7ce7e70a233fbe47feeb",
             "_tpl": "5de8fc0b205ddc616a6bc51b",
             "parentId": "4f43d8afeef8e5c2e0b3ed6e",
             "slotId": "mod_mount"
-        },
-        {
+        }, {
             "_id": "cb3ea1c508dbfdf59eaa7041",
             "_tpl": "5de922d4b11454561e39239f",
             "parentId": "bcafda5baf624ab54c5cf8c5",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "d20fda6f5f13c3f4c827e0ab",
             "_tpl": "5e00903ae9dc277128008b87",
             "parentId": "hideout",
@@ -6049,44 +5324,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "befca8eba99a87c884a0c0bb",
             "_tpl": "5de8eac42a78646d96665d91",
             "parentId": "d20fda6f5f13c3f4c827e0ab",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "18fdcd7fd107f77dbcb4b9fa",
             "_tpl": "5de910da8b6c4240ba2651b5",
             "parentId": "d20fda6f5f13c3f4c827e0ab",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "fdbeeca08bdaf4fff5c8dfcd",
             "_tpl": "5e0090f7e9dc277128008b93",
             "parentId": "d20fda6f5f13c3f4c827e0ab",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "290cd9cf4b6e16f5be5f15ef",
             "_tpl": "5de8fb539f98ac2bc659513a",
             "parentId": "fdbeeca08bdaf4fff5c8dfcd",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "c3ea37bfdfdf0d8a297ecd54",
             "_tpl": "5de922d4b11454561e39239f",
             "parentId": "d20fda6f5f13c3f4c827e0ab",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "9201335bfd2a1bdb81dc1a5a",
             "_tpl": "5de8fbf2b74cd90030650c79",
             "parentId": "d20fda6f5f13c3f4c827e0ab",
             "slotId": "mod_mount_000"
-        },
-        {
+        }, {
             "_id": "0b79d8fc0aeee03ff2d7aaff",
             "_tpl": "59984ab886f7743e98271174",
             "parentId": "hideout",
@@ -6097,56 +5365,47 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c8bcba4ef5bc1da7baefdf79",
             "_tpl": "5998517986f7746017232f7e",
             "parentId": "0b79d8fc0aeee03ff2d7aaff",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "cc8a255de4dd178900f70ef0",
             "_tpl": "599851db86f77467372f0a18",
             "parentId": "0b79d8fc0aeee03ff2d7aaff",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "ea00decf93870cc755890d58",
             "_tpl": "599860ac86f77436b225ed1a",
             "parentId": "0b79d8fc0aeee03ff2d7aaff",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "bc9c7d86eed7e400253cd1f7",
             "_tpl": "5998597786f77414ea6da093",
             "parentId": "0b79d8fc0aeee03ff2d7aaff",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "3f366f691be33a3cea5e47f5",
             "_tpl": "59985a8086f77414ec448d1a",
             "parentId": "0b79d8fc0aeee03ff2d7aaff",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "ec0f41bede619703f663761c",
             "_tpl": "599860e986f7743bb57573a6",
             "parentId": "0b79d8fc0aeee03ff2d7aaff",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "be9ba834abfffad1dfd32af0",
             "_tpl": "5648b1504bdc2d9d488b4584",
             "parentId": "5bdb3f45afe1e852d6decbee",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "5bdb3f45afe1e852d6decbee",
             "_tpl": "59ccd11386f77428f24a488f",
             "parentId": "0b79d8fc0aeee03ff2d7aaff",
             "slotId": "mod_gas_block"
-        },
-        {
+        }, {
             "_id": "2c2cdfcaaedf64f3c33a6bfe",
             "_tpl": "58948c8e86f77409493f7266",
             "parentId": "hideout",
@@ -6157,86 +5416,72 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b1f2dac7dd8ba3d4fd5fbddb",
             "_tpl": "5894a51286f77426d13baf02",
             "parentId": "2c2cdfcaaedf64f3c33a6bfe",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "4abfe9fefdd65643cbd5dbe5",
             "_tpl": "5894a05586f774094708ef75",
             "parentId": "2c2cdfcaaedf64f3c33a6bfe",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "4e89f8742fe7e8ff7dada2ab",
             "_tpl": "58949dea86f77409483e16a8",
             "parentId": "540351af5edcabea1bc5b24a",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "540351af5edcabea1bc5b24a",
             "_tpl": "5894a2c386f77427140b8342",
             "parentId": "75cb7a5aa264c10e2bbae0b5",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "c78e5ca447abc688faedfbec",
             "_tpl": "5894a73486f77426d259076c",
             "parentId": "7e893fbb6fc30cbadf749fd3",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "b2c834b7cfcdaed90b6ff87f",
             "_tpl": "58a56f8d86f774651579314c",
             "parentId": "7e893fbb6fc30cbadf749fd3",
             "slotId": "mod_mount_000"
-        },
-        {
+        }, {
             "_id": "daafe9a2fce7ab3fa125239d",
             "_tpl": "58a5c12e86f7745d585a2b9e",
             "parentId": "7e893fbb6fc30cbadf749fd3",
             "slotId": "mod_mount_001"
-        },
-        {
+        }, {
             "_id": "e965d3dc94ce3e5b597ebbea",
             "_tpl": "58a56f8d86f774651579314c",
             "parentId": "7e893fbb6fc30cbadf749fd3",
             "slotId": "mod_mount_002"
-        },
-        {
+        }, {
             "_id": "7e893fbb6fc30cbadf749fd3",
             "_tpl": "5894a42086f77426d2590762",
             "parentId": "75cb7a5aa264c10e2bbae0b5",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "1d300c5ae3cbae8ad2a8101a",
             "_tpl": "5894a81786f77427140b8347",
             "parentId": "75cb7a5aa264c10e2bbae0b5",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "75cb7a5aa264c10e2bbae0b5",
             "_tpl": "5894a5b586f77426d2590767",
             "parentId": "2c2cdfcaaedf64f3c33a6bfe",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "eac0a7fe1dafdc0ce0a01491",
             "_tpl": "5894a13e86f7742405482982",
             "parentId": "2c2cdfcaaedf64f3c33a6bfe",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "0231555c3d9ac942ca5a2c73",
             "_tpl": "58949edd86f77409483e16a9",
             "parentId": "2c2cdfcaaedf64f3c33a6bfe",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "30d38a39f4ae6338a4128f1f",
             "_tpl": "60339954d62c9b14ed777c06",
             "parentId": "hideout",
@@ -6247,68 +5492,57 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c79c96b4c78053ddcd7c0ebc",
             "_tpl": "602e71bd53a60014f9705bfa",
             "parentId": "30d38a39f4ae6338a4128f1f",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "8e3ccafdfdf30ecc75b17b71",
             "_tpl": "5a7ad2e851dfba0016153692",
             "parentId": "30d38a39f4ae6338a4128f1f",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "af34ff4e4f734c2ffbbf43c7",
             "_tpl": "602e63fb6335467b0c5ac94d",
             "parentId": "30d38a39f4ae6338a4128f1f",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "eebf44d1ce5bae0c0ecbec2b",
             "_tpl": "603372b4da11d6478d5a07ff",
             "parentId": "af34ff4e4f734c2ffbbf43c7",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "fdba9d98a4afaafdebdaaa03",
             "_tpl": "60337f5dce399e10262255d1",
             "parentId": "eebf44d1ce5bae0c0ecbec2b",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "d1efc08e88efdd6cff463ba4",
             "_tpl": "6034e3cb0ddce744014cb870",
             "parentId": "af34ff4e4f734c2ffbbf43c7",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "c7bb057b7abcf3dde9b3d7d4",
             "_tpl": "602e3f1254072b51b239f713",
             "parentId": "30d38a39f4ae6338a4128f1f",
             "slotId": "mod_stock_001"
-        },
-        {
+        }, {
             "_id": "3a5af0aae1dadb1ccaeeadf4",
             "_tpl": "602e620f9b513876d4338d9a",
             "parentId": "c7bb057b7abcf3dde9b3d7d4",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "dd67fe1f1c5dca9c22a2db1c",
             "_tpl": "6033749e88382f4fab3fd2c5",
             "parentId": "30d38a39f4ae6338a4128f1f",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "7b63a2ea76ccadd24a629029",
             "_tpl": "602f85fd9b513876d4338d9c",
             "parentId": "30d38a39f4ae6338a4128f1f",
             "slotId": "mod_tactical_000"
-        },
-        {
+        }, {
             "_id": "8da19e3fc5b0c049798ebccd",
             "_tpl": "5fc3e272f8b6a877a729eac5",
             "parentId": "hideout",
@@ -6319,44 +5553,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "60dcccede54a301655a2748c",
             "_tpl": "5fc3e466187fea44d52eda90",
             "parentId": "8da19e3fc5b0c049798ebccd",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "ebaa2ccaabda7e3ad1f4416c",
             "_tpl": "5fc3e4ee7283c4046c5814af",
             "parentId": "8da19e3fc5b0c049798ebccd",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "adccccc5fba3029db25c3eac",
             "_tpl": "5fc3e4a27283c4046c5814ab",
             "parentId": "8da19e3fc5b0c049798ebccd",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "8341dd8c01a28202145565ad",
             "_tpl": "5fc53954f8b6a877a729eaeb",
             "parentId": "8da19e3fc5b0c049798ebccd",
             "slotId": "mod_mount_000"
-        },
-        {
+        }, {
             "_id": "0decb3ce5a05f4e2a6bd91bc",
             "_tpl": "5fc5396e900b1d5091531e72",
             "parentId": "8da19e3fc5b0c049798ebccd",
             "slotId": "mod_mount_001"
-        },
-        {
+        }, {
             "_id": "ab393d3350cd760f31ebdfcb",
             "_tpl": "5fc5396e900b1d5091531e72",
             "parentId": "8da19e3fc5b0c049798ebccd",
             "slotId": "mod_mount_002"
-        },
-        {
+        }, {
             "_id": "eeba2eb4ddaceeea20ddab1a",
             "_tpl": "5fb64bc92b1b027b1f50bcf2",
             "parentId": "hideout",
@@ -6367,62 +5594,52 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a5f598956d50c24c0140d6ae",
             "_tpl": "5fb651b52b1b027b1f50bcff",
             "parentId": "eeba2eb4ddaceeea20ddab1a",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "a57a2ffb8ce52bcadbabbe0b",
             "_tpl": "5fb6567747ce63734e3fa1dc",
             "parentId": "eeba2eb4ddaceeea20ddab1a",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "de2a4ba2e7cfaefdd13089c5",
             "_tpl": "5fb6564947ce63734e3fa1da",
             "parentId": "eeba2eb4ddaceeea20ddab1a",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "45af8a1294bad87fdd3527ba",
             "_tpl": "5fb6558ad6f0b2136f2d7eb7",
             "parentId": "eeba2eb4ddaceeea20ddab1a",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "544eb5ad52c1516805f8da7c",
             "_tpl": "5fb65363d1409e5ca04b54f5",
             "parentId": "eeba2eb4ddaceeea20ddab1a",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "ed4a04efd962eaf5ee5edb3a",
             "_tpl": "5fb6548dd1409e5ca04b54f9",
             "parentId": "544eb5ad52c1516805f8da7c",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "8a85df5d3acd5edfafb84747",
             "_tpl": "5fbb976df9986c4cff3fe5f2",
             "parentId": "eeba2eb4ddaceeea20ddab1a",
             "slotId": "mod_mount"
-        },
-        {
+        }, {
             "_id": "76a71da0ffabcbfcb59ae93b",
             "_tpl": "5fce0f9b55375d18a253eff2",
             "parentId": "eeba2eb4ddaceeea20ddab1a",
             "slotId": "mod_mount_001"
-        },
-        {
+        }, {
             "_id": "7ee459889bda92bc8d3d430f",
             "_tpl": "5fce0f9b55375d18a253eff2",
             "parentId": "eeba2eb4ddaceeea20ddab1a",
             "slotId": "mod_mount_002"
-        },
-        {
+        }, {
             "_id": "f56f21853db9b53d4ac5dd5d",
             "_tpl": "5fc3f2d5900b1d5091531e57",
             "parentId": "hideout",
@@ -6433,62 +5650,52 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d5dc21a01bffabf592dfebe3",
             "_tpl": "5a718b548dc32e000d46d262",
             "parentId": "f56f21853db9b53d4ac5dd5d",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "a1cf3b388b97129b4f21aad5",
             "_tpl": "5fb6567747ce63734e3fa1dc",
             "parentId": "f56f21853db9b53d4ac5dd5d",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "d26d6c56bd6ab0ebf1a77b86",
             "_tpl": "5fb6564947ce63734e3fa1da",
             "parentId": "f56f21853db9b53d4ac5dd5d",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "5cdda5fe18d9e2bfe7cc1cfa",
             "_tpl": "5fb6558ad6f0b2136f2d7eb7",
             "parentId": "f56f21853db9b53d4ac5dd5d",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "92354fcfafc80b163b573f1f",
             "_tpl": "5fbbc366ca32ed67276c1557",
             "parentId": "f56f21853db9b53d4ac5dd5d",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "1f22ef1f419aba2eae134811",
             "_tpl": "5fbbc34106bde7524f03cbe9",
             "parentId": "92354fcfafc80b163b573f1f",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "45361df0f5edd2b7fb03773a",
             "_tpl": "5fbb976df9986c4cff3fe5f2",
             "parentId": "f56f21853db9b53d4ac5dd5d",
             "slotId": "mod_mount"
-        },
-        {
+        }, {
             "_id": "eecfde22a524a8baf4565bae",
             "_tpl": "5fce0f9b55375d18a253eff2",
             "parentId": "f56f21853db9b53d4ac5dd5d",
             "slotId": "mod_mount_001"
-        },
-        {
+        }, {
             "_id": "6e78e89affdb9f1ae07eedb0",
             "_tpl": "5fce0f9b55375d18a253eff2",
             "parentId": "f56f21853db9b53d4ac5dd5d",
             "slotId": "mod_mount_002"
-        },
-        {
+        }, {
             "_id": "5f874db0cbfb83bc7c1dacbc",
             "_tpl": "5cc82d76e24e8d00134b4b83",
             "parentId": "hideout",
@@ -6499,68 +5706,57 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c51dc92d5c5afc5cd1f95cc0",
             "_tpl": "5cc70093e4a949033c734312",
             "parentId": "5f874db0cbfb83bc7c1dacbc",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "a1efc092368f5da590a65ffb",
             "_tpl": "5cc700cae4a949035e43ba72",
             "parentId": "a7b41caabbe1f13000c58bab",
             "slotId": "mod_stock_000"
-        },
-        {
+        }, {
             "_id": "a7b41caabbe1f13000c58bab",
             "_tpl": "5cc700b9e4a949000f0f0f25",
             "parentId": "5f874db0cbfb83bc7c1dacbc",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "8e512c04135cbb67b0efb0cf",
             "_tpl": "5cebec38d7f00c00110a652a",
             "parentId": "2bfa254a91f28df87bed1dee",
             "slotId": "mod_mount_000"
-        },
-        {
+        }, {
             "_id": "a913d8dd464fa9ee355aac12",
             "_tpl": "5cc70146e4a949000d73bf6b",
             "parentId": "2bfa254a91f28df87bed1dee",
             "slotId": "mod_mount_001"
-        },
-        {
+        }, {
             "_id": "a4d564a0bedf2eea9bcc9acf",
             "_tpl": "5cc70146e4a949000d73bf6b",
             "parentId": "2bfa254a91f28df87bed1dee",
             "slotId": "mod_mount_002"
-        },
-        {
+        }, {
             "_id": "2bfa254a91f28df87bed1dee",
             "_tpl": "5cc70102e4a949035e43ba74",
             "parentId": "5f874db0cbfb83bc7c1dacbc",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "4de85ca2530d54a841eaf6fe",
             "_tpl": "5cc82796e24e8d000f5859a8",
             "parentId": "5d7ca60fceadddcef6cee520",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "5d7ca60fceadddcef6cee520",
             "_tpl": "5cc701aae4a949000e1ea45c",
             "parentId": "5f874db0cbfb83bc7c1dacbc",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "8e22abe45a9aaeae1dfc21db",
             "_tpl": "5cc6ea78e4a949000e1ea3c1",
             "parentId": "5f874db0cbfb83bc7c1dacbc",
             "slotId": "mod_charge"
-        },
-        {
+        }, {
             "_id": "a4f4cebdd504df8c6cdd5cbd",
             "_tpl": "5bd70322209c4d00d7167b8f",
             "parentId": "hideout",
@@ -6571,38 +5767,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c9f4be019dd3326f790aef4d",
             "_tpl": "5ba264f6d4351e0034777d52",
             "parentId": "a4f4cebdd504df8c6cdd5cbd",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "41aceb8bebd8ebb38ab0b41e",
             "_tpl": "5ba26acdd4351e003562908e",
             "parentId": "a4f4cebdd504df8c6cdd5cbd",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "fbf827adfd3a14fee10a9a6c",
             "_tpl": "5ba26b01d4351e0085325a51",
             "parentId": "a4f4cebdd504df8c6cdd5cbd",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "0af9c999b0aba1ec3bfac035",
             "_tpl": "5ba26b17d4351e00367f9bdd",
             "parentId": "a4f4cebdd504df8c6cdd5cbd",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "de24f5868e9da4eaca0dff3f",
             "_tpl": "5bd704e7209c4d00d7167c31",
             "parentId": "a4f4cebdd504df8c6cdd5cbd",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "ce16ab92fc2fdedbbce276a0",
             "_tpl": "5ba26383d4351e00334c93d9",
             "parentId": "hideout",
@@ -6613,38 +5803,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "969bef572e30b5c57fcde6b9",
             "_tpl": "5ba264f6d4351e0034777d52",
             "parentId": "ce16ab92fc2fdedbbce276a0",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "519c800f8ec4bac9ac6446bb",
             "_tpl": "5ba26acdd4351e003562908e",
             "parentId": "ce16ab92fc2fdedbbce276a0",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "11f903e8ce21bdc8a8fbd3e5",
             "_tpl": "5ba26b01d4351e0085325a51",
             "parentId": "ce16ab92fc2fdedbbce276a0",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "1ac4cdc14cca733f9c4ad666",
             "_tpl": "5ba26b17d4351e00367f9bdd",
             "parentId": "ce16ab92fc2fdedbbce276a0",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "466bacf093d2ef08e0fe668e",
             "_tpl": "5bcf0213d4351e0085327c17",
             "parentId": "ce16ab92fc2fdedbbce276a0",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "edefbc1e1e81e1c3aee5e0c6",
             "_tpl": "64b6979341772715af0f9c39",
             "parentId": "hideout",
@@ -6655,8 +5839,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "5da63b260eca83e9cefbd1ad",
             "_tpl": "64b6979341772715af0f9c39",
             "parentId": "hideout",
@@ -6667,8 +5850,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "64922cbcebffceeeea5ad7a5",
             "_tpl": "64b7bbb74b75259c590fa897",
             "parentId": "hideout",
@@ -6679,8 +5861,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d3d5ed8e05e02a233770ca06",
             "_tpl": "64b7bbb74b75259c590fa897",
             "parentId": "hideout",
@@ -6691,8 +5872,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fd3af4d1f7c8a28c6d3538b8",
             "_tpl": "64b8725c4b75259c590fa899",
             "parentId": "hideout",
@@ -6703,8 +5883,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bcec0a0eb24c1fbdd7bd1437",
             "_tpl": "64b8725c4b75259c590fa899",
             "parentId": "hideout",
@@ -6715,8 +5894,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d2023daced2c72d8a7d858e7",
             "_tpl": "65719f0775149d62ce0a670b",
             "parentId": "hideout",
@@ -6727,26 +5905,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "41aab1308bb6ca9e4424d53e",
             "_tpl": "657fa0fcd4caf976440afe3e",
             "parentId": "d2023daced2c72d8a7d858e7",
             "slotId": "Helmet_top"
-        },
-        {
+        }, {
             "_id": "bf675df5bea85cb0988cfd88",
             "_tpl": "657fa168e9433140ad0baf8e",
             "parentId": "d2023daced2c72d8a7d858e7",
             "slotId": "Helmet_back"
-        },
-        {
+        }, {
             "_id": "de2905e8aa2abaad2d7bbfd5",
             "_tpl": "657fa186d4caf976440afe42",
             "parentId": "d2023daced2c72d8a7d858e7",
             "slotId": "Helmet_ears"
-        },
-        {
+        }, {
             "_id": "4a76efbf9ad1ed239033dbeb",
             "_tpl": "65719f0775149d62ce0a670b",
             "parentId": "hideout",
@@ -6757,26 +5931,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "befc547ca8b9c3452adcc66d",
             "_tpl": "657fa0fcd4caf976440afe3e",
             "parentId": "4a76efbf9ad1ed239033dbeb",
             "slotId": "Helmet_top"
-        },
-        {
+        }, {
             "_id": "dabeacacf5a1c9398a4dfd4a",
             "_tpl": "657fa168e9433140ad0baf8e",
             "parentId": "4a76efbf9ad1ed239033dbeb",
             "slotId": "Helmet_back"
-        },
-        {
+        }, {
             "_id": "1b5bfcfaeeade0ae6e29e59f",
             "_tpl": "657fa186d4caf976440afe42",
             "parentId": "4a76efbf9ad1ed239033dbeb",
             "slotId": "Helmet_ears"
-        },
-        {
+        }, {
             "_id": "4bac8d6dcefb3a0cad419f56",
             "_tpl": "65709d2d21b9f815e208ff95",
             "parentId": "hideout",
@@ -6787,20 +5957,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a387bbc54fdcfb3f2963b9ad",
             "_tpl": "657f9eb7e9433140ad0baf86",
             "parentId": "4bac8d6dcefb3a0cad419f56",
             "slotId": "Helmet_top"
-        },
-        {
+        }, {
             "_id": "a5f6ebadc5dd629fcc2b5c20",
             "_tpl": "657f9ef6c6679fefb3051e1f",
             "parentId": "4bac8d6dcefb3a0cad419f56",
             "slotId": "Helmet_back"
-        },
-        {
+        }, {
             "_id": "dcb2d8f8d4b5fd2ffb4e96de",
             "_tpl": "65709d2d21b9f815e208ff95",
             "parentId": "hideout",
@@ -6811,20 +5978,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e1c46bd89b7c742c3abf4a9d",
             "_tpl": "657f9eb7e9433140ad0baf86",
             "parentId": "dcb2d8f8d4b5fd2ffb4e96de",
             "slotId": "Helmet_top"
-        },
-        {
+        }, {
             "_id": "9adbab0aaea01ceee2db42fa",
             "_tpl": "657f9ef6c6679fefb3051e1f",
             "parentId": "dcb2d8f8d4b5fd2ffb4e96de",
             "slotId": "Helmet_back"
-        },
-        {
+        }, {
             "_id": "a57e52aefc8ede2ed9eafa1f",
             "_tpl": "62e14904c2699c0ec93adc47",
             "parentId": "hideout",
@@ -6835,50 +5999,42 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a7eecf658ed3ffab70f182d0",
             "_tpl": "633a98eab8b0506e48497c1a",
             "parentId": "a57e52aefc8ede2ed9eafa1f",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "c9b62dcbb9a2ac2f6aaba5ff",
             "_tpl": "62e2a754b6c0ee2f230cee0f",
             "parentId": "a57e52aefc8ede2ed9eafa1f",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "6ecce5cf633f48a2871cecbe",
             "_tpl": "62e292e7b6c0ee2f230cee00",
             "parentId": "a57e52aefc8ede2ed9eafa1f",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "5fafffaa3d6ab3aa1ec28d0a",
             "_tpl": "62e27a7865f0b1592a49e17b",
             "parentId": "a57e52aefc8ede2ed9eafa1f",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "e75daab2457ef7aef9b058f8",
             "_tpl": "62e15547db1a5c41971c1b5e",
             "parentId": "a57e52aefc8ede2ed9eafa1f",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "fdabb622bfacaa2e9525c57f",
             "_tpl": "62ed189fb3608410ef5a2bfc",
             "parentId": "e75daab2457ef7aef9b058f8",
             "slotId": "mod_mount_001"
-        },
-        {
+        }, {
             "_id": "1ecaeea7aada6ed9b9cf5e8b",
             "_tpl": "637b9c37b7e3bc41b21ce71a",
             "parentId": "a57e52aefc8ede2ed9eafa1f",
             "slotId": "mod_pistolgrip"
-        },
-        {
+        }, {
             "_id": "36e6e5da727bcbf1ecfb6ef3",
             "_tpl": "62e14904c2699c0ec93adc47",
             "parentId": "hideout",
@@ -6889,50 +6045,42 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "12d65fdba6c90889dabbd8ed",
             "_tpl": "633a98eab8b0506e48497c1a",
             "parentId": "36e6e5da727bcbf1ecfb6ef3",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "c6dddbffb5d632885e1bfbce",
             "_tpl": "62e2a754b6c0ee2f230cee0f",
             "parentId": "36e6e5da727bcbf1ecfb6ef3",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "9d018b37fc7e0d4febc5bd3a",
             "_tpl": "62e292e7b6c0ee2f230cee00",
             "parentId": "36e6e5da727bcbf1ecfb6ef3",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "6b7bcde964bc2e3e5d933cbf",
             "_tpl": "62e27a7865f0b1592a49e17b",
             "parentId": "36e6e5da727bcbf1ecfb6ef3",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "9cf82708fff57edd7a273efd",
             "_tpl": "62e15547db1a5c41971c1b5e",
             "parentId": "36e6e5da727bcbf1ecfb6ef3",
             "slotId": "mod_handguard"
-        },
-        {
+        }, {
             "_id": "c38e1243dde4ddc65cc632fa",
             "_tpl": "62ed189fb3608410ef5a2bfc",
             "parentId": "9cf82708fff57edd7a273efd",
             "slotId": "mod_mount_001"
-        },
-        {
+        }, {
             "_id": "e93fbc13902c5a42eecb9e4a",
             "_tpl": "637b9c37b7e3bc41b21ce71a",
             "parentId": "36e6e5da727bcbf1ecfb6ef3",
             "slotId": "mod_pistolgrip"
-        },
-        {
+        }, {
             "_id": "099cd41b2f9c849ff68efda7",
             "_tpl": "62e153bcdb1a5c41971c1b5b",
             "parentId": "hideout",
@@ -6943,8 +6091,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c3adac0c4ccf4b56eca2fc50",
             "_tpl": "633a98eab8b0506e48497c1a",
             "parentId": "hideout",

--- a/db/traders/6765fbd20fdc7eb79b00000f/assort.json
+++ b/db/traders/6765fbd20fdc7eb79b00000f/assort.json
@@ -1,1752 +1,1521 @@
 {
     "barter_scheme": {
         "3a9cb7a0affcffd85acd25f8": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 7800
                 }
             ]
         ],
         "e5dddfb1dfaf5efd25d66bb5": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 800
                 }
             ]
         ],
         "fed0f57ea117d4dfd7ebaf0e": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 15000
                 }
             ]
         ],
         "83f84aa7f1d5baa8375f2ea6": [
-            [
-                {
+            [{
                     "_tpl": "5448ff904bdc2d6f028b456e",
                     "count": 12
                 }
             ]
         ],
         "b6ad0c8fee8849dfacdcad1b": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 36000
                 }
             ]
         ],
         "cdbae4551d855b106e710592": [
-            [
-                {
+            [{
                     "_tpl": "619cbfeb6b8a1b37a54eebfa",
                     "count": 2
                 }
             ]
         ],
         "eeeda5e0c30acab2387b89db": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 13000
                 }
             ]
         ],
         "1e8aa11dffada086c5068dc8": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1800
                 }
             ]
         ],
         "d3644926fee7bda253bcb1a5": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 20000
                 }
             ]
         ],
         "aa0de437e1a4dfaa7f4e8bc6": [
-            [
-                {
+            [{
                     "_tpl": "59e35ef086f7741777737012",
                     "count": 2
                 }
             ]
         ],
         "820211af1bb0cce1ecb026b2": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 6500
                 }
             ]
         ],
         "6d88bd83d9eadaf199fe607e": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1000
                 }
             ]
         ],
         "fb1a52f738e38a1cefe9c4db": [
-            [
-                {
+            [{
                     "_tpl": "57371f2b24597761224311f1",
                     "count": 3
                 }
             ]
         ],
         "e7198dc8ba1dd4d8be5de271": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 42
                 }
             ]
         ],
         "915aeeb8c2ffdacff1bb0d20": [
-            [
-                {
+            [{
                     "_tpl": "5735fdcd2459776445391d61",
                     "count": 2
                 }
             ]
         ],
         "5a5d16fd31babae6facbbd33": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 45
                 }
             ]
         ],
         "ca14ca194a60716cafa23f02": [
-            [
-                {
+            [{
                     "_tpl": "573602322459776445391df1",
                     "count": 4
                 }
             ]
         ],
         "de2be0eb3ac652ce4fbc145d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 40
                 }
             ]
         ],
         "bfb8abf507ada6d60d8fbc07": [
-            [
-                {
+            [{
                     "_tpl": "573603c924597764442bd9cb",
                     "count": 2
                 }
             ]
         ],
         "df0feb4c5e5ec8bda641de13": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60
                 }
             ]
         ],
         "8dd4bb045cd23b6cae8626d4": [
-            [
-                {
+            [{
                     "_tpl": "5735ff5c245977640e39ba7e",
                     "count": 2
                 }
             ]
         ],
         "d2b3dbbffc6d93efc5aadee7": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 45
                 }
             ]
         ],
         "f8c1b5b1cea294edd8aae8ce": [
-            [
-                {
+            [{
                     "_tpl": "573601b42459776410737435",
                     "count": 3
                 }
             ]
         ],
         "086ee00585e6fffe9c49a94e": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60
                 }
             ]
         ],
         "8e6b439cb29ff8c6f2e39ad1": [
-            [
-                {
+            [{
                     "_tpl": "5736026a245977644601dc61",
                     "count": 2
                 }
             ]
         ],
         "d7a03b44cbedfb164faa6568": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 55
                 }
             ]
         ],
         "bcefecbc9938df34a4b9ccca": [
-            [
-                {
+            [{
                     "_tpl": "57372140245977611f70ee91",
                     "count": 2
                 }
             ]
         ],
         "44ed1accafdaaed4ee3a0e16": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 55
                 }
             ]
         ],
         "b70ea8cfd98f44efddcb7ec9": [
-            [
-                {
+            [{
                     "_tpl": "560d5e524bdc2d25448b4571",
                     "count": 2
                 }
             ]
         ],
         "cd74e02d515cbceddedbe4d0": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 10
                 }
             ]
         ],
         "b09decf5006aef30bc6b81d9": [
-            [
-                {
+            [{
                     "_tpl": "57371aab2459775a77142f22",
                     "count": 2
                 }
             ]
         ],
         "fbb8cf1dff9bec9bbedd88f1": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 100
                 }
             ]
         ],
         "3d3aff70ebf8fcee2feaef19": [
-            [
-                {
+            [{
                     "_tpl": "573718ba2459775a75491131",
                     "count": 2
                 }
             ]
         ],
         "ebde2ceaef7d9ebbee06aa7d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 100
                 }
             ]
         ],
         "44dc7035bc97bc6cc5dcc383": [
-            [
-                {
+            [{
                     "_tpl": "57371e4124597760ff7b25f1",
                     "count": 4
                 }
             ]
         ],
         "dca3fc1a711ba7321847b21a": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 44
                 }
             ]
         ],
         "fb6d6d563facc7f8b9e633bd": [
-            [
-                {
+            [{
                     "_tpl": "57371eb62459776125652ac1",
                     "count": 2
                 }
             ]
         ],
         "4dc2c96e5d3e3231f51e7df6": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 36
                 }
             ]
         ],
         "1fb4b1cf54aca1271f0894b5": [
-            [
-                {
+            [{
                     "_tpl": "57371f2b24597761224311f1",
                     "count": 3
                 }
             ]
         ],
         "11f451f96ec3bf5bcfbbb40d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 30
                 }
             ]
         ],
         "bbfadaa86f4cdbd0c086dadb": [
-            [
-                {
+            [{
                     "_tpl": "57371f8d24597761006c6a81",
                     "count": 2
                 }
             ]
         ],
         "65b379bb5c3fe44c00e9fbd9": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24
                 }
             ]
         ],
         "ceae16d808bbe67f0fa7b6a0": [
-            [
-                {
+            [{
                     "_tpl": "573719762459775a626ccbc1",
                     "count": 3
                 }
             ]
         ],
         "e224f506ebadcb69be0f0c09": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 18
                 }
             ]
         ],
         "c5e8f7eff6cdb0bf95ddadc2": [
-            [
-                {
+            [{
                     "_tpl": "57371b192459775a9f58a5e0",
                     "count": 2
                 }
             ]
         ],
         "fdbfda26046c99eacda24230": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 38
                 }
             ]
         ],
         "470bae3f55f0debfbb94a46b": [
-            [
-                {
+            [{
                     "_tpl": "5737218f245977612125ba51",
                     "count": 2
                 }
             ]
         ],
         "df65013e31dffb8dfad3536f": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60
                 }
             ]
         ],
         "0edcf83e0494db293b0417fd": [
-            [
-                {
+            [{
                     "_tpl": "5737207f24597760ff7b25f2",
                     "count": 3
                 }
             ]
         ],
         "dcfe5a0eea4daf9dd0c322be": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 75
                 }
             ]
         ],
         "fefe0d415e3f871fc23539fa": [
-            [
-                {
+            [{
                     "_tpl": "573720e02459776143012541",
                     "count": 4
                 }
             ]
         ],
         "d5fac2c7a2188bae4313e918": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 145
                 }
             ]
         ],
         "c0cd0cd5d6fc2bca97e78fac": [
-            [
-                {
+            [{
                     "_tpl": "5737201124597760fc4431f1",
                     "count": 2
                 }
             ]
         ],
         "58a9aafc80d40a7eb0fc02bd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60
                 }
             ]
         ],
         "2bf6fa9ebcfa2fa7a597aa89": [
-            [
-                {
+            [{
                     "_tpl": "59e35ef086f7741777737012",
                     "count": 2
                 }
             ]
         ],
         "e311ead52063d21d4d7cedcd": [
-            [
-                {
+            [{
                     "_tpl": "5751487e245977207e26a315",
                     "count": 1
                 }
             ]
         ],
         "94ab28efe9871ded5c716c82": [
-            [
-                {
+            [{
                     "_tpl": "5673de654bdc2d180f8b456d",
                     "count": 3
                 }
             ]
         ],
         "a31fdb5d730cc4abc1359222": [
-            [
-                {
+            [{
                     "_tpl": "5c06782b86f77426df5407d2",
                     "count": 3
                 }
             ]
         ],
         "dfc0bc12fc570ccec1ffabbd": [
-            [
-                {
+            [{
                     "_tpl": "57347c93245977448d35f6e3",
                     "count": 1
                 }
             ]
         ],
         "e1bbeed79f7fea0dfa12d80b": [
-            [
-                {
+            [{
                     "_tpl": "5909e99886f7740c983b9984",
                     "count": 1
                 }
             ]
         ],
         "b42cc6376a1904a1febe235a": [
-            [
-                {
+            [{
                     "_tpl": "56742c284bdc2d98058b456d",
                     "count": 1
                 }
             ]
         ],
         "2efde2abb2baf3ae1ff2ff4a": [
-            [
-                {
+            [{
                     "_tpl": "5672cb124bdc2d1a0f8b4568",
                     "count": 1
                 }
             ]
         ],
         "f447b102bd5acfbc207eb149": [
-            [
-                {
+            [{
                     "_tpl": "57347d3d245977448f7b7f61",
                     "count": 1
                 }
             ]
         ],
         "c2ae85b817d44dbeccd1f8ee": [
-            [
-                {
+            [{
                     "_tpl": "5734795124597738002c6176",
                     "count": 1
                 }
             ]
         ],
         "d0ebab7adbcd6e4abd3e0b6a": [
-            [
-                {
+            [{
                     "_tpl": "577e1c9d2459773cd707c525",
                     "count": 1
                 }
             ]
         ],
         "7acfff1f46adfbcef1e5f760": [
-            [
-                {
+            [{
                     "_tpl": "57347cd0245977445a2d6ff1",
                     "count": 1
                 }
             ]
         ],
         "dcf10a6a92e1a9b36540f0e3": [
-            [
-                {
+            [{
                     "_tpl": "57347d9c245977448b40fa85",
                     "count": 2
                 }
             ]
         ],
         "3581cfb9a4b12786e6edec65": [
-            [
-                {
+            [{
                     "_tpl": "57347b8b24597737dd42e192",
                     "count": 1
                 }
             ]
         ],
         "df3bca39d57fb7dd5ad84bae": [
-            [
-                {
+            [{
                     "_tpl": "5d4042a986f7743185265463",
                     "count": 2
                 }
             ]
         ],
         "ee565bb7e3ecda6bcafbd514": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 11000
                 }
             ]
         ],
         "cc4bbc4118a8e9df8fbba40f": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1400
                 }
             ]
         ],
         "274abdae1feb2ac1add7fafd": [
-            [
-                {
+            [{
                     "_tpl": "5909e99886f7740c983b9984",
                     "count": 3
                 }
             ]
         ],
         "fbe55784d196ee9d82b8dda3": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 9000
                 }
             ]
         ],
         "8d7203ba6b66cc3c4b201ff5": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2400
                 }
             ]
         ],
         "937e5a4cf8ecc4218ce9bedc": [
-            [
-                {
+            [{
                     "_tpl": "573474f924597738002c6174",
                     "count": 2
-                },
-                {
+                }, {
                     "_tpl": "619cbfeb6b8a1b37a54eebfa",
                     "count": 1
                 }
             ]
         ],
         "3e7f422c138ef7375ffe785c": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 18000
                 }
             ]
         ],
         "189b44fcb7eeab81cee03fec": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1300
                 }
             ]
         ],
         "3c9f0e8134cb86cea7faab5e": [
-            [
-                {
+            [{
                     "_tpl": "5e2af29386f7746d4159f077",
                     "count": 2
                 }
             ]
         ],
         "a7d97272bfab4233d4a7a61b": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 50000
                 }
             ]
         ],
         "d01a690a010ef47f25eed3f5": [
-            [
-                {
+            [{
                     "_tpl": "59e36c6f86f774176c10a2a7",
                     "count": 2
                 }
             ]
         ],
         "a7fd9e6901ff9f0a95b106a8": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 12500
                 }
             ]
         ],
         "dd2bb0afe4e2ba47debab11c": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 725
                 }
             ]
         ],
         "db5ff86b7b75e2dde1047c3a": [
-            [
-                {
+            [{
                     "_tpl": "5a26ac06c4a282000c5a90a8",
                     "count": 4
                 }
             ]
         ],
         "f6a8a28ebfb759e0fc37bfd4": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 205
                 }
             ]
         ],
         "eeddbaba031b3f96b74dba96": [
-            [
-                {
+            [{
                     "_tpl": "56dff3afd2720bba668b4567",
                     "count": 3
                 }
             ]
         ],
         "335d2dbc72ece7c0536baeca": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 120
                 }
             ]
         ],
         "cae5752aa3ecab6b9ccd89a4": [
-            [
-                {
+            [{
                     "_tpl": "5a26abfac4a28232980eabff",
                     "count": 3
                 }
             ]
         ],
         "fa74ecbfebcfcb32fe692dbd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60
                 }
             ]
         ],
         "42bb63dfc8c40462c49fcec7": [
-            [
-                {
+            [{
                     "_tpl": "5a269f97c4a282000b151807",
                     "count": 5
                 }
             ]
         ],
         "b41a0bad056354fdd14de2e5": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 460
                 }
             ]
         ],
         "7cfec9cc8a48b1f4e1d55208": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1300
                 }
             ]
         ],
         "f7cafc93ff48d56f7864b5dd": [
-            [
-                {
+            [{
                     "_tpl": "5734781f24597737e04bf32a",
                     "count": 7
                 }
             ]
         ],
         "cfadc6fbf3d488abda498fdb": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 11500
                 }
             ]
         ],
         "a2efdd1780ef304db3cd336d": [
-            [
-                {
+            [{
                     "_tpl": "590c651286f7741e566b6461",
                     "count": 1
                 }
             ]
         ],
         "f8a58f6dfde99fafaacfa7cd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 42000
                 }
             ]
         ],
         "ba4167fb2272ac9af2ca104b": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 23500
                 }
             ]
         ],
         "b98cdb4c21f84340dc0eecec": [
-            [
-                {
+            [{
                     "_tpl": "5734773724597737fd047c14",
                     "count": 4
                 }
             ]
         ],
         "1d22a09a952d0371e416dacc": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 23500
                 }
             ]
         ],
         "5b0def9296a9f2ef8ecbca8c": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 42000
                 }
             ]
         ],
         "ecb1bdb04dcfbbc31452cafb": [
-            [
-                {
+            [{
                     "_tpl": "5b43271c5acfc432ff4dce65",
                     "count": 6
                 }
             ]
         ],
         "5a4f3ab67a1121acfe8a48b1": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 15000
                 }
             ]
         ],
         "36e467f8c6e72e8abafe64f3": [
-            [
-                {
+            [{
                     "_tpl": "5d1b3f2d86f774253763b735",
                     "count": 2
-                },
-                {
+                }, {
                     "_tpl": "5b4335ba86f7744d2837a264",
                     "count": 2
-                },
-                {
+                }, {
                     "_tpl": "590c695186f7741e566b64a2",
                     "count": 2
                 }
             ]
         ],
         "5b3ab061d60fd7fc173aaf3b": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 20000
                 }
             ]
         ],
         "ef6eff9ff72cf1af022856fc": [
-            [
-                {
+            [{
                     "_tpl": "5ed5160a87bb8443d10680b5",
                     "count": 1
-                },
-                {
+                }, {
                     "_tpl": "544fb37f4bdc2dee738b4567",
                     "count": 1
                 }
             ]
         ],
         "e6d31bb2dbe57dfca6ecb31b": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 34000
                 }
             ]
         ],
         "6df71db9db1adceeffa3fbeb": [
-            [
-                {
+            [{
                     "_tpl": "5c0e531286f7747fa54205c2",
                     "count": 1
-                },
-                {
+                }, {
                     "_tpl": "5ed515c8d380ab312177c0fa",
                     "count": 1
                 }
             ]
         ],
         "10a63721a6f9f3410de7b4cf": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 27000
                 }
             ]
         ],
         "9a6c9b7a1b763f3a054b266e": [
-            [
-                {
+            [{
                     "_tpl": "5e8488fa988a8701445df1e4",
                     "count": 2
-                },
-                {
+                }, {
                     "_tpl": "5d1b3f2d86f774253763b735",
                     "count": 2
-                },
-                {
+                }, {
                     "_tpl": "5755356824597772cb798962",
                     "count": 2
                 }
             ]
         ],
         "2dade6b16c22b26cfb488668": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 31000
                 }
             ]
         ],
         "e037c43eff00f637dbd4c5df": [
-            [
-                {
+            [{
                     "_tpl": "5c0e530286f7747fa1419862",
                     "count": 2
-                },
-                {
+                }, {
                     "_tpl": "5d403f9186f7743cac3f229b",
                     "count": 1
-                },
-                {
+                }, {
                     "_tpl": "544fb3f34bdc2d03748b456a",
                     "count": 2
                 }
             ]
         ],
         "e6bfec0008abd6e15b069fdf": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 35000
                 }
             ]
         ],
         "feccd499ae83cffc8fde0fa6": [
-            [
-                {
+            [{
                     "_tpl": "544fb3f34bdc2d03748b456a",
                     "count": 1
-                },
-                {
+                }, {
                     "_tpl": "5d1b3a5d86f774252167ba22",
                     "count": 4
                 }
             ]
         ],
         "ad638edd7a1aa4c278bae3de": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 30000
                 }
             ]
         ],
         "fec191eb6f7f5dacd57322ee": [
-            [
-                {
+            [{
                     "_tpl": "544fb45d4bdc2dee738b4568",
                     "count": 2
                 }
             ]
         ],
         "1ee092ec29c3cad8ebba19ca": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 42000
                 }
             ]
         ],
         "ffef96aaea2c43db5229145e": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 26000000
                 }
             ]
         ],
         "1df4e3dd2af0bda84f0cb06f": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 50000
                 }
             ]
         ],
         "efaf9ef33afa9d0a6f4af5e3": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 150000
                 }
             ]
         ],
         "b025e6c110d9fdcad0db075a": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 80000000
                 }
             ]
         ],
         "7325fbddeceff3d8e1a5c8ae": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5000000
                 }
             ]
         ],
         "f42e4e7b2957fbd6da8525d6": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 8000000
                 }
             ]
         ],
         "7c70e4df40fc3c5cd4a1ba1f": [
-            [
-                {
+            [{
                     "_tpl": "59faff1d86f7746c51718c9c",
                     "count": 1
                 }
             ]
         ],
         "b4dc3ff9d5cbaf5dacb4f58f": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 375000
                 }
             ]
         ],
         "7c6afdd5e9bafc1e9e546d9f": [
-            [
-                {
+            [{
                     "_tpl": "5734779624597737e04bf329",
                     "count": 2
                 }
             ]
         ],
         "c9b1a0fc5d3eaceffe1b74fe": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 11000
                 }
             ]
         ],
         "75bb11b0c4fc1dcc8e7de05f": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1500
                 }
             ]
         ],
         "67194e1598bd9759b9eba1c2": [
-            [
-                {
+            [{
                     "_tpl": "5cc80f67e4a949035e43bbba",
                     "count": 2
                 }
             ]
         ],
         "bc4191a2caeb2274eaee31ca": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 390
                 }
             ]
         ],
         "6f3bcaf9be7efb5a9cc6386e": [
-            [
-                {
+            [{
                     "_tpl": "5cc80f8fe4a949033b0224a2",
                     "count": 4
                 }
             ]
         ],
         "bbfdbf7e8c829bdaf01a24e2": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 250
                 }
             ]
         ],
         "9ffbbd4bd1cd72aae9ce79fa": [
-            [
-                {
+            [{
                     "_tpl": "5cc80f53e4a949000e1ea4f8",
                     "count": 2
                 }
             ]
         ],
         "a6db1c5dabbed0cb1da38f36": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 225
                 }
             ]
         ],
         "b9ce119cb82d40e1ad2b9dfb": [
-            [
-                {
+            [{
                     "_tpl": "5cc86832d7f00c000d3a6e6c",
                     "count": 2
                 }
             ]
         ],
         "d64e76d3adb9dee66fdcf4a0": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 66
                 }
             ]
         ],
         "7d9f1fbf02eb1b63ef9a91cf": [
-            [
-                {
+            [{
                     "_tpl": "5cc80f79e4a949033c7343b2",
                     "count": 3
                 }
             ]
         ],
         "a77a1d44b124aaf78bf413cb": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 130
                 }
             ]
         ],
         "bbcf627a3011fb7a9609a4bf": [
-            [
-                {
+            [{
                     "_tpl": "5cc86840d7f00c002412c56c",
                     "count": 3
                 }
             ]
         ],
         "8deef6d1b3234e09971c1fab": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 340
                 }
             ]
         ],
         "f7a696d2fe8a349d56b34ec9": [
-            [
-                {
+            [{
                     "_tpl": "59e4cf5286f7741778269d8a",
                     "count": 8
                 }
             ]
         ],
         "a0d4a64e2c2d3eccb3bd41fe": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 185
                 }
             ]
         ],
         "beb9f3ffaeadabfa84bd63c7": [
-            [
-                {
+            [{
                     "_tpl": "5d40419286f774318526545f",
                     "count": 2
                 }
             ]
         ],
         "8cbab7ee081cbd50f3ee9bbd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24000
                 }
             ]
         ],
         "fb783eba01beec33bcdcdb2b": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3100
                 }
             ]
         ],
         "cb6b0fad2e612f6354f9e2b2": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24000
                 }
             ]
         ],
         "1fffddf2426ada1efc09f219": [
-            [
-                {
+            [{
                     "_tpl": "57347c5b245977448d35f6e1",
                     "count": 5
                 }
             ]
         ],
         "c07efaad20cede5b63b77b3a": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 33000
                 }
             ]
         ],
         "8edbdea1febb00cf69e6e324": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 12000
                 }
             ]
         ],
         "4fdabd5c10fababd592cceac": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 950
                 }
             ]
         ],
         "ecaa6a29b754356b07eb0286": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 14000
                 }
             ]
         ],
         "09de143beaf8ded85d2130bc": [
-            [
-                {
+            [{
                     "_tpl": "5ed515ece452db0eb56fc028",
                     "count": 1
-                },
-                {
+                }, {
                     "_tpl": "590c695186f7741e566b64a2",
                     "count": 2
                 }
             ]
         ],
         "fa0ef0acde8adb6aaf9a8cda": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 30000
                 }
             ]
         ],
         "a8f087a77b26cba3e1d8f1d9": [
-            [
-                {
+            [{
                     "_tpl": "5d1b3f2d86f774253763b735",
                     "count": 2
-                },
-                {
+                }, {
                     "_tpl": "5b4335ba86f7744d2837a264",
                     "count": 2
-                },
-                {
+                }, {
                     "_tpl": "59e361e886f774176c10a2a5",
                     "count": 2
                 }
             ]
         ],
         "7d827f002dceb39a9ed88a3a": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 36000
                 }
             ]
         ],
         "65fc7dd29df6cebfc0de8c27": [
-            [
-                {
+            [{
                     "_tpl": "5d1b3f2d86f774253763b735",
                     "count": 2
-                },
-                {
+                }, {
                     "_tpl": "5b4335ba86f7744d2837a264",
                     "count": 2
-                },
-                {
+                }, {
                     "_tpl": "59e3606886f77417674759a5",
                     "count": 2
                 }
             ]
         ],
         "b8e69a07ef9effe19a22ffdd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 39000
                 }
             ]
         ],
         "5a3deddebcddac8a1feadba3": [
-            [
-                {
+            [{
                     "_tpl": "5c0e533786f7747fa23f4d47",
                     "count": 1
-                },
-                {
+                }, {
                     "_tpl": "59e361e886f774176c10a2a5",
                     "count": 2
                 }
             ]
         ],
         "ff8a0fbadfeaa1c454b4105d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 44000
                 }
             ]
         ],
         "a3ddd8acba327e0affbefbc3": [
-            [
-                {
+            [{
                     "_tpl": "5ed515c8d380ab312177c0fa",
                     "count": 1
-                },
-                {
+                }, {
                     "_tpl": "590c661e86f7741e566b646a",
                     "count": 2
-                },
-                {
+                }, {
                     "_tpl": "544fb3f34bdc2d03748b456a",
                     "count": 2
                 }
             ]
         ],
         "cdf7f18ffe59d5d44ecacc40": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 54000
                 }
             ]
         ],
         "cfabff3a2c751c1efd4f6483": [
-            [
-                {
+            [{
                     "_tpl": "5ed5166ad380ab312177c100",
                     "count": 1
-                },
-                {
+                }, {
                     "_tpl": "5d403f9186f7743cac3f229b",
                     "count": 1
-                },
-                {
+                }, {
                     "_tpl": "5751435d24597720a27126d1",
                     "count": 5
                 }
             ]
         ],
         "6116dd5beadd48eadbc4a2a7": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 42000
                 }
             ]
         ],
         "f196cf65e92c1f9c59b578fc": [
-            [
-                {
+            [{
                     "_tpl": "5c10c8fd86f7743d7d706df3",
                     "count": 2
-                },
-                {
+                }, {
                     "_tpl": "59e3606886f77417674759a5",
                     "count": 2
                 }
             ]
         ],
         "3e46eb2ceedee4916cfafd6b": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 58000
                 }
             ]
         ],
         "ea57bcb2aabde22ea6ffe5a4": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 250000
                 }
             ]
         ],
         "7e2bf94e29cf707e7f0b5ad8": [
-            [
-                {
+            [{
                     "_tpl": "57347cd0245977445a2d6ff1",
                     "count": 3
                 }
             ]
         ],
         "8e3ffa1c2a1bb3e7eb1543ab": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 18000
                 }
             ]
         ],
         "dfbdd6cbc2fbc48576e8f8d9": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1000
                 }
             ]
         ],
         "c27e4e7bb0cdc556dca031fc": [
-            [
-                {
+            [{
                     "_tpl": "573477e124597737dd42e191",
                     "count": 5
                 }
             ]
         ],
         "943b4c8e756cd15cdd8ed8b1": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 56000
                 }
             ]
         ],
         "c9b91dc803d3d547bada5a2f": [
-            [
-                {
+            [{
                     "_tpl": "544fb45d4bdc2dee738b4568",
                     "count": 2
-                },
-                {
+                }, {
                     "_tpl": "544fb3f34bdc2d03748b456a",
                     "count": 2
-                },
-                {
+                }, {
                     "_tpl": "5d1b3f2d86f774253763b735",
                     "count": 2
                 }
             ]
         ],
         "7f1f7bdf3aac7ea2effe7a5d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 75000
                 }
             ]
         ],
         "eabfedc9aae68d071e3bba45": [
-            [
-                {
+            [{
                     "_tpl": "5c0e531286f7747fa54205c2",
                     "count": 2
-                },
-                {
+                }, {
                     "_tpl": "5ed515e03a40a50460332579",
                     "count": 2
                 }
             ]
         ],
         "eaf7c2c7bbaf1bb808a84a0b": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 82000
                 }
             ]
         ],
         "aabcec9052e82ab98e259acf": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1200
                 }
             ]
         ],
         "7381a6f08346819bccccac84": [
-            [
-                {
+            [{
                     "_tpl": "5d235b4d86f7742e017bc88a",
                     "count": 1
                 }
             ]
         ],
         "b6acdfe7eaa7cdb2bfa2af5e": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 14000
                 }
             ]
         ],
         "fafeafaf9e86834f07cbef8c": [
-            [
-                {
+            [{
                     "_tpl": "5d1b392c86f77425243e98fe",
                     "count": 4
                 }
             ]
         ],
         "8958ba634c1bf3dd1d0ce6eb": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24000
                 }
             ]
         ],
         "aaaa7a8a7368208a87fabaa7": [
-            [
-                {
+            [{
                     "_tpl": "619cc01e0a7c3a1a2731940c",
                     "count": 3
                 }
             ]
         ],
         "82943a8a8b5b8e8386735044": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 21000
                 }
             ]
         ],
         "f6f8094cc6edeaff15378dfd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1900
                 }
             ]
         ],
         "bbcc98abb8cf958dff59dabf": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "a826dd99cc0fc4fa7aaefc60": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 120
                 }
             ]
         ],
         "dd2c394a33df33a9ab02d4ba": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "bcfeebcba4bcc6a76c73ed27": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 105
                 }
             ]
         ],
         "0f4dd0176004f90d09f9fec7": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "ca3cc8458daeb8e42a44bedc": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 155
                 }
             ]
         ],
         "9f2b65add7a7286acdd6c5f5": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "dcbce2cd8d82cade6ab01a75": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 85
                 }
             ]
         ],
         "f9aae57fcbece367d1736061": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "7ca7aa12aeb5d9eac16762e5": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 660
                 }
             ]
         ],
         "ecc7c755adf0faa2eecd3aee": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "ae684f0007f84bc01b82f9ca": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 225
                 }
             ]
         ],
         "931ad09dd17e74913aa1cbed": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "f202753efa000776a00fca31": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 75000
                 }
             ]
         ],
         "621cc07ca2f746f925a8c14a": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "cc0e369bad5bddf6ecff95bc": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 32000
                 }
             ]
         ],
         "97fcb8491d0c7a8ed026c9ab": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "7b5cacfc5ce7cef9b86d5dc7": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 16000
                 }
             ]
         ],
         "e967ded978ed55ad21c2b969": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "b15a058dfddeaca379a4dd9d": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 11500
                 }
             ]
         ],
         "cfeefce853c48bd197474d5c": [
-            [
-                {
+            [{
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "0fb0f7f6c18e8694b0d1c2f3": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 6600
                 }
             ]
         ],
         "03b702156dbdd4bd86b91cef": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1500
                 }
             ]
         ],
         "2281fcc678f0cd6fc510cddd": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2100
                 }
             ]
         ],
         "b763aacb3415f3ae25e6cb89": [
-            [
-                {
+            [{
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2500
                 }
             ]
         ]
     },
-    "items": [
-        {
+    "items": [{
             "_id": "feccd499ae83cffc8fde0fa6",
             "_tpl": "5c10c8fd86f7743d7d706df3",
             "parentId": "hideout",
@@ -1757,8 +1526,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "9a6c9b7a1b763f3a054b266e",
             "_tpl": "5c0e533786f7747fa23f4d47",
             "parentId": "hideout",
@@ -1769,8 +1537,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "65fc7dd29df6cebfc0de8c27",
             "_tpl": "5ed515ece452db0eb56fc028",
             "parentId": "hideout",
@@ -1781,8 +1548,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "09de143beaf8ded85d2130bc",
             "_tpl": "5ed515c8d380ab312177c0fa",
             "parentId": "hideout",
@@ -1793,8 +1559,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "5a3deddebcddac8a1feadba3",
             "_tpl": "5ed515f6915ec335206e4152",
             "parentId": "hideout",
@@ -1805,8 +1570,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "36e467f8c6e72e8abafe64f3",
             "_tpl": "5c0e530286f7747fa1419862",
             "parentId": "hideout",
@@ -1817,8 +1581,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a8f087a77b26cba3e1d8f1d9",
             "_tpl": "5ed515e03a40a50460332579",
             "parentId": "hideout",
@@ -1829,8 +1592,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f196cf65e92c1f9c59b578fc",
             "_tpl": "5ed5166ad380ab312177c100",
             "parentId": "hideout",
@@ -1841,8 +1603,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c9b91dc803d3d547bada5a2f",
             "_tpl": "5fca138c2a7b221b2852a5c6",
             "parentId": "hideout",
@@ -1853,8 +1614,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a3ddd8acba327e0affbefbc3",
             "_tpl": "5ed5160a87bb8443d10680b5",
             "parentId": "hideout",
@@ -1865,8 +1625,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ef6eff9ff72cf1af022856fc",
             "_tpl": "5c0e531286f7747fa54205c2",
             "parentId": "hideout",
@@ -1877,8 +1636,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "6df71db9db1adceeffa3fbeb",
             "_tpl": "5c0e531d86f7747fa23f4d42",
             "parentId": "hideout",
@@ -1889,8 +1647,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "eabfedc9aae68d071e3bba45",
             "_tpl": "5fca13ca637ee0341a484f46",
             "parentId": "hideout",
@@ -1901,8 +1658,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "cfabff3a2c751c1efd4f6483",
             "_tpl": "5ed51652f6c34d2cc26336a1",
             "parentId": "hideout",
@@ -1913,8 +1669,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e037c43eff00f637dbd4c5df",
             "_tpl": "5c0e534186f7747fa1419867",
             "parentId": "hideout",
@@ -1925,8 +1680,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ad638edd7a1aa4c278bae3de",
             "_tpl": "5c10c8fd86f7743d7d706df3",
             "parentId": "hideout",
@@ -1937,8 +1691,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "2dade6b16c22b26cfb488668",
             "_tpl": "5c0e533786f7747fa23f4d47",
             "parentId": "hideout",
@@ -1949,8 +1702,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b8e69a07ef9effe19a22ffdd",
             "_tpl": "5ed515ece452db0eb56fc028",
             "parentId": "hideout",
@@ -1961,8 +1713,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fa0ef0acde8adb6aaf9a8cda",
             "_tpl": "5ed515c8d380ab312177c0fa",
             "parentId": "hideout",
@@ -1973,8 +1724,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ff8a0fbadfeaa1c454b4105d",
             "_tpl": "5ed515f6915ec335206e4152",
             "parentId": "hideout",
@@ -1985,8 +1735,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "5b3ab061d60fd7fc173aaf3b",
             "_tpl": "5c0e530286f7747fa1419862",
             "parentId": "hideout",
@@ -1997,8 +1746,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7d827f002dceb39a9ed88a3a",
             "_tpl": "5ed515e03a40a50460332579",
             "parentId": "hideout",
@@ -2009,8 +1757,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "3e46eb2ceedee4916cfafd6b",
             "_tpl": "5ed5166ad380ab312177c100",
             "parentId": "hideout",
@@ -2021,8 +1768,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7f1f7bdf3aac7ea2effe7a5d",
             "_tpl": "5fca138c2a7b221b2852a5c6",
             "parentId": "hideout",
@@ -2033,8 +1779,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "cdf7f18ffe59d5d44ecacc40",
             "_tpl": "5ed5160a87bb8443d10680b5",
             "parentId": "hideout",
@@ -2045,8 +1790,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e6d31bb2dbe57dfca6ecb31b",
             "_tpl": "5c0e531286f7747fa54205c2",
             "parentId": "hideout",
@@ -2057,8 +1801,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "10a63721a6f9f3410de7b4cf",
             "_tpl": "5c0e531d86f7747fa23f4d42",
             "parentId": "hideout",
@@ -2069,8 +1812,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "eaf7c2c7bbaf1bb808a84a0b",
             "_tpl": "5fca13ca637ee0341a484f46",
             "parentId": "hideout",
@@ -2081,8 +1823,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "6116dd5beadd48eadbc4a2a7",
             "_tpl": "5ed51652f6c34d2cc26336a1",
             "parentId": "hideout",
@@ -2093,8 +1834,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e6bfec0008abd6e15b069fdf",
             "_tpl": "5c0e534186f7747fa1419867",
             "parentId": "hideout",
@@ -2105,8 +1845,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7c70e4df40fc3c5cd4a1ba1f",
             "_tpl": "5c94bbff86f7747ee735c08f",
             "parentId": "hideout",
@@ -2117,8 +1856,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b4dc3ff9d5cbaf5dacb4f58f",
             "_tpl": "5c94bbff86f7747ee735c08f",
             "parentId": "hideout",
@@ -2129,8 +1867,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ea57bcb2aabde22ea6ffe5a4",
             "_tpl": "5efde6b4f5448336730dbd61",
             "parentId": "hideout",
@@ -2141,8 +1878,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7325fbddeceff3d8e1a5c8ae",
             "_tpl": "5c1d0f4986f7744bb01837fa",
             "parentId": "hideout",
@@ -2153,8 +1889,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ffef96aaea2c43db5229145e",
             "_tpl": "5c1d0c5f86f7744bb2683cf0",
             "parentId": "hideout",
@@ -2165,8 +1900,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "efaf9ef33afa9d0a6f4af5e3",
             "_tpl": "5c1d0dc586f7744baf2e7b79",
             "parentId": "hideout",
@@ -2177,8 +1911,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b025e6c110d9fdcad0db075a",
             "_tpl": "5c1d0efb86f7744baf2e7b7b",
             "parentId": "hideout",
@@ -2189,8 +1922,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f42e4e7b2957fbd6da8525d6",
             "_tpl": "5c1e495a86f7743109743dfb",
             "parentId": "hideout",
@@ -2201,8 +1933,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "1df4e3dd2af0bda84f0cb06f",
             "_tpl": "5c1d0d6d86f7744bb2683e1f",
             "parentId": "hideout",
@@ -2213,8 +1944,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f7a696d2fe8a349d56b34ec9",
             "_tpl": "5cc86840d7f00c002412c56c",
             "parentId": "hideout",
@@ -2225,8 +1955,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bbcf627a3011fb7a9609a4bf",
             "_tpl": "5cc86832d7f00c000d3a6e6c",
             "parentId": "hideout",
@@ -2237,8 +1966,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b9ce119cb82d40e1ad2b9dfb",
             "_tpl": "5cc80f79e4a949033c7343b2",
             "parentId": "hideout",
@@ -2249,8 +1977,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7d9f1fbf02eb1b63ef9a91cf",
             "_tpl": "5cc80f8fe4a949033b0224a2",
             "parentId": "hideout",
@@ -2261,8 +1988,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "6f3bcaf9be7efb5a9cc6386e",
             "_tpl": "5cc80f53e4a949000e1ea4f8",
             "parentId": "hideout",
@@ -2273,8 +1999,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "9ffbbd4bd1cd72aae9ce79fa",
             "_tpl": "5cc80f67e4a949035e43bbba",
             "parentId": "hideout",
@@ -2285,8 +2010,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "67194e1598bd9759b9eba1c2",
             "_tpl": "5cc80f38e4a949001152b560",
             "parentId": "hideout",
@@ -2297,8 +2021,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a0d4a64e2c2d3eccb3bd41fe",
             "_tpl": "5cc86840d7f00c002412c56c",
             "parentId": "hideout",
@@ -2309,8 +2032,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "8deef6d1b3234e09971c1fab",
             "_tpl": "5cc86832d7f00c000d3a6e6c",
             "parentId": "hideout",
@@ -2321,8 +2043,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d64e76d3adb9dee66fdcf4a0",
             "_tpl": "5cc80f79e4a949033c7343b2",
             "parentId": "hideout",
@@ -2333,8 +2054,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a77a1d44b124aaf78bf413cb",
             "_tpl": "5cc80f8fe4a949033b0224a2",
             "parentId": "hideout",
@@ -2345,8 +2065,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bbfdbf7e8c829bdaf01a24e2",
             "_tpl": "5cc80f53e4a949000e1ea4f8",
             "parentId": "hideout",
@@ -2357,8 +2076,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a6db1c5dabbed0cb1da38f36",
             "_tpl": "5cc80f67e4a949035e43bbba",
             "parentId": "hideout",
@@ -2369,8 +2087,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bc4191a2caeb2274eaee31ca",
             "_tpl": "5cc80f38e4a949001152b560",
             "parentId": "hideout",
@@ -2381,8 +2098,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fb1a52f738e38a1cefe9c4db",
             "_tpl": "5735fdcd2459776445391d61",
             "parentId": "hideout",
@@ -2393,8 +2109,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "915aeeb8c2ffdacff1bb0d20",
             "_tpl": "5735ff5c245977640e39ba7e",
             "parentId": "hideout",
@@ -2405,8 +2120,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "8dd4bb045cd23b6cae8626d4",
             "_tpl": "5736026a245977644601dc61",
             "parentId": "hideout",
@@ -2417,8 +2131,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "8e6b439cb29ff8c6f2e39ad1",
             "_tpl": "573603c924597764442bd9cb",
             "parentId": "hideout",
@@ -2429,8 +2142,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ecaa6a29b754356b07eb0286",
             "_tpl": "5ea034f65aad6446a939737e",
             "parentId": "hideout",
@@ -2441,8 +2153,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bfb8abf507ada6d60d8fbc07",
             "_tpl": "573602322459776445391df1",
             "parentId": "hideout",
@@ -2453,8 +2164,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ca14ca194a60716cafa23f02",
             "_tpl": "573601b42459776410737435",
             "parentId": "hideout",
@@ -2465,8 +2175,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f8c1b5b1cea294edd8aae8ce",
             "_tpl": "573603562459776430731618",
             "parentId": "hideout",
@@ -2477,8 +2186,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e7198dc8ba1dd4d8be5de271",
             "_tpl": "5735fdcd2459776445391d61",
             "parentId": "hideout",
@@ -2489,8 +2197,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "5a5d16fd31babae6facbbd33",
             "_tpl": "5735ff5c245977640e39ba7e",
             "parentId": "hideout",
@@ -2501,8 +2208,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d2b3dbbffc6d93efc5aadee7",
             "_tpl": "5736026a245977644601dc61",
             "parentId": "hideout",
@@ -2513,8 +2219,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d7a03b44cbedfb164faa6568",
             "_tpl": "573603c924597764442bd9cb",
             "parentId": "hideout",
@@ -2525,8 +2230,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "df0feb4c5e5ec8bda641de13",
             "_tpl": "573602322459776445391df1",
             "parentId": "hideout",
@@ -2537,8 +2241,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "de2be0eb3ac652ce4fbc145d",
             "_tpl": "573601b42459776410737435",
             "parentId": "hideout",
@@ -2549,8 +2252,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "086ee00585e6fffe9c49a94e",
             "_tpl": "573603562459776430731618",
             "parentId": "hideout",
@@ -2561,8 +2263,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b70ea8cfd98f44efddcb7ec9",
             "_tpl": "573719762459775a626ccbc1",
             "parentId": "hideout",
@@ -2573,8 +2274,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e311ead52063d21d4d7cedcd",
             "_tpl": "573724b42459776125652ac2",
             "parentId": "hideout",
@@ -2585,14 +2285,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a67fc7c3bdacc083023cba0a",
             "_tpl": "573719762459775a626ccbc1",
             "parentId": "e311ead52063d21d4d7cedcd",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 16
+            }
+        }, {
             "_id": "ceae16d808bbe67f0fa7b6a0",
             "_tpl": "57371f8d24597761006c6a81",
             "parentId": "hideout",
@@ -2603,8 +2305,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f447b102bd5acfbc207eb149",
             "_tpl": "5737273924597765dd374461",
             "parentId": "hideout",
@@ -2615,14 +2316,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e88baa68c97af2ccece35bde",
             "_tpl": "57371f8d24597761006c6a81",
             "parentId": "f447b102bd5acfbc207eb149",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 16
+            }
+        }, {
             "_id": "bbfadaa86f4cdbd0c086dadb",
             "_tpl": "57371f2b24597761224311f1",
             "parentId": "hideout",
@@ -2633,8 +2336,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "2efde2abb2baf3ae1ff2ff4a",
             "_tpl": "573726d824597765d96be361",
             "parentId": "hideout",
@@ -2645,14 +2347,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b55fb66ba6edbe04cd477ab7",
             "_tpl": "57371f2b24597761224311f1",
             "parentId": "2efde2abb2baf3ae1ff2ff4a",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 16
+            }
+        }, {
             "_id": "1fb4b1cf54aca1271f0894b5",
             "_tpl": "57371eb62459776125652ac1",
             "parentId": "hideout",
@@ -2663,8 +2367,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b42cc6376a1904a1febe235a",
             "_tpl": "5737266524597761006c6a8c",
             "parentId": "hideout",
@@ -2675,14 +2378,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fddd521cbb50c0beffbc75e8",
             "_tpl": "57371eb62459776125652ac1",
             "parentId": "b42cc6376a1904a1febe235a",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 16
+            }
+        }, {
             "_id": "fb6d6d563facc7f8b9e633bd",
             "_tpl": "57371e4124597760ff7b25f1",
             "parentId": "hideout",
@@ -2693,8 +2398,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e1bbeed79f7fea0dfa12d80b",
             "_tpl": "5737260b24597761224311f2",
             "parentId": "hideout",
@@ -2705,14 +2409,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "46cfee7d4becddfb2adc8aaf",
             "_tpl": "57371e4124597760ff7b25f1",
             "parentId": "e1bbeed79f7fea0dfa12d80b",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 16
+            }
+        }, {
             "_id": "44dc7035bc97bc6cc5dcc383",
             "_tpl": "57371b192459775a9f58a5e0",
             "parentId": "hideout",
@@ -2723,8 +2429,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "dfc0bc12fc570ccec1ffabbd",
             "_tpl": "573725b0245977612125bae2",
             "parentId": "hideout",
@@ -2735,14 +2440,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a0d3a13f4daf8c829d42e073",
             "_tpl": "57371b192459775a9f58a5e0",
             "parentId": "dfc0bc12fc570ccec1ffabbd",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 16
+            }
+        }, {
             "_id": "c5e8f7eff6cdb0bf95ddadc2",
             "_tpl": "5737201124597760fc4431f1",
             "parentId": "hideout",
@@ -2753,8 +2460,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c2ae85b817d44dbeccd1f8ee",
             "_tpl": "573727c624597765cc785b5b",
             "parentId": "hideout",
@@ -2765,14 +2471,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "9b9cebaa12cba1fcbf17c986",
             "_tpl": "5737201124597760fc4431f1",
             "parentId": "c2ae85b817d44dbeccd1f8ee",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 16
+            }
+        }, {
             "_id": "c0cd0cd5d6fc2bca97e78fac",
             "_tpl": "5737218f245977612125ba51",
             "parentId": "hideout",
@@ -2783,8 +2491,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "3581cfb9a4b12786e6edec65",
             "_tpl": "573728f324597765e5728561",
             "parentId": "hideout",
@@ -2795,14 +2502,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "75429bba600f19fcbfb1bc6b",
             "_tpl": "5737218f245977612125ba51",
             "parentId": "3581cfb9a4b12786e6edec65",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 16
+            }
+        }, {
             "_id": "8d7203ba6b66cc3c4b201ff5",
             "_tpl": "57d1519e24597714373db79d",
             "parentId": "hideout",
@@ -2813,8 +2522,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "470bae3f55f0debfbb94a46b",
             "_tpl": "5737207f24597760ff7b25f2",
             "parentId": "hideout",
@@ -2825,8 +2533,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d0ebab7adbcd6e4abd3e0b6a",
             "_tpl": "5737280e24597765cc785b5c",
             "parentId": "hideout",
@@ -2837,14 +2544,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d869fbeda45f6da5d4e8bf0b",
             "_tpl": "5737207f24597760ff7b25f2",
             "parentId": "d0ebab7adbcd6e4abd3e0b6a",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 16
+            }
+        }, {
             "_id": "0edcf83e0494db293b0417fd",
             "_tpl": "573720e02459776143012541",
             "parentId": "hideout",
@@ -2855,8 +2564,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7acfff1f46adfbcef1e5f760",
             "_tpl": "5737287724597765e1625ae2",
             "parentId": "hideout",
@@ -2867,14 +2575,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "22cc0416b5d9aa81c20ba5ef",
             "_tpl": "573720e02459776143012541",
             "parentId": "7acfff1f46adfbcef1e5f760",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 16
+            }
+        }, {
             "_id": "fefe0d415e3f871fc23539fa",
             "_tpl": "57372140245977611f70ee91",
             "parentId": "hideout",
@@ -2885,8 +2595,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "dcf10a6a92e1a9b36540f0e3",
             "_tpl": "573728cc24597765cc785b5d",
             "parentId": "hideout",
@@ -2897,14 +2606,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "9573cec812b4ce0eb0d7e1cc",
             "_tpl": "57372140245977611f70ee91",
             "parentId": "dcf10a6a92e1a9b36540f0e3",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 16
+            }
+        }, {
             "_id": "bcefecbc9938df34a4b9ccca",
             "_tpl": "573718ba2459775a75491131",
             "parentId": "hideout",
@@ -2915,8 +2626,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "2bf6fa9ebcfa2fa7a597aa89",
             "_tpl": "573722e82459776104581c21",
             "parentId": "hideout",
@@ -2927,14 +2637,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "68ec8105cedc2875d08dc20e",
             "_tpl": "573718ba2459775a75491131",
             "parentId": "2bf6fa9ebcfa2fa7a597aa89",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 16
+            }
+        }, {
             "_id": "fed0f57ea117d4dfd7ebaf0e",
             "_tpl": "55d485be4bdc2d962f8b456f",
             "parentId": "hideout",
@@ -2945,8 +2657,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "3d3aff70ebf8fcee2feaef19",
             "_tpl": "57371aab2459775a77142f22",
             "parentId": "hideout",
@@ -2957,8 +2668,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a31fdb5d730cc4abc1359222",
             "_tpl": "5737256c2459776125652acd",
             "parentId": "hideout",
@@ -2969,14 +2679,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ddbc0e5daef9b13bb2cb5401",
-            "_tpl": "57371aab2459775a77142f22",
+            "_tpl": "573722e82459776104581c21",
             "parentId": "a31fdb5d730cc4abc1359222",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 16
+            }
+        }, {
             "_id": "b09decf5006aef30bc6b81d9",
             "_tpl": "573719df2459775a626ccbc2",
             "parentId": "hideout",
@@ -2987,10 +2699,9 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "94ab28efe9871ded5c716c82",
-            "_tpl": "5737250c2459776125652acc",
+            "_tpl": "573722e82459776104581c21",
             "parentId": "hideout",
             "slotId": "hideout",
             "upd": {
@@ -2999,14 +2710,16 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c1ae74dfd3013ff9caac782b",
             "_tpl": "573719df2459775a626ccbc2",
             "parentId": "94ab28efe9871ded5c716c82",
-            "slotId": "cartridges"
-        },
-        {
+            "slotId": "cartridges",
+            "location": 0,
+            "upd": {
+                "StackObjectsCount": 16
+            }
+        }, {
             "_id": "cd74e02d515cbceddedbe4d0",
             "_tpl": "573719762459775a626ccbc1",
             "parentId": "hideout",
@@ -3017,8 +2730,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e224f506ebadcb69be0f0c09",
             "_tpl": "57371f8d24597761006c6a81",
             "parentId": "hideout",
@@ -3029,8 +2741,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "65b379bb5c3fe44c00e9fbd9",
             "_tpl": "57371f2b24597761224311f1",
             "parentId": "hideout",
@@ -3041,8 +2752,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "11f451f96ec3bf5bcfbbb40d",
             "_tpl": "57371eb62459776125652ac1",
             "parentId": "hideout",
@@ -3053,8 +2763,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "4dc2c96e5d3e3231f51e7df6",
             "_tpl": "57371e4124597760ff7b25f1",
             "parentId": "hideout",
@@ -3065,8 +2774,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "dca3fc1a711ba7321847b21a",
             "_tpl": "57371b192459775a9f58a5e0",
             "parentId": "hideout",
@@ -3077,8 +2785,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fdbfda26046c99eacda24230",
             "_tpl": "5737201124597760fc4431f1",
             "parentId": "hideout",
@@ -3089,8 +2796,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "58a9aafc80d40a7eb0fc02bd",
             "_tpl": "5737218f245977612125ba51",
             "parentId": "hideout",
@@ -3101,8 +2807,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "df65013e31dffb8dfad3536f",
             "_tpl": "5737207f24597760ff7b25f2",
             "parentId": "hideout",
@@ -3113,8 +2818,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "dcfe5a0eea4daf9dd0c322be",
             "_tpl": "573720e02459776143012541",
             "parentId": "hideout",
@@ -3125,8 +2829,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d5fac2c7a2188bae4313e918",
             "_tpl": "57372140245977611f70ee91",
             "parentId": "hideout",
@@ -3137,8 +2840,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "44ed1accafdaaed4ee3a0e16",
             "_tpl": "573718ba2459775a75491131",
             "parentId": "hideout",
@@ -3149,8 +2851,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ebde2ceaef7d9ebbee06aa7d",
             "_tpl": "57371aab2459775a77142f22",
             "parentId": "hideout",
@@ -3161,8 +2862,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fbb8cf1dff9bec9bbedd88f1",
             "_tpl": "573719df2459775a626ccbc2",
             "parentId": "hideout",
@@ -3173,8 +2873,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "eeddbaba031b3f96b74dba96",
             "_tpl": "5a26abfac4a28232980eabff",
             "parentId": "hideout",
@@ -3185,8 +2884,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "cae5752aa3ecab6b9ccd89a4",
             "_tpl": "5a26ac06c4a282000c5a90a8",
             "parentId": "hideout",
@@ -3197,8 +2895,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "db5ff86b7b75e2dde1047c3a",
             "_tpl": "5a269f97c4a282000b151807",
             "parentId": "hideout",
@@ -3209,8 +2906,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "42bb63dfc8c40462c49fcec7",
             "_tpl": "5a26ac0ec4a28200741e1e18",
             "parentId": "hideout",
@@ -3221,8 +2917,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "335d2dbc72ece7c0536baeca",
             "_tpl": "5a26abfac4a28232980eabff",
             "parentId": "hideout",
@@ -3233,8 +2928,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fa74ecbfebcfcb32fe692dbd",
             "_tpl": "5a26ac06c4a282000c5a90a8",
             "parentId": "hideout",
@@ -3245,8 +2939,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f6a8a28ebfb759e0fc37bfd4",
             "_tpl": "5a269f97c4a282000b151807",
             "parentId": "hideout",
@@ -3257,8 +2950,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b41a0bad056354fdd14de2e5",
             "_tpl": "5a26ac0ec4a28200741e1e18",
             "parentId": "hideout",
@@ -3269,8 +2961,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ecb1bdb04dcfbbc31452cafb",
             "_tpl": "5b432b965acfc47a8774094e",
             "parentId": "hideout",
@@ -3281,8 +2972,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fafeafaf9e86834f07cbef8c",
             "_tpl": "6033fa48ffd42c541047f728",
             "parentId": "hideout",
@@ -3293,8 +2983,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fec191eb6f7f5dacd57322ee",
             "_tpl": "5c165d832e2216398b5a7e36",
             "parentId": "hideout",
@@ -3305,8 +2994,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "83f84aa7f1d5baa8375f2ea6",
             "_tpl": "5645bcc04bdc2d363b8b4572",
             "parentId": "hideout",
@@ -3317,8 +3005,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a2efdd1780ef304db3cd336d",
             "_tpl": "5aa2ba71e5b5b000137b758f",
             "parentId": "hideout",
@@ -3329,8 +3016,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "3c9f0e8134cb86cea7faab5e",
             "_tpl": "5a16b9fffcdbcb0176308b34",
             "parentId": "hideout",
@@ -3341,8 +3027,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "1fffddf2426ada1efc09f219",
             "_tpl": "5e4d34ca86f774264f758330",
             "parentId": "hideout",
@@ -3353,8 +3038,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c27e4e7bb0cdc556dca031fc",
             "_tpl": "5f60cd6cf2bcbb675b00dac6",
             "parentId": "hideout",
@@ -3365,8 +3049,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "5a4f3ab67a1121acfe8a48b1",
             "_tpl": "5b432b965acfc47a8774094e",
             "parentId": "hideout",
@@ -3377,8 +3060,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "8958ba634c1bf3dd1d0ce6eb",
             "_tpl": "6033fa48ffd42c541047f728",
             "parentId": "hideout",
@@ -3389,8 +3071,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "1ee092ec29c3cad8ebba19ca",
             "_tpl": "5c165d832e2216398b5a7e36",
             "parentId": "hideout",
@@ -3401,8 +3082,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b6ad0c8fee8849dfacdcad1b",
             "_tpl": "5645bcc04bdc2d363b8b4572",
             "parentId": "hideout",
@@ -3413,8 +3093,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f8a58f6dfde99fafaacfa7cd",
             "_tpl": "5aa2ba71e5b5b000137b758f",
             "parentId": "hideout",
@@ -3425,8 +3104,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a7d97272bfab4233d4a7a61b",
             "_tpl": "5a16b9fffcdbcb0176308b34",
             "parentId": "hideout",
@@ -3437,8 +3115,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c07efaad20cede5b63b77b3a",
             "_tpl": "5e4d34ca86f774264f758330",
             "parentId": "hideout",
@@ -3449,8 +3126,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "943b4c8e756cd15cdd8ed8b1",
             "_tpl": "5f60cd6cf2bcbb675b00dac6",
             "parentId": "hideout",
@@ -3461,8 +3137,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7c6afdd5e9bafc1e9e546d9f",
             "_tpl": "5cadc190ae921500103bb3b6",
             "parentId": "hideout",
@@ -3473,50 +3148,42 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "da51efda5c4873d3220bfbc6",
             "_tpl": "5cadc1c6ae9215000f2775a4",
             "parentId": "7c6afdd5e9bafc1e9e546d9f",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "f28fefcfdf8fda274acbfa72",
             "_tpl": "5cadc390ae921500126a77f1",
             "parentId": "da51efda5c4873d3220bfbc6",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "af79ffeef3e7a87afbe75bdd",
             "_tpl": "5cadc431ae921500113bb8d5",
             "parentId": "7c6afdd5e9bafc1e9e546d9f",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "c4b8988b1fb92ae99fca94a4",
             "_tpl": "5cadc55cae921500103bb3be",
             "parentId": "7c6afdd5e9bafc1e9e546d9f",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "ea0acf27cfe4fbfafbf4af9c",
             "_tpl": "5cadd940ae9215051e1c2316",
             "parentId": "c4b8988b1fb92ae99fca94a4",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "5bfe14c7fafe1bb8c0e4badb",
             "_tpl": "5cadd919ae921500126a77f3",
             "parentId": "c4b8988b1fb92ae99fca94a4",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "1afde0fcf7c97ea8bdc3f054",
             "_tpl": "5cadc2e0ae9215051e1c21e7",
             "parentId": "7c6afdd5e9bafc1e9e546d9f",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "274abdae1feb2ac1add7fafd",
             "_tpl": "579204f224597773d619e051",
             "parentId": "hideout",
@@ -3527,32 +3194,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d45",
-          "_tpl": "5448c12b4bdc2d02308b456f",
-          "parentId": "274abdae1feb2ac1add7fafd",
-          "slotId": "mod_magazine"
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d46",
-          "_tpl": "6374a822e629013b9c0645c8",
-          "parentId": "274abdae1feb2ac1add7fafd",
-          "slotId": "mod_reciever"
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d47",
-          "_tpl": "63c6adcfb4ba094317063742",
-          "parentId": "6670e6bb622e80dbf3056d46",
-          "slotId": "mod_sight_rear"
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d48",
-          "_tpl": "6374a7e7417239a7bf00f042",
-          "parentId": "274abdae1feb2ac1add7fafd",
-          "slotId": "mod_pistolgrip"
-        },
-        {
+        }, {
+            "_id": "6670e6bb622e80dbf3056d45",
+            "_tpl": "5448c12b4bdc2d02308b456f",
+            "parentId": "274abdae1feb2ac1add7fafd",
+            "slotId": "mod_magazine"
+        }, {
+            "_id": "6670e6bb622e80dbf3056d46",
+            "_tpl": "6374a822e629013b9c0645c8",
+            "parentId": "274abdae1feb2ac1add7fafd",
+            "slotId": "mod_reciever"
+        }, {
+            "_id": "6670e6bb622e80dbf3056d47",
+            "_tpl": "63c6adcfb4ba094317063742",
+            "parentId": "6670e6bb622e80dbf3056d46",
+            "slotId": "mod_sight_rear"
+        }, {
+            "_id": "6670e6bb622e80dbf3056d48",
+            "_tpl": "6374a7e7417239a7bf00f042",
+            "parentId": "274abdae1feb2ac1add7fafd",
+            "slotId": "mod_pistolgrip"
+        }, {
             "_id": "aa0de437e1a4dfaa7f4e8bc6",
             "_tpl": "571a12c42459771f627b58a0",
             "parentId": "hideout",
@@ -3563,26 +3225,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "210e30dce8abe6d10ebfa5c6",
             "_tpl": "571a26d524597720680fbe8a",
             "parentId": "aa0de437e1a4dfaa7f4e8bc6",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "0efe2ef5bc47c9eebc2e9a28",
             "_tpl": "571a282c2459771fb2755a69",
             "parentId": "aa0de437e1a4dfaa7f4e8bc6",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "9d2d59694fcdd24d0b6aeccf",
             "_tpl": "571a29dc2459771fb2755a6a",
             "parentId": "aa0de437e1a4dfaa7f4e8bc6",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "6d88bd83d9eadaf199fe607e",
             "_tpl": "571a29dc2459771fb2755a6a",
             "parentId": "hideout",
@@ -3593,8 +3251,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e5dddfb1dfaf5efd25d66bb5",
             "_tpl": "5448c12b4bdc2d02308b456f",
             "parentId": "hideout",
@@ -3605,8 +3262,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "75bb11b0c4fc1dcc8e7de05f",
             "_tpl": "5cadc2e0ae9215051e1c21e7",
             "parentId": "hideout",
@@ -3617,8 +3273,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "df3bca39d57fb7dd5ad84bae",
             "_tpl": "576a581d2459771e7b1bc4f1",
             "parentId": "hideout",
@@ -3629,20 +3284,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7515cefbcdb420ebf3a6c9e4",
             "_tpl": "576a5ed62459771e9c2096cb",
             "parentId": "df3bca39d57fb7dd5ad84bae",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "eea7a6e95e92ff7aac039ba1",
             "_tpl": "576a63cd2459771e796e0e11",
             "parentId": "df3bca39d57fb7dd5ad84bae",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "f7cafc93ff48d56f7864b5dd",
             "_tpl": "5a7ae0c351dfba0017554310",
             "parentId": "hideout",
@@ -3653,38 +3305,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a9e271ebe0691bb6ab5021ce",
             "_tpl": "5a6b5f868dc32e000a311389",
             "parentId": "f7cafc93ff48d56f7864b5dd",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "c9b4b6c0238cb5f0ba3de95c",
             "_tpl": "5a6f5d528dc32e00094b97d9",
             "parentId": "acfa0e23a24e4bbe9c1ff10d",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "4fc8f6a5cc11622ab08bd0dd",
             "_tpl": "5a6f58f68dc32e000a311390",
             "parentId": "acfa0e23a24e4bbe9c1ff10d",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "acfa0e23a24e4bbe9c1ff10d",
             "_tpl": "5a6f5e048dc32e00094b97da",
             "parentId": "f7cafc93ff48d56f7864b5dd",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "daf3f9a638fccb061b9dc5ff",
             "_tpl": "5a718b548dc32e000d46d262",
             "parentId": "f7cafc93ff48d56f7864b5dd",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "cdbae4551d855b106e710592",
             "_tpl": "56d59856d2720bd8418b456a",
             "parentId": "hideout",
@@ -3695,44 +3341,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bb0a8f977bcac81bdf15efe5",
             "_tpl": "56d5a1f7d2720bb3418b456a",
             "parentId": "cdbae4551d855b106e710592",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "58ee58dc404baddccb9df07f",
             "_tpl": "56d5a2bbd2720bb8418b456a",
             "parentId": "cdbae4551d855b106e710592",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "4bbe1edcd1cea8cee0cee15a",
             "_tpl": "56d5a77ed2720b90418b4568",
             "parentId": "cda553b8dbd1afe1c9e8ee2d",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "43bf9d2fa5ba4f74b0f9224f",
             "_tpl": "56d5a661d2720bd8418b456b",
             "parentId": "cda553b8dbd1afe1c9e8ee2d",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "cda553b8dbd1afe1c9e8ee2d",
             "_tpl": "56d5a407d2720bb3418b456b",
             "parentId": "cdbae4551d855b106e710592",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "67be4d1bafac3b9ae5c7500d",
             "_tpl": "56d59948d2720bb7418b4582",
             "parentId": "cdbae4551d855b106e710592",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "cc4bbc4118a8e9df8fbba40f",
             "_tpl": "576a5ed62459771e9c2096cb",
             "parentId": "hideout",
@@ -3743,8 +3382,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "1e8aa11dffada086c5068dc8",
             "_tpl": "56d59948d2720bb7418b4582",
             "parentId": "hideout",
@@ -3755,8 +3393,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7cfec9cc8a48b1f4e1d55208",
             "_tpl": "5a718b548dc32e000d46d262",
             "parentId": "hideout",
@@ -3767,8 +3404,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7e2bf94e29cf707e7f0b5ad8",
             "_tpl": "5f36a0e5fbf956000b716b65",
             "parentId": "hideout",
@@ -3779,62 +3415,52 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "dcf2de83c9dec72f85fcf5fe",
             "_tpl": "5f3e7801153b8571434a924c",
             "parentId": "7e2bf94e29cf707e7f0b5ad8",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "9de2edd1e92c1f6f1956dae5",
             "_tpl": "5f3e778efcd9b651187d7201",
             "parentId": "7e2bf94e29cf707e7f0b5ad8",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "8eb0e67a2bdeb2ed78d5ed65",
             "_tpl": "5f3e7823ddc4f03b010e2045",
             "parentId": "7e2bf94e29cf707e7f0b5ad8",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "27ddcdeca6fed2c3eddfcda0",
             "_tpl": "5f3e7897ddc4f03b010e204a",
             "parentId": "8eb0e67a2bdeb2ed78d5ed65",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "0b4ae2e71acd65cdd3acec1b",
             "_tpl": "5f3e78a7fbf956000b716b8e",
             "parentId": "8eb0e67a2bdeb2ed78d5ed65",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "03a00baf5de13002a0732e91",
             "_tpl": "5f3e77b26cda304dcc634057",
             "parentId": "7e2bf94e29cf707e7f0b5ad8",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "4eab8df33c075cec5b9caedc",
             "_tpl": "5f3e772a670e2a7b01739a52",
             "parentId": "7e2bf94e29cf707e7f0b5ad8",
             "slotId": "mod_trigger"
-        },
-        {
+        }, {
             "_id": "cba70583c5dacaea3a2bbb1f",
             "_tpl": "5f3e76d86cda304dcc634054",
             "parentId": "7e2bf94e29cf707e7f0b5ad8",
             "slotId": "mod_hammer"
-        },
-        {
+        }, {
             "_id": "f5d04441fed5b937f0cb9b33",
             "_tpl": "5f3e777688ca2d00ad199d25",
             "parentId": "7e2bf94e29cf707e7f0b5ad8",
             "slotId": "mod_catch"
-        },
-        {
+        }, {
             "_id": "aaaa7a8a7368208a87fabaa7",
             "_tpl": "6193a720f8ee7e52e42109ed",
             "parentId": "hideout",
@@ -3845,68 +3471,57 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "fe8c3f1e8abb478eef9da321",
             "_tpl": "6194efe07c6c7b169525f11b",
             "parentId": "aaaa7a8a7368208a87fabaa7",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "e7bcb15cafbfff7a8b5bca47",
             "_tpl": "6194f1f918a3974e5e7421e4",
             "parentId": "fe8c3f1e8abb478eef9da321",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "032d5eb22640a6d41ed7f17d",
             "_tpl": "6194f41f9fb0c665d5490e75",
             "parentId": "aaaa7a8a7368208a87fabaa7",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "4f8fa5b09bec8ab50c0a41cc",
             "_tpl": "6194f2df645b5d229654ad77",
             "parentId": "032d5eb22640a6d41ed7f17d",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "e7fcb508fb713f0127d69a1d",
             "_tpl": "6194f3286db0f2477964e67d",
             "parentId": "032d5eb22640a6d41ed7f17d",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "ccc30bdcca1bfe2066fabb71",
             "_tpl": "6193d3149fb0c665d5490e32",
             "parentId": "aaaa7a8a7368208a87fabaa7",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "72926eb1acbc8d8cccd7dc8b",
             "_tpl": "6193d3cded0429009f543e6a",
             "parentId": "aaaa7a8a7368208a87fabaa7",
             "slotId": "mod_trigger"
-        },
-        {
+        }, {
             "_id": "a3d43a04e83ca0b70fde1c12",
             "_tpl": "6193d3be7c6c7b169525f0da",
             "parentId": "aaaa7a8a7368208a87fabaa7",
             "slotId": "mod_hammer"
-        },
-        {
+        }, {
             "_id": "8fc119d84a36bfb93115eefb",
             "_tpl": "6193d5d4f8ee7e52e4210a1b",
             "parentId": "aaaa7a8a7368208a87fabaa7",
             "slotId": "mod_catch"
-        },
-        {
+        }, {
             "_id": "05fd21344a52dafc795ad58a",
             "_tpl": "6196255558ef8c428c287d1c",
             "parentId": "aaaa7a8a7368208a87fabaa7",
             "slotId": "mod_mount_000"
-        },
-        {
+        }, {
             "_id": "d01a690a010ef47f25eed3f5",
             "_tpl": "5a17f98cfcdbcb0980087290",
             "parentId": "hideout",
@@ -3917,32 +3532,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "edd4aaad55ecadcbb0dba96c",
             "_tpl": "5a17fb03fcdbcbcae668728f",
             "parentId": "d01a690a010ef47f25eed3f5",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "7bbc4fbebae7b0d8cefbaf7f",
             "_tpl": "5a17fc70fcdbcb0176308b3d",
             "parentId": "d01a690a010ef47f25eed3f5",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "db0b0216eb9dbacc4cdd93d3",
             "_tpl": "5aba62f8d8ce87001943946b",
             "parentId": "d01a690a010ef47f25eed3f5",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "7a8c2aed9448f34b5bd5efb5",
             "_tpl": "5aba637ad8ce87001773e17f",
             "parentId": "d01a690a010ef47f25eed3f5",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "7381a6f08346819bccccac84",
             "_tpl": "602a9740da11d6478d5a06dc",
             "parentId": "hideout",
@@ -3953,38 +3563,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f57c6cd5bf8da81bd4fce6eb",
             "_tpl": "602a95edda11d6478d5a06da",
             "parentId": "7381a6f08346819bccccac84",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "b74810dcefdac62d7fb30aaf",
             "_tpl": "60228924961b8d75ee233c32",
             "parentId": "7381a6f08346819bccccac84",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "de5bdcf99b0aaaeae7ddbe46",
             "_tpl": "60229948cacb6b0506369e27",
             "parentId": "b74810dcefdac62d7fb30aaf",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "d3d3fb57c51c0cbfca41a034",
             "_tpl": "60228a76d62c9b14ed777a66",
             "parentId": "b74810dcefdac62d7fb30aaf",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "f88574377cbbe2fd781ce1dc",
             "_tpl": "602286df23506e50807090c6",
             "parentId": "7381a6f08346819bccccac84",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "4fdabd5c10fababd592cceac",
             "_tpl": "5e81c4ca763d9f754677befa",
             "parentId": "hideout",
@@ -3995,8 +3599,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "dfbdd6cbc2fbc48576e8f8d9",
             "_tpl": "5f3e77b26cda304dcc634057",
             "parentId": "hideout",
@@ -4007,8 +3610,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "dd2bb0afe4e2ba47debab11c",
             "_tpl": "5a17fb03fcdbcbcae668728f",
             "parentId": "hideout",
@@ -4019,8 +3621,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "aabcec9052e82ab98e259acf",
             "_tpl": "602286df23506e50807090c6",
             "parentId": "hideout",
@@ -4031,8 +3632,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f6f8094cc6edeaff15378dfd",
             "_tpl": "6193d338de3cdf1d2614a6fc",
             "parentId": "hideout",
@@ -4043,8 +3643,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "beb9f3ffaeadabfa84bd63c7",
             "_tpl": "5d3eb3b0a4b93615055e84d2",
             "parentId": "hideout",
@@ -4055,38 +3654,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ceda1534de69e167d46eddee",
             "_tpl": "5d3eb5b6a4b9361eab311902",
             "parentId": "beb9f3ffaeadabfa84bd63c7",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "e4be2c4e0dc5a743baa8ccbd",
             "_tpl": "5d3eb44aa4b93650d64e4979",
             "parentId": "beb9f3ffaeadabfa84bd63c7",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "cdaf17abc3f33c3791aed617",
             "_tpl": "5d3eb4aba4b93650d64e497d",
             "parentId": "e4be2c4e0dc5a743baa8ccbd",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "3edcabaaae5d2cd8d8710ee3",
             "_tpl": "5d3eb536a4b9363b1f22f8e2",
             "parentId": "e4be2c4e0dc5a743baa8ccbd",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "596fb2f637f2b898df3f4fd9",
             "_tpl": "5d3eb5eca4b9363b1f22f8e4",
             "parentId": "beb9f3ffaeadabfa84bd63c7",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "b98cdb4c21f84340dc0eecec",
             "_tpl": "5b1fa9b25acfc40018633c01",
             "parentId": "hideout",
@@ -4097,38 +3690,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7caeadffee0222a8a3a2791d",
             "_tpl": "5b1fa9ea5acfc40018633c0a",
             "parentId": "b98cdb4c21f84340dc0eecec",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "8b2cecf81fe3aa3c52c2c072",
             "_tpl": "5b1faa0f5acfc40dc528aeb5",
             "parentId": "b98cdb4c21f84340dc0eecec",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "de4f96d3ebbadbfe48999ad9",
             "_tpl": "5a6f5d528dc32e00094b97d9",
             "parentId": "8b2cecf81fe3aa3c52c2c072",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "a47cbaadfaa74cb44f387f9b",
             "_tpl": "5a6f58f68dc32e000a311390",
             "parentId": "8b2cecf81fe3aa3c52c2c072",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "b4eff2ebc24e1c9eeaed33f6",
             "_tpl": "5a718b548dc32e000d46d262",
             "parentId": "b98cdb4c21f84340dc0eecec",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "937e5a4cf8ecc4218ce9bedc",
             "_tpl": "59f98b4986f7746f546d2cef",
             "parentId": "hideout",
@@ -4139,14 +3726,12 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "6b9e1a5512472bf5ed1aaf1e",
             "_tpl": "59f99a7d86f7745b134aa97b",
             "parentId": "937e5a4cf8ecc4218ce9bedc",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "fb783eba01beec33bcdcdb2b",
             "_tpl": "5d3eb5eca4b9363b1f22f8e4",
             "parentId": "hideout",
@@ -4157,8 +3742,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "189b44fcb7eeab81cee03fec",
             "_tpl": "59f99a7d86f7745b134aa97b",
             "parentId": "hideout",
@@ -4169,8 +3753,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c9b1a0fc5d3eaceffe1b74fe",
             "_tpl": "5cadc190ae921500103bb3b6",
             "parentId": "hideout",
@@ -4181,50 +3764,42 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ab5cdbdd12a4faa0eceadcdc",
             "_tpl": "5cadc1c6ae9215000f2775a4",
             "parentId": "c9b1a0fc5d3eaceffe1b74fe",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "331d4ce41b81a5fd0b84ccfb",
             "_tpl": "5cadc390ae921500126a77f1",
             "parentId": "ab5cdbdd12a4faa0eceadcdc",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "a35e5bc8ccf266727515af71",
             "_tpl": "5cadc431ae921500113bb8d5",
             "parentId": "c9b1a0fc5d3eaceffe1b74fe",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "4121f3cbeb458d78bc18f48c",
             "_tpl": "5cadc55cae921500103bb3be",
             "parentId": "c9b1a0fc5d3eaceffe1b74fe",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "b4fd3b21dffd9a75fe2b2b62",
             "_tpl": "5cadd940ae9215051e1c2316",
             "parentId": "4121f3cbeb458d78bc18f48c",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "4ffe7da64e219ff9ad7efda0",
             "_tpl": "5cadd919ae921500126a77f3",
             "parentId": "4121f3cbeb458d78bc18f48c",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "e560991cf8defede9a72db87",
             "_tpl": "5cadc2e0ae9215051e1c21e7",
             "parentId": "c9b1a0fc5d3eaceffe1b74fe",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "fbe55784d196ee9d82b8dda3",
             "_tpl": "579204f224597773d619e051",
             "parentId": "hideout",
@@ -4235,32 +3810,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d51",
-          "_tpl": "5448c12b4bdc2d02308b456f",
-          "parentId": "fbe55784d196ee9d82b8dda3",
-          "slotId": "mod_magazine"
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d52",
-          "_tpl": "6374a822e629013b9c0645c8",
-          "parentId": "fbe55784d196ee9d82b8dda3",
-          "slotId": "mod_reciever"
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d53",
-          "_tpl": "63c6adcfb4ba094317063742",
-          "parentId": "6670e6bb622e80dbf3056d52",
-          "slotId": "mod_sight_rear"
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d54",
-          "_tpl": "6374a7e7417239a7bf00f042",
-          "parentId": "fbe55784d196ee9d82b8dda3",
-          "slotId": "mod_pistolgrip"
-        },
-        {
+        }, {
+            "_id": "6670e6bb622e80dbf3056d51",
+            "_tpl": "5448c12b4bdc2d02308b456f",
+            "parentId": "fbe55784d196ee9d82b8dda3",
+            "slotId": "mod_magazine"
+        }, {
+            "_id": "6670e6bb622e80dbf3056d52",
+            "_tpl": "6374a822e629013b9c0645c8",
+            "parentId": "fbe55784d196ee9d82b8dda3",
+            "slotId": "mod_reciever"
+        }, {
+            "_id": "6670e6bb622e80dbf3056d53",
+            "_tpl": "63c6adcfb4ba094317063742",
+            "parentId": "6670e6bb622e80dbf3056d52",
+            "slotId": "mod_sight_rear"
+        }, {
+            "_id": "6670e6bb622e80dbf3056d54",
+            "_tpl": "6374a7e7417239a7bf00f042",
+            "parentId": "fbe55784d196ee9d82b8dda3",
+            "slotId": "mod_pistolgrip"
+        }, {
             "_id": "3a9cb7a0affcffd85acd25f8",
             "_tpl": "5448bd6b4bdc2dfc2f8b4569",
             "parentId": "hideout",
@@ -4271,32 +3841,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d3a",
-          "_tpl": "5448c12b4bdc2d02308b456f",
-          "parentId": "3a9cb7a0affcffd85acd25f8",
-          "slotId": "mod_magazine"
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d3b",
-          "_tpl": "6374a822e629013b9c0645c8",
-          "parentId": "3a9cb7a0affcffd85acd25f8",
-          "slotId": "mod_reciever"
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d3c",
-          "_tpl": "63c6adcfb4ba094317063742",
-          "parentId": "6670e6bb622e80dbf3056d3b",
-          "slotId": "mod_sight_rear"
-        },
-        {
-          "_id": "6670e6bb622e80dbf3056d3d",
-          "_tpl": "6374a7e7417239a7bf00f042",
-          "parentId": "3a9cb7a0affcffd85acd25f8",
-          "slotId": "mod_pistolgrip"
-        },
-        {
+        }, {
+            "_id": "6670e6bb622e80dbf3056d3a",
+            "_tpl": "5448c12b4bdc2d02308b456f",
+            "parentId": "3a9cb7a0affcffd85acd25f8",
+            "slotId": "mod_magazine"
+        }, {
+            "_id": "6670e6bb622e80dbf3056d3b",
+            "_tpl": "6374a822e629013b9c0645c8",
+            "parentId": "3a9cb7a0affcffd85acd25f8",
+            "slotId": "mod_reciever"
+        }, {
+            "_id": "6670e6bb622e80dbf3056d3c",
+            "_tpl": "63c6adcfb4ba094317063742",
+            "parentId": "6670e6bb622e80dbf3056d3b",
+            "slotId": "mod_sight_rear"
+        }, {
+            "_id": "6670e6bb622e80dbf3056d3d",
+            "_tpl": "6374a7e7417239a7bf00f042",
+            "parentId": "3a9cb7a0affcffd85acd25f8",
+            "slotId": "mod_pistolgrip"
+        }, {
             "_id": "d3644926fee7bda253bcb1a5",
             "_tpl": "56e0598dd2720bb5668b45a6",
             "parentId": "hideout",
@@ -4307,26 +3872,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "88ac8f0c7b60d1bf21f56ad3",
             "_tpl": "5448c12b4bdc2d02308b456f",
             "parentId": "d3644926fee7bda253bcb1a5",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "b39a4bf8ddecbaa41ced2bfb",
             "_tpl": "56e05b06d2720bb2668b4586",
             "parentId": "d3644926fee7bda253bcb1a5",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "bbaa9ebd66bdb20c53e41fc6",
             "_tpl": "56e05a6ed2720bd0748b4567",
             "parentId": "d3644926fee7bda253bcb1a5",
             "slotId": "mod_pistolgrip"
-        },
-        {
+        }, {
             "_id": "820211af1bb0cce1ecb026b2",
             "_tpl": "571a12c42459771f627b58a0",
             "parentId": "hideout",
@@ -4337,26 +3898,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "48acad9f2a2b9bbfc966f2ca",
             "_tpl": "571a26d524597720680fbe8a",
             "parentId": "820211af1bb0cce1ecb026b2",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "1cb5acdfd6acc7f9a71bdb5f",
             "_tpl": "571a282c2459771fb2755a69",
             "parentId": "820211af1bb0cce1ecb026b2",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "7bbdffaa9e020a0b69aca41b",
             "_tpl": "571a29dc2459771fb2755a6a",
             "parentId": "820211af1bb0cce1ecb026b2",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "5b0def9296a9f2ef8ecbca8c",
             "_tpl": "5b3b713c5acfc4330140bd8d",
             "parentId": "hideout",
@@ -4367,26 +3924,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "14ae613d9828dec76ad591f2",
             "_tpl": "5b3baf8f5acfc40dc5296692",
             "parentId": "5b0def9296a9f2ef8ecbca8c",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "eb0ebb4dfa9e2cbf8f5e3cde",
             "_tpl": "5b3cadf35acfc400194776a0",
             "parentId": "5b0def9296a9f2ef8ecbca8c",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "5f6d56c9aa2a1deea4badada",
             "_tpl": "571a29dc2459771fb2755a6a",
             "parentId": "5b0def9296a9f2ef8ecbca8c",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "ee565bb7e3ecda6bcafbd514",
             "_tpl": "576a581d2459771e7b1bc4f1",
             "parentId": "hideout",
@@ -4397,20 +3950,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "5ffb53e9a049bda75dd2de2f",
             "_tpl": "576a5ed62459771e9c2096cb",
             "parentId": "ee565bb7e3ecda6bcafbd514",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "950f4eaddfb25c5ab4fa7d9a",
             "_tpl": "576a63cd2459771e796e0e11",
             "parentId": "ee565bb7e3ecda6bcafbd514",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "cfadc6fbf3d488abda498fdb",
             "_tpl": "5a7ae0c351dfba0017554310",
             "parentId": "hideout",
@@ -4421,38 +3971,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "af5aadde9c6de56eba2ba8dc",
             "_tpl": "5a6b5f868dc32e000a311389",
             "parentId": "cfadc6fbf3d488abda498fdb",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "981cfcca93af4bd03ea4cdb2",
             "_tpl": "5a6f5d528dc32e00094b97d9",
             "parentId": "fe5fd3b4e22950bff35e987b",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "4a0ccd9292eeaafc139d56d3",
             "_tpl": "5a6f58f68dc32e000a311390",
             "parentId": "fe5fd3b4e22950bff35e987b",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "fe5fd3b4e22950bff35e987b",
             "_tpl": "5a6f5e048dc32e00094b97da",
             "parentId": "cfadc6fbf3d488abda498fdb",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "1db8da3defe52950facea2be",
             "_tpl": "5a718b548dc32e000d46d262",
             "parentId": "cfadc6fbf3d488abda498fdb",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "eeeda5e0c30acab2387b89db",
             "_tpl": "56d59856d2720bd8418b456a",
             "parentId": "hideout",
@@ -4463,44 +4007,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "dbabaeabf92d0352c4fce93f",
             "_tpl": "56d5a1f7d2720bb3418b456a",
             "parentId": "eeeda5e0c30acab2387b89db",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "fee4ef2cba9e9bedefff9247",
             "_tpl": "56d5a2bbd2720bb8418b456a",
             "parentId": "eeeda5e0c30acab2387b89db",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "ed4aaae97ec775482f09894c",
             "_tpl": "56d5a77ed2720b90418b4568",
             "parentId": "b93adfe9bca1e5c1b74a5cf0",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "fe0ad0102ebca6deb2954d0f",
             "_tpl": "56d5a661d2720bd8418b456b",
             "parentId": "b93adfe9bca1e5c1b74a5cf0",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "b93adfe9bca1e5c1b74a5cf0",
             "_tpl": "56d5a407d2720bb3418b456b",
             "parentId": "eeeda5e0c30acab2387b89db",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "81bcefef5a4d5edbfa6370b6",
             "_tpl": "56d59948d2720bb7418b4582",
             "parentId": "eeeda5e0c30acab2387b89db",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "8e3ffa1c2a1bb3e7eb1543ab",
             "_tpl": "5f36a0e5fbf956000b716b65",
             "parentId": "hideout",
@@ -4511,62 +4048,52 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "c1adeedacaed103dec1b4d6a",
             "_tpl": "5f3e7801153b8571434a924c",
             "parentId": "8e3ffa1c2a1bb3e7eb1543ab",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "8ae3b91cfb91d93db2427d60",
             "_tpl": "5f3e778efcd9b651187d7201",
             "parentId": "8e3ffa1c2a1bb3e7eb1543ab",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "d0c6bd64d696371b4ffdfbfb",
             "_tpl": "5f3e7823ddc4f03b010e2045",
             "parentId": "8e3ffa1c2a1bb3e7eb1543ab",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "d275e2fa6c6fc2bdfd999daf",
             "_tpl": "5f3e7897ddc4f03b010e204a",
             "parentId": "d0c6bd64d696371b4ffdfbfb",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "28532d760731cbffdcd18207",
             "_tpl": "5f3e78a7fbf956000b716b8e",
             "parentId": "d0c6bd64d696371b4ffdfbfb",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "24f40bbf15cfc53bcddcd86f",
             "_tpl": "5f3e77b26cda304dcc634057",
             "parentId": "8e3ffa1c2a1bb3e7eb1543ab",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "47edab1c71c42feb2f5d4a5e",
             "_tpl": "5f3e772a670e2a7b01739a52",
             "parentId": "8e3ffa1c2a1bb3e7eb1543ab",
             "slotId": "mod_trigger"
-        },
-        {
+        }, {
             "_id": "3cc0ff9ec8ab6a474e7d1417",
             "_tpl": "5f3e76d86cda304dcc634054",
             "parentId": "8e3ffa1c2a1bb3e7eb1543ab",
             "slotId": "mod_hammer"
-        },
-        {
+        }, {
             "_id": "ffe27ca19c6ce73babc00cdb",
             "_tpl": "5f3e777688ca2d00ad199d25",
             "parentId": "8e3ffa1c2a1bb3e7eb1543ab",
             "slotId": "mod_catch"
-        },
-        {
+        }, {
             "_id": "8edbdea1febb00cf69e6e324",
             "_tpl": "5e81c3cbac2bb513793cdc75",
             "parentId": "hideout",
@@ -4577,62 +4104,52 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "94bef44fd20389e2fdd68f83",
             "_tpl": "5e81c519cb2b95385c177551",
             "parentId": "8edbdea1febb00cf69e6e324",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "afdcc1f4c1ea8d5cceb95b9b",
             "_tpl": "5e81c6bf763d9f754677beff",
             "parentId": "8edbdea1febb00cf69e6e324",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "ab95dfd3ca82ebb2d8a91db2",
             "_tpl": "5e81edc13397a21db957f6a1",
             "parentId": "8edbdea1febb00cf69e6e324",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "ffb17abb39cbf0eecd33838f",
             "_tpl": "5e81ee4dcb2b95385c177582",
             "parentId": "ab95dfd3ca82ebb2d8a91db2",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "46dcaadff40ba1f3a91b95e9",
             "_tpl": "5e81ee213397a21db957f6a6",
             "parentId": "ab95dfd3ca82ebb2d8a91db2",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "19cda7d4fb65ccf7eaea4bce",
             "_tpl": "5e81c4ca763d9f754677befa",
             "parentId": "8edbdea1febb00cf69e6e324",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "abaa1983649b1a856b6cc3e0",
             "_tpl": "5e81c6a2ac2bb513793cdc7f",
             "parentId": "8edbdea1febb00cf69e6e324",
             "slotId": "mod_trigger"
-        },
-        {
+        }, {
             "_id": "bbea479ec825bec6adf59ad5",
             "_tpl": "5e81c550763d9f754677befd",
             "parentId": "8edbdea1febb00cf69e6e324",
             "slotId": "mod_hammer"
-        },
-        {
+        }, {
             "_id": "2073a48c1cfdfa05d5af00cd",
             "_tpl": "5e81c539cb2b95385c177553",
             "parentId": "8edbdea1febb00cf69e6e324",
             "slotId": "mod_catch"
-        },
-        {
+        }, {
             "_id": "82943a8a8b5b8e8386735044",
             "_tpl": "6193a720f8ee7e52e42109ed",
             "parentId": "hideout",
@@ -4643,68 +4160,57 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "26e8ff23e571bad4dbe6ff65",
             "_tpl": "6194efe07c6c7b169525f11b",
             "parentId": "82943a8a8b5b8e8386735044",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "827b3b714d763e2c52fdd4a2",
             "_tpl": "6194f1f918a3974e5e7421e4",
             "parentId": "26e8ff23e571bad4dbe6ff65",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "16c0edadaea6c7ef7ecaaeec",
             "_tpl": "6194f41f9fb0c665d5490e75",
             "parentId": "82943a8a8b5b8e8386735044",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "cbbb7c83dc8daface9f9e3cc",
             "_tpl": "6194f2df645b5d229654ad77",
             "parentId": "16c0edadaea6c7ef7ecaaeec",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "22e1ab2a7629c8421ea6a0b2",
             "_tpl": "6194f3286db0f2477964e67d",
             "parentId": "16c0edadaea6c7ef7ecaaeec",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "3bac47c730ad5efba6fdf8bb",
             "_tpl": "6193d3149fb0c665d5490e32",
             "parentId": "82943a8a8b5b8e8386735044",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "ad37db1fed87c217ec2a7a5c",
             "_tpl": "6193d3cded0429009f543e6a",
             "parentId": "82943a8a8b5b8e8386735044",
             "slotId": "mod_trigger"
-        },
-        {
+        }, {
             "_id": "cc50d0bc9df6bd6066cac713",
             "_tpl": "6193d3be7c6c7b169525f0da",
             "parentId": "82943a8a8b5b8e8386735044",
             "slotId": "mod_hammer"
-        },
-        {
+        }, {
             "_id": "5efeaa4ea6315f23cddeeba5",
             "_tpl": "6193d5d4f8ee7e52e4210a1b",
             "parentId": "82943a8a8b5b8e8386735044",
             "slotId": "mod_catch"
-        },
-        {
+        }, {
             "_id": "2fbfeb1f67f573ce17c89a14",
             "_tpl": "6196255558ef8c428c287d1c",
             "parentId": "82943a8a8b5b8e8386735044",
             "slotId": "mod_mount_000"
-        },
-        {
+        }, {
             "_id": "a7fd9e6901ff9f0a95b106a8",
             "_tpl": "5a17f98cfcdbcb0980087290",
             "parentId": "hideout",
@@ -4715,32 +4221,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f117294ddfdd7d5e262ebafb",
             "_tpl": "5a17fb03fcdbcbcae668728f",
             "parentId": "a7fd9e6901ff9f0a95b106a8",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "2897e96b66bf170da6e5be94",
             "_tpl": "5a17fc70fcdbcb0176308b3d",
             "parentId": "a7fd9e6901ff9f0a95b106a8",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "e9f92f9a0d1a2db690ce5ea5",
             "_tpl": "5aba62f8d8ce87001943946b",
             "parentId": "a7fd9e6901ff9f0a95b106a8",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "1b762d3ad383abbd415e1e89",
             "_tpl": "5aba637ad8ce87001773e17f",
             "parentId": "a7fd9e6901ff9f0a95b106a8",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "ba4167fb2272ac9af2ca104b",
             "_tpl": "5abccb7dd8ce87001773e277",
             "parentId": "hideout",
@@ -4751,44 +4252,37 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "dfcf9adcce522cbfcced69fa",
             "_tpl": "5a17fb03fcdbcbcae668728f",
             "parentId": "ba4167fb2272ac9af2ca104b",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "cafcef992b57350fc0940a23",
             "_tpl": "5a17fb9dfcdbcbcae6687291",
             "parentId": "ba4167fb2272ac9af2ca104b",
             "slotId": "mod_stock"
-        },
-        {
+        }, {
             "_id": "96abfae916a42bec9aea66f0",
             "_tpl": "5a17fc70fcdbcb0176308b3d",
             "parentId": "ba4167fb2272ac9af2ca104b",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "6cfbe2fefd239783deabbf5c",
             "_tpl": "5aba62f8d8ce87001943946b",
             "parentId": "ba4167fb2272ac9af2ca104b",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "61ebb18d923afccb3b17b6dc",
             "_tpl": "5aba639ed8ce8700182ece67",
             "parentId": "ba4167fb2272ac9af2ca104b",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "fa4c23302e813b7df1b09396",
             "_tpl": "5abcc328d8ce8700194394f3",
             "parentId": "ba4167fb2272ac9af2ca104b",
             "slotId": "mod_muzzle"
-        },
-        {
+        }, {
             "_id": "b6acdfe7eaa7cdb2bfa2af5e",
             "_tpl": "602a9740da11d6478d5a06dc",
             "parentId": "hideout",
@@ -4799,38 +4293,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "6fdd2c985edda9181eb29ac5",
             "_tpl": "602a95edda11d6478d5a06da",
             "parentId": "b6acdfe7eaa7cdb2bfa2af5e",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "af64cd6dbd9ffcedcdb9ba82",
             "_tpl": "60228924961b8d75ee233c32",
             "parentId": "b6acdfe7eaa7cdb2bfa2af5e",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "c5bcbbbd744fa0fc9e257632",
             "_tpl": "60229948cacb6b0506369e27",
             "parentId": "af64cd6dbd9ffcedcdb9ba82",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "3a8daa58442077b2a62adfb4",
             "_tpl": "60228a76d62c9b14ed777a66",
             "parentId": "af64cd6dbd9ffcedcdb9ba82",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "97ac04c2bf581b6af49aa9f3",
             "_tpl": "602286df23506e50807090c6",
             "parentId": "b6acdfe7eaa7cdb2bfa2af5e",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "8cbab7ee081cbd50f3ee9bbd",
             "_tpl": "5d3eb3b0a4b93615055e84d2",
             "parentId": "hideout",
@@ -4841,38 +4329,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ad8f3e9afb2cfb2abdcfcbcf",
             "_tpl": "5d3eb5b6a4b9361eab311902",
             "parentId": "8cbab7ee081cbd50f3ee9bbd",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "efbb6829ffe8ff38ffb14efd",
             "_tpl": "5d3eb44aa4b93650d64e4979",
             "parentId": "8cbab7ee081cbd50f3ee9bbd",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "c5aaac2c8fe9ace6a55f5c8c",
             "_tpl": "5d3eb4aba4b93650d64e497d",
             "parentId": "efbb6829ffe8ff38ffb14efd",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "c288220b80a69aa5fadb7829",
             "_tpl": "5d3eb536a4b9363b1f22f8e2",
             "parentId": "efbb6829ffe8ff38ffb14efd",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "a0fea8cd9c03fc3b9a34bc11",
             "_tpl": "5d3eb5eca4b9363b1f22f8e4",
             "parentId": "8cbab7ee081cbd50f3ee9bbd",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "cb6b0fad2e612f6354f9e2b2",
             "_tpl": "5d67abc1a4b93614ec50137f",
             "parentId": "hideout",
@@ -4883,38 +4365,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bac2fec01dead7af3a95a707",
             "_tpl": "5d3eb5b6a4b9361eab311902",
             "parentId": "cb6b0fad2e612f6354f9e2b2",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "3add8e40729761c2c9eb73f9",
             "_tpl": "5d3eb44aa4b93650d64e4979",
             "parentId": "cb6b0fad2e612f6354f9e2b2",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "ffc8af4febdfb12e3c8c8be4",
             "_tpl": "5d3eb4aba4b93650d64e497d",
             "parentId": "3add8e40729761c2c9eb73f9",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "d0afe19e3c2aeb252dc31301",
             "_tpl": "5d3eb536a4b9363b1f22f8e2",
             "parentId": "3add8e40729761c2c9eb73f9",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "97aeedb19d48fd2fdf0db84c",
             "_tpl": "5d3eb5eca4b9363b1f22f8e4",
             "parentId": "cb6b0fad2e612f6354f9e2b2",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "1d22a09a952d0371e416dacc",
             "_tpl": "5b1fa9b25acfc40018633c01",
             "parentId": "hideout",
@@ -4925,38 +4401,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "cb8a99c84e30eea86bab5d9d",
             "_tpl": "5b1fa9ea5acfc40018633c0a",
             "parentId": "1d22a09a952d0371e416dacc",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "750a55cdfdaedc07d5639da3",
             "_tpl": "5b1faa0f5acfc40dc528aeb5",
             "parentId": "1d22a09a952d0371e416dacc",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "f781add6bfa66fc68ed1a5bf",
             "_tpl": "5a6f5d528dc32e00094b97d9",
             "parentId": "750a55cdfdaedc07d5639da3",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "2d3ef9d8cc0ef4ae6a0eef4b",
             "_tpl": "5a6f58f68dc32e000a311390",
             "parentId": "750a55cdfdaedc07d5639da3",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "f68f40f7d6bcf8ecae95d108",
             "_tpl": "5a718b548dc32e000d46d262",
             "parentId": "1d22a09a952d0371e416dacc",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "3e7f422c138ef7375ffe785c",
             "_tpl": "59f98b4986f7746f546d2cef",
             "parentId": "hideout",
@@ -4967,14 +4437,12 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "e92e4b346bb869dff4aa4aad",
             "_tpl": "59f99a7d86f7745b134aa97b",
             "parentId": "3e7f422c138ef7375ffe785c",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "bbcc98abb8cf958dff59dabf",
             "_tpl": "62330b3ed4dc74626d570b95",
             "parentId": "hideout",
@@ -4985,8 +4453,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a826dd99cc0fc4fa7aaefc60",
             "_tpl": "62330b3ed4dc74626d570b95",
             "parentId": "hideout",
@@ -4997,8 +4464,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "dd2c394a33df33a9ab02d4ba",
             "_tpl": "62330bfadc5883093563729b",
             "parentId": "hideout",
@@ -5009,8 +4475,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "bcfeebcba4bcc6a76c73ed27",
             "_tpl": "62330bfadc5883093563729b",
             "parentId": "hideout",
@@ -5021,8 +4486,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "0f4dd0176004f90d09f9fec7",
             "_tpl": "62330c18744e5e31df12f516",
             "parentId": "hideout",
@@ -5033,8 +4497,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ca3cc8458daeb8e42a44bedc",
             "_tpl": "62330c18744e5e31df12f516",
             "parentId": "hideout",
@@ -5045,8 +4508,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "9f2b65add7a7286acdd6c5f5",
             "_tpl": "62330c40bdd19b369e1e53d1",
             "parentId": "hideout",
@@ -5057,8 +4519,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "dcbce2cd8d82cade6ab01a75",
             "_tpl": "62330c40bdd19b369e1e53d1",
             "parentId": "hideout",
@@ -5069,8 +4530,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f9aae57fcbece367d1736061",
             "_tpl": "6576f4708ca9c4381d16cd9d",
             "parentId": "hideout",
@@ -5081,8 +4541,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7ca7aa12aeb5d9eac16762e5",
             "_tpl": "6576f4708ca9c4381d16cd9d",
             "parentId": "hideout",
@@ -5093,8 +4552,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ecc7c755adf0faa2eecd3aee",
             "_tpl": "6576f93989f0062e741ba952",
             "parentId": "hideout",
@@ -5105,8 +4563,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "ae684f0007f84bc01b82f9ca",
             "_tpl": "6576f93989f0062e741ba952",
             "parentId": "hideout",
@@ -5117,8 +4574,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "931ad09dd17e74913aa1cbed",
             "_tpl": "628e4e576d783146b124c64d",
             "parentId": "hideout",
@@ -5129,8 +4585,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "f202753efa000776a00fca31",
             "_tpl": "628e4e576d783146b124c64d",
             "parentId": "hideout",
@@ -5141,8 +4596,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "7b5cacfc5ce7cef9b86d5dc7",
             "_tpl": "63088377b5cd696784087147",
             "parentId": "hideout",
@@ -5153,38 +4607,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "0f4cbe425a1e599def3abc6f",
             "_tpl": "630764fea987397c0816d219",
             "parentId": "7b5cacfc5ce7cef9b86d5dc7",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "fd2bcbefd22979cd185ec3fa",
             "_tpl": "63075cc5962d0247b029dc2a",
             "parentId": "7b5cacfc5ce7cef9b86d5dc7",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "9f15cea6a85de41d3e1fa749",
             "_tpl": "630765cb962d0247b029dc45",
             "parentId": "fd2bcbefd22979cd185ec3fa",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "c5cffcfafad5deafafca9e3a",
             "_tpl": "630765777d50ff5e8a1ea718",
             "parentId": "fd2bcbefd22979cd185ec3fa",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "90a8dbde1c6ba4dada7efa06",
             "_tpl": "63076701a987397c0816d21b",
             "parentId": "7b5cacfc5ce7cef9b86d5dc7",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "b15a058dfddeaca379a4dd9d",
             "_tpl": "61a4c8884f95bc3b2c5dc96f",
             "parentId": "hideout",
@@ -5195,32 +4643,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d5dbaefe72e128f3b2f68368",
             "_tpl": "619f54a1d25cbd424731fb99",
             "parentId": "b15a058dfddeaca379a4dd9d",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "9ab1bb8a7d2109ebf65edd76",
             "_tpl": "619f4cee4c58466fe1228435",
             "parentId": "b15a058dfddeaca379a4dd9d",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "eabe07bbcb280ea8e9c6abb7",
             "_tpl": "619f4d304c58466fe1228437",
             "parentId": "b15a058dfddeaca379a4dd9d",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "1fec8cec76c56d2b545a4fda",
             "_tpl": "619f4bffd25cbd424731fb97",
             "parentId": "b15a058dfddeaca379a4dd9d",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "0fb0f7f6c18e8694b0d1c2f3",
             "_tpl": "624c2e8614da335f1e034d8c",
             "parentId": "hideout",
@@ -5231,26 +4674,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "d5ca7c002ba6e51cfab37f63",
             "_tpl": "624c3074dbbd335e8e6becf3",
             "parentId": "0fb0f7f6c18e8694b0d1c2f3",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "ee9e0e12ee098b6bdc5e1be9",
             "_tpl": "619f4d304c58466fe1228437",
             "parentId": "0fb0f7f6c18e8694b0d1c2f3",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "cd81becd52d0f8e4e0d16f4b",
             "_tpl": "619f4bffd25cbd424731fb97",
             "parentId": "0fb0f7f6c18e8694b0d1c2f3",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "cc0e369bad5bddf6ecff95bc",
             "_tpl": "633ec7c2a6918cb895019c6c",
             "parentId": "hideout",
@@ -5261,20 +4700,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "85a35ea1119af827c255aeea",
             "_tpl": "633ec6ee025b096d320a3b15",
             "parentId": "cc0e369bad5bddf6ecff95bc",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "daeadea6bdf767a7a25e02fd",
             "_tpl": "633ec8e4025b096d320a3b1e",
             "parentId": "cc0e369bad5bddf6ecff95bc",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "97fcb8491d0c7a8ed026c9ab",
             "_tpl": "63088377b5cd696784087147",
             "parentId": "hideout",
@@ -5285,38 +4721,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "014ead47f53a349df9ad51fa",
             "_tpl": "630764fea987397c0816d219",
             "parentId": "97fcb8491d0c7a8ed026c9ab",
             "slotId": "mod_barrel"
-        },
-        {
+        }, {
             "_id": "ef1b14d0b39abefeb41bcd9c",
             "_tpl": "63075cc5962d0247b029dc2a",
             "parentId": "97fcb8491d0c7a8ed026c9ab",
             "slotId": "mod_reciever"
-        },
-        {
+        }, {
             "_id": "c2dcd3978e1e26b64fab2221",
             "_tpl": "630765cb962d0247b029dc45",
             "parentId": "ef1b14d0b39abefeb41bcd9c",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "f7f45abe1d5afabc89cb2a56",
             "_tpl": "630765777d50ff5e8a1ea718",
             "parentId": "ef1b14d0b39abefeb41bcd9c",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "df4fd6ce1fad66fa9ee80690",
             "_tpl": "63076701a987397c0816d21b",
             "parentId": "97fcb8491d0c7a8ed026c9ab",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "e967ded978ed55ad21c2b969",
             "_tpl": "61a4c8884f95bc3b2c5dc96f",
             "parentId": "hideout",
@@ -5327,32 +4757,27 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "a8da09fbe83c9da4ad8bedee",
             "_tpl": "619f54a1d25cbd424731fb99",
             "parentId": "e967ded978ed55ad21c2b969",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "36dfb6fafad51baef6ad815e",
             "_tpl": "619f4cee4c58466fe1228435",
             "parentId": "e967ded978ed55ad21c2b969",
             "slotId": "mod_sight_rear"
-        },
-        {
+        }, {
             "_id": "d5af761c3c4dda48f8665eeb",
             "_tpl": "619f4d304c58466fe1228437",
             "parentId": "e967ded978ed55ad21c2b969",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "54e6cccd3b10baa605ffdff2",
             "_tpl": "619f4bffd25cbd424731fb97",
             "parentId": "e967ded978ed55ad21c2b969",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "cfeefce853c48bd197474d5c",
             "_tpl": "624c2e8614da335f1e034d8c",
             "parentId": "hideout",
@@ -5363,26 +4788,22 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "cb26eafc6decdeab0cd30a1a",
             "_tpl": "624c3074dbbd335e8e6becf3",
             "parentId": "cfeefce853c48bd197474d5c",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "ce20615dd3c1e5642feac1fd",
             "_tpl": "619f4d304c58466fe1228437",
             "parentId": "cfeefce853c48bd197474d5c",
             "slotId": "mod_sight_front"
-        },
-        {
+        }, {
             "_id": "1e9be9d32d52d2bc8b8f0ce0",
             "_tpl": "619f4bffd25cbd424731fb97",
             "parentId": "cfeefce853c48bd197474d5c",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "621cc07ca2f746f925a8c14a",
             "_tpl": "633ec7c2a6918cb895019c6c",
             "parentId": "hideout",
@@ -5393,20 +4814,17 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "32a7fd921ba0ebd8faa85cf9",
             "_tpl": "633ec6ee025b096d320a3b15",
             "parentId": "621cc07ca2f746f925a8c14a",
             "slotId": "mod_magazine"
-        },
-        {
+        }, {
             "_id": "98cfbf822ebc0b5becaaa649",
             "_tpl": "633ec8e4025b096d320a3b1e",
             "parentId": "621cc07ca2f746f925a8c14a",
             "slotId": "mod_pistol_grip"
-        },
-        {
+        }, {
             "_id": "03b702156dbdd4bd86b91cef",
             "_tpl": "63076701a987397c0816d21b",
             "parentId": "hideout",
@@ -5417,8 +4835,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "2281fcc678f0cd6fc510cddd",
             "_tpl": "630769c4962d0247b029dc60",
             "parentId": "hideout",
@@ -5429,8 +4846,7 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        },
-        {
+        }, {
             "_id": "b763aacb3415f3ae25e6cb89",
             "_tpl": "630767c37d50ff5e8a1ea71a",
             "parentId": "hideout",

--- a/db/traders/6765fbd20fdc7eb79b00000f/assort.json
+++ b/db/traders/6765fbd20fdc7eb79b00000f/assort.json
@@ -3020,7 +3020,7 @@
         },
         {
             "_id": "ddbc0e5daef9b13bb2cb5401",
-            "_tpl": "573722e82459776104581c21",
+            "_tpl": "57371aab2459775a77142f22",
             "parentId": "a31fdb5d730cc4abc1359222",
             "slotId": "cartridges",
             "location": 0,
@@ -3042,7 +3042,7 @@
         },
         {
             "_id": "94ab28efe9871ded5c716c82",
-            "_tpl": "573722e82459776104581c21",
+            "_tpl": "5737250c2459776125652acc",
             "parentId": "hideout",
             "slotId": "hideout",
             "upd": {

--- a/db/traders/6765fbd20fdc7eb79b00000f/assort.json
+++ b/db/traders/6765fbd20fdc7eb79b00000f/assort.json
@@ -1,1521 +1,1752 @@
 {
     "barter_scheme": {
         "3a9cb7a0affcffd85acd25f8": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 7800
                 }
             ]
         ],
         "e5dddfb1dfaf5efd25d66bb5": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 800
                 }
             ]
         ],
         "fed0f57ea117d4dfd7ebaf0e": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 15000
                 }
             ]
         ],
         "83f84aa7f1d5baa8375f2ea6": [
-            [{
+            [
+                {
                     "_tpl": "5448ff904bdc2d6f028b456e",
                     "count": 12
                 }
             ]
         ],
         "b6ad0c8fee8849dfacdcad1b": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 36000
                 }
             ]
         ],
         "cdbae4551d855b106e710592": [
-            [{
+            [
+                {
                     "_tpl": "619cbfeb6b8a1b37a54eebfa",
                     "count": 2
                 }
             ]
         ],
         "eeeda5e0c30acab2387b89db": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 13000
                 }
             ]
         ],
         "1e8aa11dffada086c5068dc8": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1800
                 }
             ]
         ],
         "d3644926fee7bda253bcb1a5": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 20000
                 }
             ]
         ],
         "aa0de437e1a4dfaa7f4e8bc6": [
-            [{
+            [
+                {
                     "_tpl": "59e35ef086f7741777737012",
                     "count": 2
                 }
             ]
         ],
         "820211af1bb0cce1ecb026b2": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 6500
                 }
             ]
         ],
         "6d88bd83d9eadaf199fe607e": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1000
                 }
             ]
         ],
         "fb1a52f738e38a1cefe9c4db": [
-            [{
+            [
+                {
                     "_tpl": "57371f2b24597761224311f1",
                     "count": 3
                 }
             ]
         ],
         "e7198dc8ba1dd4d8be5de271": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 42
                 }
             ]
         ],
         "915aeeb8c2ffdacff1bb0d20": [
-            [{
+            [
+                {
                     "_tpl": "5735fdcd2459776445391d61",
                     "count": 2
                 }
             ]
         ],
         "5a5d16fd31babae6facbbd33": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 45
                 }
             ]
         ],
         "ca14ca194a60716cafa23f02": [
-            [{
+            [
+                {
                     "_tpl": "573602322459776445391df1",
                     "count": 4
                 }
             ]
         ],
         "de2be0eb3ac652ce4fbc145d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 40
                 }
             ]
         ],
         "bfb8abf507ada6d60d8fbc07": [
-            [{
+            [
+                {
                     "_tpl": "573603c924597764442bd9cb",
                     "count": 2
                 }
             ]
         ],
         "df0feb4c5e5ec8bda641de13": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60
                 }
             ]
         ],
         "8dd4bb045cd23b6cae8626d4": [
-            [{
+            [
+                {
                     "_tpl": "5735ff5c245977640e39ba7e",
                     "count": 2
                 }
             ]
         ],
         "d2b3dbbffc6d93efc5aadee7": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 45
                 }
             ]
         ],
         "f8c1b5b1cea294edd8aae8ce": [
-            [{
+            [
+                {
                     "_tpl": "573601b42459776410737435",
                     "count": 3
                 }
             ]
         ],
         "086ee00585e6fffe9c49a94e": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60
                 }
             ]
         ],
         "8e6b439cb29ff8c6f2e39ad1": [
-            [{
+            [
+                {
                     "_tpl": "5736026a245977644601dc61",
                     "count": 2
                 }
             ]
         ],
         "d7a03b44cbedfb164faa6568": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 55
                 }
             ]
         ],
         "bcefecbc9938df34a4b9ccca": [
-            [{
+            [
+                {
                     "_tpl": "57372140245977611f70ee91",
                     "count": 2
                 }
             ]
         ],
         "44ed1accafdaaed4ee3a0e16": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 55
                 }
             ]
         ],
         "b70ea8cfd98f44efddcb7ec9": [
-            [{
+            [
+                {
                     "_tpl": "560d5e524bdc2d25448b4571",
                     "count": 2
                 }
             ]
         ],
         "cd74e02d515cbceddedbe4d0": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 10
                 }
             ]
         ],
         "b09decf5006aef30bc6b81d9": [
-            [{
+            [
+                {
                     "_tpl": "57371aab2459775a77142f22",
                     "count": 2
                 }
             ]
         ],
         "fbb8cf1dff9bec9bbedd88f1": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 100
                 }
             ]
         ],
         "3d3aff70ebf8fcee2feaef19": [
-            [{
+            [
+                {
                     "_tpl": "573718ba2459775a75491131",
                     "count": 2
                 }
             ]
         ],
         "ebde2ceaef7d9ebbee06aa7d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 100
                 }
             ]
         ],
         "44dc7035bc97bc6cc5dcc383": [
-            [{
+            [
+                {
                     "_tpl": "57371e4124597760ff7b25f1",
                     "count": 4
                 }
             ]
         ],
         "dca3fc1a711ba7321847b21a": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 44
                 }
             ]
         ],
         "fb6d6d563facc7f8b9e633bd": [
-            [{
+            [
+                {
                     "_tpl": "57371eb62459776125652ac1",
                     "count": 2
                 }
             ]
         ],
         "4dc2c96e5d3e3231f51e7df6": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 36
                 }
             ]
         ],
         "1fb4b1cf54aca1271f0894b5": [
-            [{
+            [
+                {
                     "_tpl": "57371f2b24597761224311f1",
                     "count": 3
                 }
             ]
         ],
         "11f451f96ec3bf5bcfbbb40d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 30
                 }
             ]
         ],
         "bbfadaa86f4cdbd0c086dadb": [
-            [{
+            [
+                {
                     "_tpl": "57371f8d24597761006c6a81",
                     "count": 2
                 }
             ]
         ],
         "65b379bb5c3fe44c00e9fbd9": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24
                 }
             ]
         ],
         "ceae16d808bbe67f0fa7b6a0": [
-            [{
+            [
+                {
                     "_tpl": "573719762459775a626ccbc1",
                     "count": 3
                 }
             ]
         ],
         "e224f506ebadcb69be0f0c09": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 18
                 }
             ]
         ],
         "c5e8f7eff6cdb0bf95ddadc2": [
-            [{
+            [
+                {
                     "_tpl": "57371b192459775a9f58a5e0",
                     "count": 2
                 }
             ]
         ],
         "fdbfda26046c99eacda24230": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 38
                 }
             ]
         ],
         "470bae3f55f0debfbb94a46b": [
-            [{
+            [
+                {
                     "_tpl": "5737218f245977612125ba51",
                     "count": 2
                 }
             ]
         ],
         "df65013e31dffb8dfad3536f": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60
                 }
             ]
         ],
         "0edcf83e0494db293b0417fd": [
-            [{
+            [
+                {
                     "_tpl": "5737207f24597760ff7b25f2",
                     "count": 3
                 }
             ]
         ],
         "dcfe5a0eea4daf9dd0c322be": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 75
                 }
             ]
         ],
         "fefe0d415e3f871fc23539fa": [
-            [{
+            [
+                {
                     "_tpl": "573720e02459776143012541",
                     "count": 4
                 }
             ]
         ],
         "d5fac2c7a2188bae4313e918": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 145
                 }
             ]
         ],
         "c0cd0cd5d6fc2bca97e78fac": [
-            [{
+            [
+                {
                     "_tpl": "5737201124597760fc4431f1",
                     "count": 2
                 }
             ]
         ],
         "58a9aafc80d40a7eb0fc02bd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60
                 }
             ]
         ],
         "2bf6fa9ebcfa2fa7a597aa89": [
-            [{
+            [
+                {
                     "_tpl": "59e35ef086f7741777737012",
                     "count": 2
                 }
             ]
         ],
         "e311ead52063d21d4d7cedcd": [
-            [{
+            [
+                {
                     "_tpl": "5751487e245977207e26a315",
                     "count": 1
                 }
             ]
         ],
         "94ab28efe9871ded5c716c82": [
-            [{
+            [
+                {
                     "_tpl": "5673de654bdc2d180f8b456d",
                     "count": 3
                 }
             ]
         ],
         "a31fdb5d730cc4abc1359222": [
-            [{
+            [
+                {
                     "_tpl": "5c06782b86f77426df5407d2",
                     "count": 3
                 }
             ]
         ],
         "dfc0bc12fc570ccec1ffabbd": [
-            [{
+            [
+                {
                     "_tpl": "57347c93245977448d35f6e3",
                     "count": 1
                 }
             ]
         ],
         "e1bbeed79f7fea0dfa12d80b": [
-            [{
+            [
+                {
                     "_tpl": "5909e99886f7740c983b9984",
                     "count": 1
                 }
             ]
         ],
         "b42cc6376a1904a1febe235a": [
-            [{
+            [
+                {
                     "_tpl": "56742c284bdc2d98058b456d",
                     "count": 1
                 }
             ]
         ],
         "2efde2abb2baf3ae1ff2ff4a": [
-            [{
+            [
+                {
                     "_tpl": "5672cb124bdc2d1a0f8b4568",
                     "count": 1
                 }
             ]
         ],
         "f447b102bd5acfbc207eb149": [
-            [{
+            [
+                {
                     "_tpl": "57347d3d245977448f7b7f61",
                     "count": 1
                 }
             ]
         ],
         "c2ae85b817d44dbeccd1f8ee": [
-            [{
+            [
+                {
                     "_tpl": "5734795124597738002c6176",
                     "count": 1
                 }
             ]
         ],
         "d0ebab7adbcd6e4abd3e0b6a": [
-            [{
+            [
+                {
                     "_tpl": "577e1c9d2459773cd707c525",
                     "count": 1
                 }
             ]
         ],
         "7acfff1f46adfbcef1e5f760": [
-            [{
+            [
+                {
                     "_tpl": "57347cd0245977445a2d6ff1",
                     "count": 1
                 }
             ]
         ],
         "dcf10a6a92e1a9b36540f0e3": [
-            [{
+            [
+                {
                     "_tpl": "57347d9c245977448b40fa85",
                     "count": 2
                 }
             ]
         ],
         "3581cfb9a4b12786e6edec65": [
-            [{
+            [
+                {
                     "_tpl": "57347b8b24597737dd42e192",
                     "count": 1
                 }
             ]
         ],
         "df3bca39d57fb7dd5ad84bae": [
-            [{
+            [
+                {
                     "_tpl": "5d4042a986f7743185265463",
                     "count": 2
                 }
             ]
         ],
         "ee565bb7e3ecda6bcafbd514": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 11000
                 }
             ]
         ],
         "cc4bbc4118a8e9df8fbba40f": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1400
                 }
             ]
         ],
         "274abdae1feb2ac1add7fafd": [
-            [{
+            [
+                {
                     "_tpl": "5909e99886f7740c983b9984",
                     "count": 3
                 }
             ]
         ],
         "fbe55784d196ee9d82b8dda3": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 9000
                 }
             ]
         ],
         "8d7203ba6b66cc3c4b201ff5": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2400
                 }
             ]
         ],
         "937e5a4cf8ecc4218ce9bedc": [
-            [{
+            [
+                {
                     "_tpl": "573474f924597738002c6174",
                     "count": 2
-                }, {
+                },
+                {
                     "_tpl": "619cbfeb6b8a1b37a54eebfa",
                     "count": 1
                 }
             ]
         ],
         "3e7f422c138ef7375ffe785c": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 18000
                 }
             ]
         ],
         "189b44fcb7eeab81cee03fec": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1300
                 }
             ]
         ],
         "3c9f0e8134cb86cea7faab5e": [
-            [{
+            [
+                {
                     "_tpl": "5e2af29386f7746d4159f077",
                     "count": 2
                 }
             ]
         ],
         "a7d97272bfab4233d4a7a61b": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 50000
                 }
             ]
         ],
         "d01a690a010ef47f25eed3f5": [
-            [{
+            [
+                {
                     "_tpl": "59e36c6f86f774176c10a2a7",
                     "count": 2
                 }
             ]
         ],
         "a7fd9e6901ff9f0a95b106a8": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 12500
                 }
             ]
         ],
         "dd2bb0afe4e2ba47debab11c": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 725
                 }
             ]
         ],
         "db5ff86b7b75e2dde1047c3a": [
-            [{
+            [
+                {
                     "_tpl": "5a26ac06c4a282000c5a90a8",
                     "count": 4
                 }
             ]
         ],
         "f6a8a28ebfb759e0fc37bfd4": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 205
                 }
             ]
         ],
         "eeddbaba031b3f96b74dba96": [
-            [{
+            [
+                {
                     "_tpl": "56dff3afd2720bba668b4567",
                     "count": 3
                 }
             ]
         ],
         "335d2dbc72ece7c0536baeca": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 120
                 }
             ]
         ],
         "cae5752aa3ecab6b9ccd89a4": [
-            [{
+            [
+                {
                     "_tpl": "5a26abfac4a28232980eabff",
                     "count": 3
                 }
             ]
         ],
         "fa74ecbfebcfcb32fe692dbd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 60
                 }
             ]
         ],
         "42bb63dfc8c40462c49fcec7": [
-            [{
+            [
+                {
                     "_tpl": "5a269f97c4a282000b151807",
                     "count": 5
                 }
             ]
         ],
         "b41a0bad056354fdd14de2e5": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 460
                 }
             ]
         ],
         "7cfec9cc8a48b1f4e1d55208": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1300
                 }
             ]
         ],
         "f7cafc93ff48d56f7864b5dd": [
-            [{
+            [
+                {
                     "_tpl": "5734781f24597737e04bf32a",
                     "count": 7
                 }
             ]
         ],
         "cfadc6fbf3d488abda498fdb": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 11500
                 }
             ]
         ],
         "a2efdd1780ef304db3cd336d": [
-            [{
+            [
+                {
                     "_tpl": "590c651286f7741e566b6461",
                     "count": 1
                 }
             ]
         ],
         "f8a58f6dfde99fafaacfa7cd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 42000
                 }
             ]
         ],
         "ba4167fb2272ac9af2ca104b": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 23500
                 }
             ]
         ],
         "b98cdb4c21f84340dc0eecec": [
-            [{
+            [
+                {
                     "_tpl": "5734773724597737fd047c14",
                     "count": 4
                 }
             ]
         ],
         "1d22a09a952d0371e416dacc": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 23500
                 }
             ]
         ],
         "5b0def9296a9f2ef8ecbca8c": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 42000
                 }
             ]
         ],
         "ecb1bdb04dcfbbc31452cafb": [
-            [{
+            [
+                {
                     "_tpl": "5b43271c5acfc432ff4dce65",
                     "count": 6
                 }
             ]
         ],
         "5a4f3ab67a1121acfe8a48b1": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 15000
                 }
             ]
         ],
         "36e467f8c6e72e8abafe64f3": [
-            [{
+            [
+                {
                     "_tpl": "5d1b3f2d86f774253763b735",
                     "count": 2
-                }, {
+                },
+                {
                     "_tpl": "5b4335ba86f7744d2837a264",
                     "count": 2
-                }, {
+                },
+                {
                     "_tpl": "590c695186f7741e566b64a2",
                     "count": 2
                 }
             ]
         ],
         "5b3ab061d60fd7fc173aaf3b": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 20000
                 }
             ]
         ],
         "ef6eff9ff72cf1af022856fc": [
-            [{
+            [
+                {
                     "_tpl": "5ed5160a87bb8443d10680b5",
                     "count": 1
-                }, {
+                },
+                {
                     "_tpl": "544fb37f4bdc2dee738b4567",
                     "count": 1
                 }
             ]
         ],
         "e6d31bb2dbe57dfca6ecb31b": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 34000
                 }
             ]
         ],
         "6df71db9db1adceeffa3fbeb": [
-            [{
+            [
+                {
                     "_tpl": "5c0e531286f7747fa54205c2",
                     "count": 1
-                }, {
+                },
+                {
                     "_tpl": "5ed515c8d380ab312177c0fa",
                     "count": 1
                 }
             ]
         ],
         "10a63721a6f9f3410de7b4cf": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 27000
                 }
             ]
         ],
         "9a6c9b7a1b763f3a054b266e": [
-            [{
+            [
+                {
                     "_tpl": "5e8488fa988a8701445df1e4",
                     "count": 2
-                }, {
+                },
+                {
                     "_tpl": "5d1b3f2d86f774253763b735",
                     "count": 2
-                }, {
+                },
+                {
                     "_tpl": "5755356824597772cb798962",
                     "count": 2
                 }
             ]
         ],
         "2dade6b16c22b26cfb488668": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 31000
                 }
             ]
         ],
         "e037c43eff00f637dbd4c5df": [
-            [{
+            [
+                {
                     "_tpl": "5c0e530286f7747fa1419862",
                     "count": 2
-                }, {
+                },
+                {
                     "_tpl": "5d403f9186f7743cac3f229b",
                     "count": 1
-                }, {
+                },
+                {
                     "_tpl": "544fb3f34bdc2d03748b456a",
                     "count": 2
                 }
             ]
         ],
         "e6bfec0008abd6e15b069fdf": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 35000
                 }
             ]
         ],
         "feccd499ae83cffc8fde0fa6": [
-            [{
+            [
+                {
                     "_tpl": "544fb3f34bdc2d03748b456a",
                     "count": 1
-                }, {
+                },
+                {
                     "_tpl": "5d1b3a5d86f774252167ba22",
                     "count": 4
                 }
             ]
         ],
         "ad638edd7a1aa4c278bae3de": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 30000
                 }
             ]
         ],
         "fec191eb6f7f5dacd57322ee": [
-            [{
+            [
+                {
                     "_tpl": "544fb45d4bdc2dee738b4568",
                     "count": 2
                 }
             ]
         ],
         "1ee092ec29c3cad8ebba19ca": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 42000
                 }
             ]
         ],
         "ffef96aaea2c43db5229145e": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 26000000
                 }
             ]
         ],
         "1df4e3dd2af0bda84f0cb06f": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 50000
                 }
             ]
         ],
         "efaf9ef33afa9d0a6f4af5e3": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 150000
                 }
             ]
         ],
         "b025e6c110d9fdcad0db075a": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 80000000
                 }
             ]
         ],
         "7325fbddeceff3d8e1a5c8ae": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 5000000
                 }
             ]
         ],
         "f42e4e7b2957fbd6da8525d6": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 8000000
                 }
             ]
         ],
         "7c70e4df40fc3c5cd4a1ba1f": [
-            [{
+            [
+                {
                     "_tpl": "59faff1d86f7746c51718c9c",
                     "count": 1
                 }
             ]
         ],
         "b4dc3ff9d5cbaf5dacb4f58f": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 375000
                 }
             ]
         ],
         "7c6afdd5e9bafc1e9e546d9f": [
-            [{
+            [
+                {
                     "_tpl": "5734779624597737e04bf329",
                     "count": 2
                 }
             ]
         ],
         "c9b1a0fc5d3eaceffe1b74fe": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 11000
                 }
             ]
         ],
         "75bb11b0c4fc1dcc8e7de05f": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1500
                 }
             ]
         ],
         "67194e1598bd9759b9eba1c2": [
-            [{
+            [
+                {
                     "_tpl": "5cc80f67e4a949035e43bbba",
                     "count": 2
                 }
             ]
         ],
         "bc4191a2caeb2274eaee31ca": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 390
                 }
             ]
         ],
         "6f3bcaf9be7efb5a9cc6386e": [
-            [{
+            [
+                {
                     "_tpl": "5cc80f8fe4a949033b0224a2",
                     "count": 4
                 }
             ]
         ],
         "bbfdbf7e8c829bdaf01a24e2": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 250
                 }
             ]
         ],
         "9ffbbd4bd1cd72aae9ce79fa": [
-            [{
+            [
+                {
                     "_tpl": "5cc80f53e4a949000e1ea4f8",
                     "count": 2
                 }
             ]
         ],
         "a6db1c5dabbed0cb1da38f36": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 225
                 }
             ]
         ],
         "b9ce119cb82d40e1ad2b9dfb": [
-            [{
+            [
+                {
                     "_tpl": "5cc86832d7f00c000d3a6e6c",
                     "count": 2
                 }
             ]
         ],
         "d64e76d3adb9dee66fdcf4a0": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 66
                 }
             ]
         ],
         "7d9f1fbf02eb1b63ef9a91cf": [
-            [{
+            [
+                {
                     "_tpl": "5cc80f79e4a949033c7343b2",
                     "count": 3
                 }
             ]
         ],
         "a77a1d44b124aaf78bf413cb": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 130
                 }
             ]
         ],
         "bbcf627a3011fb7a9609a4bf": [
-            [{
+            [
+                {
                     "_tpl": "5cc86840d7f00c002412c56c",
                     "count": 3
                 }
             ]
         ],
         "8deef6d1b3234e09971c1fab": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 340
                 }
             ]
         ],
         "f7a696d2fe8a349d56b34ec9": [
-            [{
+            [
+                {
                     "_tpl": "59e4cf5286f7741778269d8a",
                     "count": 8
                 }
             ]
         ],
         "a0d4a64e2c2d3eccb3bd41fe": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 185
                 }
             ]
         ],
         "beb9f3ffaeadabfa84bd63c7": [
-            [{
+            [
+                {
                     "_tpl": "5d40419286f774318526545f",
                     "count": 2
                 }
             ]
         ],
         "8cbab7ee081cbd50f3ee9bbd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24000
                 }
             ]
         ],
         "fb783eba01beec33bcdcdb2b": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 3100
                 }
             ]
         ],
         "cb6b0fad2e612f6354f9e2b2": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24000
                 }
             ]
         ],
         "1fffddf2426ada1efc09f219": [
-            [{
+            [
+                {
                     "_tpl": "57347c5b245977448d35f6e1",
                     "count": 5
                 }
             ]
         ],
         "c07efaad20cede5b63b77b3a": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 33000
                 }
             ]
         ],
         "8edbdea1febb00cf69e6e324": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 12000
                 }
             ]
         ],
         "4fdabd5c10fababd592cceac": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 950
                 }
             ]
         ],
         "ecaa6a29b754356b07eb0286": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 14000
                 }
             ]
         ],
         "09de143beaf8ded85d2130bc": [
-            [{
+            [
+                {
                     "_tpl": "5ed515ece452db0eb56fc028",
                     "count": 1
-                }, {
+                },
+                {
                     "_tpl": "590c695186f7741e566b64a2",
                     "count": 2
                 }
             ]
         ],
         "fa0ef0acde8adb6aaf9a8cda": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 30000
                 }
             ]
         ],
         "a8f087a77b26cba3e1d8f1d9": [
-            [{
+            [
+                {
                     "_tpl": "5d1b3f2d86f774253763b735",
                     "count": 2
-                }, {
+                },
+                {
                     "_tpl": "5b4335ba86f7744d2837a264",
                     "count": 2
-                }, {
+                },
+                {
                     "_tpl": "59e361e886f774176c10a2a5",
                     "count": 2
                 }
             ]
         ],
         "7d827f002dceb39a9ed88a3a": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 36000
                 }
             ]
         ],
         "65fc7dd29df6cebfc0de8c27": [
-            [{
+            [
+                {
                     "_tpl": "5d1b3f2d86f774253763b735",
                     "count": 2
-                }, {
+                },
+                {
                     "_tpl": "5b4335ba86f7744d2837a264",
                     "count": 2
-                }, {
+                },
+                {
                     "_tpl": "59e3606886f77417674759a5",
                     "count": 2
                 }
             ]
         ],
         "b8e69a07ef9effe19a22ffdd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 39000
                 }
             ]
         ],
         "5a3deddebcddac8a1feadba3": [
-            [{
+            [
+                {
                     "_tpl": "5c0e533786f7747fa23f4d47",
                     "count": 1
-                }, {
+                },
+                {
                     "_tpl": "59e361e886f774176c10a2a5",
                     "count": 2
                 }
             ]
         ],
         "ff8a0fbadfeaa1c454b4105d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 44000
                 }
             ]
         ],
         "a3ddd8acba327e0affbefbc3": [
-            [{
+            [
+                {
                     "_tpl": "5ed515c8d380ab312177c0fa",
                     "count": 1
-                }, {
+                },
+                {
                     "_tpl": "590c661e86f7741e566b646a",
                     "count": 2
-                }, {
+                },
+                {
                     "_tpl": "544fb3f34bdc2d03748b456a",
                     "count": 2
                 }
             ]
         ],
         "cdf7f18ffe59d5d44ecacc40": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 54000
                 }
             ]
         ],
         "cfabff3a2c751c1efd4f6483": [
-            [{
+            [
+                {
                     "_tpl": "5ed5166ad380ab312177c100",
                     "count": 1
-                }, {
+                },
+                {
                     "_tpl": "5d403f9186f7743cac3f229b",
                     "count": 1
-                }, {
+                },
+                {
                     "_tpl": "5751435d24597720a27126d1",
                     "count": 5
                 }
             ]
         ],
         "6116dd5beadd48eadbc4a2a7": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 42000
                 }
             ]
         ],
         "f196cf65e92c1f9c59b578fc": [
-            [{
+            [
+                {
                     "_tpl": "5c10c8fd86f7743d7d706df3",
                     "count": 2
-                }, {
+                },
+                {
                     "_tpl": "59e3606886f77417674759a5",
                     "count": 2
                 }
             ]
         ],
         "3e46eb2ceedee4916cfafd6b": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 58000
                 }
             ]
         ],
         "ea57bcb2aabde22ea6ffe5a4": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 250000
                 }
             ]
         ],
         "7e2bf94e29cf707e7f0b5ad8": [
-            [{
+            [
+                {
                     "_tpl": "57347cd0245977445a2d6ff1",
                     "count": 3
                 }
             ]
         ],
         "8e3ffa1c2a1bb3e7eb1543ab": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 18000
                 }
             ]
         ],
         "dfbdd6cbc2fbc48576e8f8d9": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1000
                 }
             ]
         ],
         "c27e4e7bb0cdc556dca031fc": [
-            [{
+            [
+                {
                     "_tpl": "573477e124597737dd42e191",
                     "count": 5
                 }
             ]
         ],
         "943b4c8e756cd15cdd8ed8b1": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 56000
                 }
             ]
         ],
         "c9b91dc803d3d547bada5a2f": [
-            [{
+            [
+                {
                     "_tpl": "544fb45d4bdc2dee738b4568",
                     "count": 2
-                }, {
+                },
+                {
                     "_tpl": "544fb3f34bdc2d03748b456a",
                     "count": 2
-                }, {
+                },
+                {
                     "_tpl": "5d1b3f2d86f774253763b735",
                     "count": 2
                 }
             ]
         ],
         "7f1f7bdf3aac7ea2effe7a5d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 75000
                 }
             ]
         ],
         "eabfedc9aae68d071e3bba45": [
-            [{
+            [
+                {
                     "_tpl": "5c0e531286f7747fa54205c2",
                     "count": 2
-                }, {
+                },
+                {
                     "_tpl": "5ed515e03a40a50460332579",
                     "count": 2
                 }
             ]
         ],
         "eaf7c2c7bbaf1bb808a84a0b": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 82000
                 }
             ]
         ],
         "aabcec9052e82ab98e259acf": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1200
                 }
             ]
         ],
         "7381a6f08346819bccccac84": [
-            [{
+            [
+                {
                     "_tpl": "5d235b4d86f7742e017bc88a",
                     "count": 1
                 }
             ]
         ],
         "b6acdfe7eaa7cdb2bfa2af5e": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 14000
                 }
             ]
         ],
         "fafeafaf9e86834f07cbef8c": [
-            [{
+            [
+                {
                     "_tpl": "5d1b392c86f77425243e98fe",
                     "count": 4
                 }
             ]
         ],
         "8958ba634c1bf3dd1d0ce6eb": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 24000
                 }
             ]
         ],
         "aaaa7a8a7368208a87fabaa7": [
-            [{
+            [
+                {
                     "_tpl": "619cc01e0a7c3a1a2731940c",
                     "count": 3
                 }
             ]
         ],
         "82943a8a8b5b8e8386735044": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 21000
                 }
             ]
         ],
         "f6f8094cc6edeaff15378dfd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1900
                 }
             ]
         ],
         "bbcc98abb8cf958dff59dabf": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "a826dd99cc0fc4fa7aaefc60": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 120
                 }
             ]
         ],
         "dd2c394a33df33a9ab02d4ba": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "bcfeebcba4bcc6a76c73ed27": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 105
                 }
             ]
         ],
         "0f4dd0176004f90d09f9fec7": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "ca3cc8458daeb8e42a44bedc": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 155
                 }
             ]
         ],
         "9f2b65add7a7286acdd6c5f5": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "dcbce2cd8d82cade6ab01a75": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 85
                 }
             ]
         ],
         "f9aae57fcbece367d1736061": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "7ca7aa12aeb5d9eac16762e5": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 660
                 }
             ]
         ],
         "ecc7c755adf0faa2eecd3aee": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "ae684f0007f84bc01b82f9ca": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 225
                 }
             ]
         ],
         "931ad09dd17e74913aa1cbed": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "f202753efa000776a00fca31": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 75000
                 }
             ]
         ],
         "621cc07ca2f746f925a8c14a": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "cc0e369bad5bddf6ecff95bc": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 32000
                 }
             ]
         ],
         "97fcb8491d0c7a8ed026c9ab": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "7b5cacfc5ce7cef9b86d5dc7": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 16000
                 }
             ]
         ],
         "e967ded978ed55ad21c2b969": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "b15a058dfddeaca379a4dd9d": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 11500
                 }
             ]
         ],
         "cfeefce853c48bd197474d5c": [
-            [{
+            [
+                {
                     "_tpl": "6389c85357baa773a825b356",
                     "count": 1
                 }
             ]
         ],
         "0fb0f7f6c18e8694b0d1c2f3": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 6600
                 }
             ]
         ],
         "03b702156dbdd4bd86b91cef": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 1500
                 }
             ]
         ],
         "2281fcc678f0cd6fc510cddd": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2100
                 }
             ]
         ],
         "b763aacb3415f3ae25e6cb89": [
-            [{
+            [
+                {
                     "_tpl": "5449016a4bdc2d6f028b456f",
                     "count": 2500
                 }
             ]
         ]
     },
-    "items": [{
+    "items": [
+        {
             "_id": "feccd499ae83cffc8fde0fa6",
             "_tpl": "5c10c8fd86f7743d7d706df3",
             "parentId": "hideout",
@@ -1526,7 +1757,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "9a6c9b7a1b763f3a054b266e",
             "_tpl": "5c0e533786f7747fa23f4d47",
             "parentId": "hideout",
@@ -1537,7 +1769,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "65fc7dd29df6cebfc0de8c27",
             "_tpl": "5ed515ece452db0eb56fc028",
             "parentId": "hideout",
@@ -1548,7 +1781,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "09de143beaf8ded85d2130bc",
             "_tpl": "5ed515c8d380ab312177c0fa",
             "parentId": "hideout",
@@ -1559,7 +1793,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "5a3deddebcddac8a1feadba3",
             "_tpl": "5ed515f6915ec335206e4152",
             "parentId": "hideout",
@@ -1570,7 +1805,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "36e467f8c6e72e8abafe64f3",
             "_tpl": "5c0e530286f7747fa1419862",
             "parentId": "hideout",
@@ -1581,7 +1817,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a8f087a77b26cba3e1d8f1d9",
             "_tpl": "5ed515e03a40a50460332579",
             "parentId": "hideout",
@@ -1592,7 +1829,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f196cf65e92c1f9c59b578fc",
             "_tpl": "5ed5166ad380ab312177c100",
             "parentId": "hideout",
@@ -1603,7 +1841,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c9b91dc803d3d547bada5a2f",
             "_tpl": "5fca138c2a7b221b2852a5c6",
             "parentId": "hideout",
@@ -1614,7 +1853,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a3ddd8acba327e0affbefbc3",
             "_tpl": "5ed5160a87bb8443d10680b5",
             "parentId": "hideout",
@@ -1625,7 +1865,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ef6eff9ff72cf1af022856fc",
             "_tpl": "5c0e531286f7747fa54205c2",
             "parentId": "hideout",
@@ -1636,7 +1877,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "6df71db9db1adceeffa3fbeb",
             "_tpl": "5c0e531d86f7747fa23f4d42",
             "parentId": "hideout",
@@ -1647,7 +1889,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "eabfedc9aae68d071e3bba45",
             "_tpl": "5fca13ca637ee0341a484f46",
             "parentId": "hideout",
@@ -1658,7 +1901,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "cfabff3a2c751c1efd4f6483",
             "_tpl": "5ed51652f6c34d2cc26336a1",
             "parentId": "hideout",
@@ -1669,7 +1913,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e037c43eff00f637dbd4c5df",
             "_tpl": "5c0e534186f7747fa1419867",
             "parentId": "hideout",
@@ -1680,7 +1925,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ad638edd7a1aa4c278bae3de",
             "_tpl": "5c10c8fd86f7743d7d706df3",
             "parentId": "hideout",
@@ -1691,7 +1937,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "2dade6b16c22b26cfb488668",
             "_tpl": "5c0e533786f7747fa23f4d47",
             "parentId": "hideout",
@@ -1702,7 +1949,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b8e69a07ef9effe19a22ffdd",
             "_tpl": "5ed515ece452db0eb56fc028",
             "parentId": "hideout",
@@ -1713,7 +1961,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fa0ef0acde8adb6aaf9a8cda",
             "_tpl": "5ed515c8d380ab312177c0fa",
             "parentId": "hideout",
@@ -1724,7 +1973,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ff8a0fbadfeaa1c454b4105d",
             "_tpl": "5ed515f6915ec335206e4152",
             "parentId": "hideout",
@@ -1735,7 +1985,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "5b3ab061d60fd7fc173aaf3b",
             "_tpl": "5c0e530286f7747fa1419862",
             "parentId": "hideout",
@@ -1746,7 +1997,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7d827f002dceb39a9ed88a3a",
             "_tpl": "5ed515e03a40a50460332579",
             "parentId": "hideout",
@@ -1757,7 +2009,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "3e46eb2ceedee4916cfafd6b",
             "_tpl": "5ed5166ad380ab312177c100",
             "parentId": "hideout",
@@ -1768,7 +2021,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7f1f7bdf3aac7ea2effe7a5d",
             "_tpl": "5fca138c2a7b221b2852a5c6",
             "parentId": "hideout",
@@ -1779,7 +2033,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "cdf7f18ffe59d5d44ecacc40",
             "_tpl": "5ed5160a87bb8443d10680b5",
             "parentId": "hideout",
@@ -1790,7 +2045,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e6d31bb2dbe57dfca6ecb31b",
             "_tpl": "5c0e531286f7747fa54205c2",
             "parentId": "hideout",
@@ -1801,7 +2057,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "10a63721a6f9f3410de7b4cf",
             "_tpl": "5c0e531d86f7747fa23f4d42",
             "parentId": "hideout",
@@ -1812,7 +2069,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "eaf7c2c7bbaf1bb808a84a0b",
             "_tpl": "5fca13ca637ee0341a484f46",
             "parentId": "hideout",
@@ -1823,7 +2081,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "6116dd5beadd48eadbc4a2a7",
             "_tpl": "5ed51652f6c34d2cc26336a1",
             "parentId": "hideout",
@@ -1834,7 +2093,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e6bfec0008abd6e15b069fdf",
             "_tpl": "5c0e534186f7747fa1419867",
             "parentId": "hideout",
@@ -1845,7 +2105,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7c70e4df40fc3c5cd4a1ba1f",
             "_tpl": "5c94bbff86f7747ee735c08f",
             "parentId": "hideout",
@@ -1856,7 +2117,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b4dc3ff9d5cbaf5dacb4f58f",
             "_tpl": "5c94bbff86f7747ee735c08f",
             "parentId": "hideout",
@@ -1867,7 +2129,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ea57bcb2aabde22ea6ffe5a4",
             "_tpl": "5efde6b4f5448336730dbd61",
             "parentId": "hideout",
@@ -1878,7 +2141,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7325fbddeceff3d8e1a5c8ae",
             "_tpl": "5c1d0f4986f7744bb01837fa",
             "parentId": "hideout",
@@ -1889,7 +2153,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ffef96aaea2c43db5229145e",
             "_tpl": "5c1d0c5f86f7744bb2683cf0",
             "parentId": "hideout",
@@ -1900,7 +2165,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "efaf9ef33afa9d0a6f4af5e3",
             "_tpl": "5c1d0dc586f7744baf2e7b79",
             "parentId": "hideout",
@@ -1911,7 +2177,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b025e6c110d9fdcad0db075a",
             "_tpl": "5c1d0efb86f7744baf2e7b7b",
             "parentId": "hideout",
@@ -1922,7 +2189,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f42e4e7b2957fbd6da8525d6",
             "_tpl": "5c1e495a86f7743109743dfb",
             "parentId": "hideout",
@@ -1933,7 +2201,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "1df4e3dd2af0bda84f0cb06f",
             "_tpl": "5c1d0d6d86f7744bb2683e1f",
             "parentId": "hideout",
@@ -1944,7 +2213,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f7a696d2fe8a349d56b34ec9",
             "_tpl": "5cc86840d7f00c002412c56c",
             "parentId": "hideout",
@@ -1955,7 +2225,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bbcf627a3011fb7a9609a4bf",
             "_tpl": "5cc86832d7f00c000d3a6e6c",
             "parentId": "hideout",
@@ -1966,7 +2237,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b9ce119cb82d40e1ad2b9dfb",
             "_tpl": "5cc80f79e4a949033c7343b2",
             "parentId": "hideout",
@@ -1977,7 +2249,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7d9f1fbf02eb1b63ef9a91cf",
             "_tpl": "5cc80f8fe4a949033b0224a2",
             "parentId": "hideout",
@@ -1988,7 +2261,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "6f3bcaf9be7efb5a9cc6386e",
             "_tpl": "5cc80f53e4a949000e1ea4f8",
             "parentId": "hideout",
@@ -1999,7 +2273,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "9ffbbd4bd1cd72aae9ce79fa",
             "_tpl": "5cc80f67e4a949035e43bbba",
             "parentId": "hideout",
@@ -2010,7 +2285,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "67194e1598bd9759b9eba1c2",
             "_tpl": "5cc80f38e4a949001152b560",
             "parentId": "hideout",
@@ -2021,7 +2297,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a0d4a64e2c2d3eccb3bd41fe",
             "_tpl": "5cc86840d7f00c002412c56c",
             "parentId": "hideout",
@@ -2032,7 +2309,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "8deef6d1b3234e09971c1fab",
             "_tpl": "5cc86832d7f00c000d3a6e6c",
             "parentId": "hideout",
@@ -2043,7 +2321,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d64e76d3adb9dee66fdcf4a0",
             "_tpl": "5cc80f79e4a949033c7343b2",
             "parentId": "hideout",
@@ -2054,7 +2333,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a77a1d44b124aaf78bf413cb",
             "_tpl": "5cc80f8fe4a949033b0224a2",
             "parentId": "hideout",
@@ -2065,7 +2345,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bbfdbf7e8c829bdaf01a24e2",
             "_tpl": "5cc80f53e4a949000e1ea4f8",
             "parentId": "hideout",
@@ -2076,7 +2357,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a6db1c5dabbed0cb1da38f36",
             "_tpl": "5cc80f67e4a949035e43bbba",
             "parentId": "hideout",
@@ -2087,7 +2369,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bc4191a2caeb2274eaee31ca",
             "_tpl": "5cc80f38e4a949001152b560",
             "parentId": "hideout",
@@ -2098,7 +2381,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fb1a52f738e38a1cefe9c4db",
             "_tpl": "5735fdcd2459776445391d61",
             "parentId": "hideout",
@@ -2109,7 +2393,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "915aeeb8c2ffdacff1bb0d20",
             "_tpl": "5735ff5c245977640e39ba7e",
             "parentId": "hideout",
@@ -2120,7 +2405,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "8dd4bb045cd23b6cae8626d4",
             "_tpl": "5736026a245977644601dc61",
             "parentId": "hideout",
@@ -2131,7 +2417,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "8e6b439cb29ff8c6f2e39ad1",
             "_tpl": "573603c924597764442bd9cb",
             "parentId": "hideout",
@@ -2142,7 +2429,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ecaa6a29b754356b07eb0286",
             "_tpl": "5ea034f65aad6446a939737e",
             "parentId": "hideout",
@@ -2153,7 +2441,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bfb8abf507ada6d60d8fbc07",
             "_tpl": "573602322459776445391df1",
             "parentId": "hideout",
@@ -2164,7 +2453,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ca14ca194a60716cafa23f02",
             "_tpl": "573601b42459776410737435",
             "parentId": "hideout",
@@ -2175,7 +2465,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f8c1b5b1cea294edd8aae8ce",
             "_tpl": "573603562459776430731618",
             "parentId": "hideout",
@@ -2186,7 +2477,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e7198dc8ba1dd4d8be5de271",
             "_tpl": "5735fdcd2459776445391d61",
             "parentId": "hideout",
@@ -2197,7 +2489,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "5a5d16fd31babae6facbbd33",
             "_tpl": "5735ff5c245977640e39ba7e",
             "parentId": "hideout",
@@ -2208,7 +2501,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d2b3dbbffc6d93efc5aadee7",
             "_tpl": "5736026a245977644601dc61",
             "parentId": "hideout",
@@ -2219,7 +2513,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d7a03b44cbedfb164faa6568",
             "_tpl": "573603c924597764442bd9cb",
             "parentId": "hideout",
@@ -2230,7 +2525,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "df0feb4c5e5ec8bda641de13",
             "_tpl": "573602322459776445391df1",
             "parentId": "hideout",
@@ -2241,7 +2537,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "de2be0eb3ac652ce4fbc145d",
             "_tpl": "573601b42459776410737435",
             "parentId": "hideout",
@@ -2252,7 +2549,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "086ee00585e6fffe9c49a94e",
             "_tpl": "573603562459776430731618",
             "parentId": "hideout",
@@ -2263,7 +2561,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b70ea8cfd98f44efddcb7ec9",
             "_tpl": "573719762459775a626ccbc1",
             "parentId": "hideout",
@@ -2274,7 +2573,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e311ead52063d21d4d7cedcd",
             "_tpl": "573724b42459776125652ac2",
             "parentId": "hideout",
@@ -2285,7 +2585,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a67fc7c3bdacc083023cba0a",
             "_tpl": "573719762459775a626ccbc1",
             "parentId": "e311ead52063d21d4d7cedcd",
@@ -2294,7 +2595,8 @@
             "upd": {
                 "StackObjectsCount": 16
             }
-        }, {
+        },
+        {
             "_id": "ceae16d808bbe67f0fa7b6a0",
             "_tpl": "57371f8d24597761006c6a81",
             "parentId": "hideout",
@@ -2305,7 +2607,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f447b102bd5acfbc207eb149",
             "_tpl": "5737273924597765dd374461",
             "parentId": "hideout",
@@ -2316,7 +2619,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e88baa68c97af2ccece35bde",
             "_tpl": "57371f8d24597761006c6a81",
             "parentId": "f447b102bd5acfbc207eb149",
@@ -2325,7 +2629,8 @@
             "upd": {
                 "StackObjectsCount": 16
             }
-        }, {
+        },
+        {
             "_id": "bbfadaa86f4cdbd0c086dadb",
             "_tpl": "57371f2b24597761224311f1",
             "parentId": "hideout",
@@ -2336,7 +2641,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "2efde2abb2baf3ae1ff2ff4a",
             "_tpl": "573726d824597765d96be361",
             "parentId": "hideout",
@@ -2347,7 +2653,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b55fb66ba6edbe04cd477ab7",
             "_tpl": "57371f2b24597761224311f1",
             "parentId": "2efde2abb2baf3ae1ff2ff4a",
@@ -2356,7 +2663,8 @@
             "upd": {
                 "StackObjectsCount": 16
             }
-        }, {
+        },
+        {
             "_id": "1fb4b1cf54aca1271f0894b5",
             "_tpl": "57371eb62459776125652ac1",
             "parentId": "hideout",
@@ -2367,7 +2675,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b42cc6376a1904a1febe235a",
             "_tpl": "5737266524597761006c6a8c",
             "parentId": "hideout",
@@ -2378,7 +2687,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fddd521cbb50c0beffbc75e8",
             "_tpl": "57371eb62459776125652ac1",
             "parentId": "b42cc6376a1904a1febe235a",
@@ -2387,7 +2697,8 @@
             "upd": {
                 "StackObjectsCount": 16
             }
-        }, {
+        },
+        {
             "_id": "fb6d6d563facc7f8b9e633bd",
             "_tpl": "57371e4124597760ff7b25f1",
             "parentId": "hideout",
@@ -2398,7 +2709,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e1bbeed79f7fea0dfa12d80b",
             "_tpl": "5737260b24597761224311f2",
             "parentId": "hideout",
@@ -2409,7 +2721,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "46cfee7d4becddfb2adc8aaf",
             "_tpl": "57371e4124597760ff7b25f1",
             "parentId": "e1bbeed79f7fea0dfa12d80b",
@@ -2418,7 +2731,8 @@
             "upd": {
                 "StackObjectsCount": 16
             }
-        }, {
+        },
+        {
             "_id": "44dc7035bc97bc6cc5dcc383",
             "_tpl": "57371b192459775a9f58a5e0",
             "parentId": "hideout",
@@ -2429,7 +2743,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "dfc0bc12fc570ccec1ffabbd",
             "_tpl": "573725b0245977612125bae2",
             "parentId": "hideout",
@@ -2440,7 +2755,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a0d3a13f4daf8c829d42e073",
             "_tpl": "57371b192459775a9f58a5e0",
             "parentId": "dfc0bc12fc570ccec1ffabbd",
@@ -2449,7 +2765,8 @@
             "upd": {
                 "StackObjectsCount": 16
             }
-        }, {
+        },
+        {
             "_id": "c5e8f7eff6cdb0bf95ddadc2",
             "_tpl": "5737201124597760fc4431f1",
             "parentId": "hideout",
@@ -2460,7 +2777,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c2ae85b817d44dbeccd1f8ee",
             "_tpl": "573727c624597765cc785b5b",
             "parentId": "hideout",
@@ -2471,7 +2789,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "9b9cebaa12cba1fcbf17c986",
             "_tpl": "5737201124597760fc4431f1",
             "parentId": "c2ae85b817d44dbeccd1f8ee",
@@ -2480,7 +2799,8 @@
             "upd": {
                 "StackObjectsCount": 16
             }
-        }, {
+        },
+        {
             "_id": "c0cd0cd5d6fc2bca97e78fac",
             "_tpl": "5737218f245977612125ba51",
             "parentId": "hideout",
@@ -2491,7 +2811,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "3581cfb9a4b12786e6edec65",
             "_tpl": "573728f324597765e5728561",
             "parentId": "hideout",
@@ -2502,7 +2823,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "75429bba600f19fcbfb1bc6b",
             "_tpl": "5737218f245977612125ba51",
             "parentId": "3581cfb9a4b12786e6edec65",
@@ -2511,7 +2833,8 @@
             "upd": {
                 "StackObjectsCount": 16
             }
-        }, {
+        },
+        {
             "_id": "8d7203ba6b66cc3c4b201ff5",
             "_tpl": "57d1519e24597714373db79d",
             "parentId": "hideout",
@@ -2522,7 +2845,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "470bae3f55f0debfbb94a46b",
             "_tpl": "5737207f24597760ff7b25f2",
             "parentId": "hideout",
@@ -2533,7 +2857,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d0ebab7adbcd6e4abd3e0b6a",
             "_tpl": "5737280e24597765cc785b5c",
             "parentId": "hideout",
@@ -2544,7 +2869,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d869fbeda45f6da5d4e8bf0b",
             "_tpl": "5737207f24597760ff7b25f2",
             "parentId": "d0ebab7adbcd6e4abd3e0b6a",
@@ -2553,7 +2879,8 @@
             "upd": {
                 "StackObjectsCount": 16
             }
-        }, {
+        },
+        {
             "_id": "0edcf83e0494db293b0417fd",
             "_tpl": "573720e02459776143012541",
             "parentId": "hideout",
@@ -2564,7 +2891,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7acfff1f46adfbcef1e5f760",
             "_tpl": "5737287724597765e1625ae2",
             "parentId": "hideout",
@@ -2575,7 +2903,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "22cc0416b5d9aa81c20ba5ef",
             "_tpl": "573720e02459776143012541",
             "parentId": "7acfff1f46adfbcef1e5f760",
@@ -2584,7 +2913,8 @@
             "upd": {
                 "StackObjectsCount": 16
             }
-        }, {
+        },
+        {
             "_id": "fefe0d415e3f871fc23539fa",
             "_tpl": "57372140245977611f70ee91",
             "parentId": "hideout",
@@ -2595,7 +2925,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "dcf10a6a92e1a9b36540f0e3",
             "_tpl": "573728cc24597765cc785b5d",
             "parentId": "hideout",
@@ -2606,7 +2937,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "9573cec812b4ce0eb0d7e1cc",
             "_tpl": "57372140245977611f70ee91",
             "parentId": "dcf10a6a92e1a9b36540f0e3",
@@ -2615,7 +2947,8 @@
             "upd": {
                 "StackObjectsCount": 16
             }
-        }, {
+        },
+        {
             "_id": "bcefecbc9938df34a4b9ccca",
             "_tpl": "573718ba2459775a75491131",
             "parentId": "hideout",
@@ -2626,7 +2959,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "2bf6fa9ebcfa2fa7a597aa89",
             "_tpl": "573722e82459776104581c21",
             "parentId": "hideout",
@@ -2637,7 +2971,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "68ec8105cedc2875d08dc20e",
             "_tpl": "573718ba2459775a75491131",
             "parentId": "2bf6fa9ebcfa2fa7a597aa89",
@@ -2646,7 +2981,8 @@
             "upd": {
                 "StackObjectsCount": 16
             }
-        }, {
+        },
+        {
             "_id": "fed0f57ea117d4dfd7ebaf0e",
             "_tpl": "55d485be4bdc2d962f8b456f",
             "parentId": "hideout",
@@ -2657,7 +2993,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "3d3aff70ebf8fcee2feaef19",
             "_tpl": "57371aab2459775a77142f22",
             "parentId": "hideout",
@@ -2668,7 +3005,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a31fdb5d730cc4abc1359222",
             "_tpl": "5737256c2459776125652acd",
             "parentId": "hideout",
@@ -2679,7 +3017,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ddbc0e5daef9b13bb2cb5401",
             "_tpl": "573722e82459776104581c21",
             "parentId": "a31fdb5d730cc4abc1359222",
@@ -2688,7 +3027,8 @@
             "upd": {
                 "StackObjectsCount": 16
             }
-        }, {
+        },
+        {
             "_id": "b09decf5006aef30bc6b81d9",
             "_tpl": "573719df2459775a626ccbc2",
             "parentId": "hideout",
@@ -2699,7 +3039,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "94ab28efe9871ded5c716c82",
             "_tpl": "573722e82459776104581c21",
             "parentId": "hideout",
@@ -2710,7 +3051,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c1ae74dfd3013ff9caac782b",
             "_tpl": "573719df2459775a626ccbc2",
             "parentId": "94ab28efe9871ded5c716c82",
@@ -2719,7 +3061,8 @@
             "upd": {
                 "StackObjectsCount": 16
             }
-        }, {
+        },
+        {
             "_id": "cd74e02d515cbceddedbe4d0",
             "_tpl": "573719762459775a626ccbc1",
             "parentId": "hideout",
@@ -2730,7 +3073,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e224f506ebadcb69be0f0c09",
             "_tpl": "57371f8d24597761006c6a81",
             "parentId": "hideout",
@@ -2741,7 +3085,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "65b379bb5c3fe44c00e9fbd9",
             "_tpl": "57371f2b24597761224311f1",
             "parentId": "hideout",
@@ -2752,7 +3097,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "11f451f96ec3bf5bcfbbb40d",
             "_tpl": "57371eb62459776125652ac1",
             "parentId": "hideout",
@@ -2763,7 +3109,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "4dc2c96e5d3e3231f51e7df6",
             "_tpl": "57371e4124597760ff7b25f1",
             "parentId": "hideout",
@@ -2774,7 +3121,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "dca3fc1a711ba7321847b21a",
             "_tpl": "57371b192459775a9f58a5e0",
             "parentId": "hideout",
@@ -2785,7 +3133,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fdbfda26046c99eacda24230",
             "_tpl": "5737201124597760fc4431f1",
             "parentId": "hideout",
@@ -2796,7 +3145,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "58a9aafc80d40a7eb0fc02bd",
             "_tpl": "5737218f245977612125ba51",
             "parentId": "hideout",
@@ -2807,7 +3157,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "df65013e31dffb8dfad3536f",
             "_tpl": "5737207f24597760ff7b25f2",
             "parentId": "hideout",
@@ -2818,7 +3169,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "dcfe5a0eea4daf9dd0c322be",
             "_tpl": "573720e02459776143012541",
             "parentId": "hideout",
@@ -2829,7 +3181,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d5fac2c7a2188bae4313e918",
             "_tpl": "57372140245977611f70ee91",
             "parentId": "hideout",
@@ -2840,7 +3193,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "44ed1accafdaaed4ee3a0e16",
             "_tpl": "573718ba2459775a75491131",
             "parentId": "hideout",
@@ -2851,7 +3205,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ebde2ceaef7d9ebbee06aa7d",
             "_tpl": "57371aab2459775a77142f22",
             "parentId": "hideout",
@@ -2862,7 +3217,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fbb8cf1dff9bec9bbedd88f1",
             "_tpl": "573719df2459775a626ccbc2",
             "parentId": "hideout",
@@ -2873,7 +3229,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "eeddbaba031b3f96b74dba96",
             "_tpl": "5a26abfac4a28232980eabff",
             "parentId": "hideout",
@@ -2884,7 +3241,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "cae5752aa3ecab6b9ccd89a4",
             "_tpl": "5a26ac06c4a282000c5a90a8",
             "parentId": "hideout",
@@ -2895,7 +3253,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "db5ff86b7b75e2dde1047c3a",
             "_tpl": "5a269f97c4a282000b151807",
             "parentId": "hideout",
@@ -2906,7 +3265,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "42bb63dfc8c40462c49fcec7",
             "_tpl": "5a26ac0ec4a28200741e1e18",
             "parentId": "hideout",
@@ -2917,7 +3277,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "335d2dbc72ece7c0536baeca",
             "_tpl": "5a26abfac4a28232980eabff",
             "parentId": "hideout",
@@ -2928,7 +3289,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fa74ecbfebcfcb32fe692dbd",
             "_tpl": "5a26ac06c4a282000c5a90a8",
             "parentId": "hideout",
@@ -2939,7 +3301,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f6a8a28ebfb759e0fc37bfd4",
             "_tpl": "5a269f97c4a282000b151807",
             "parentId": "hideout",
@@ -2950,7 +3313,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b41a0bad056354fdd14de2e5",
             "_tpl": "5a26ac0ec4a28200741e1e18",
             "parentId": "hideout",
@@ -2961,7 +3325,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ecb1bdb04dcfbbc31452cafb",
             "_tpl": "5b432b965acfc47a8774094e",
             "parentId": "hideout",
@@ -2972,7 +3337,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fafeafaf9e86834f07cbef8c",
             "_tpl": "6033fa48ffd42c541047f728",
             "parentId": "hideout",
@@ -2983,7 +3349,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fec191eb6f7f5dacd57322ee",
             "_tpl": "5c165d832e2216398b5a7e36",
             "parentId": "hideout",
@@ -2994,7 +3361,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "83f84aa7f1d5baa8375f2ea6",
             "_tpl": "5645bcc04bdc2d363b8b4572",
             "parentId": "hideout",
@@ -3005,7 +3373,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a2efdd1780ef304db3cd336d",
             "_tpl": "5aa2ba71e5b5b000137b758f",
             "parentId": "hideout",
@@ -3016,7 +3385,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "3c9f0e8134cb86cea7faab5e",
             "_tpl": "5a16b9fffcdbcb0176308b34",
             "parentId": "hideout",
@@ -3027,7 +3397,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "1fffddf2426ada1efc09f219",
             "_tpl": "5e4d34ca86f774264f758330",
             "parentId": "hideout",
@@ -3038,7 +3409,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c27e4e7bb0cdc556dca031fc",
             "_tpl": "5f60cd6cf2bcbb675b00dac6",
             "parentId": "hideout",
@@ -3049,7 +3421,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "5a4f3ab67a1121acfe8a48b1",
             "_tpl": "5b432b965acfc47a8774094e",
             "parentId": "hideout",
@@ -3060,7 +3433,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "8958ba634c1bf3dd1d0ce6eb",
             "_tpl": "6033fa48ffd42c541047f728",
             "parentId": "hideout",
@@ -3071,7 +3445,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "1ee092ec29c3cad8ebba19ca",
             "_tpl": "5c165d832e2216398b5a7e36",
             "parentId": "hideout",
@@ -3082,7 +3457,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b6ad0c8fee8849dfacdcad1b",
             "_tpl": "5645bcc04bdc2d363b8b4572",
             "parentId": "hideout",
@@ -3093,7 +3469,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f8a58f6dfde99fafaacfa7cd",
             "_tpl": "5aa2ba71e5b5b000137b758f",
             "parentId": "hideout",
@@ -3104,7 +3481,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a7d97272bfab4233d4a7a61b",
             "_tpl": "5a16b9fffcdbcb0176308b34",
             "parentId": "hideout",
@@ -3115,7 +3493,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c07efaad20cede5b63b77b3a",
             "_tpl": "5e4d34ca86f774264f758330",
             "parentId": "hideout",
@@ -3126,7 +3505,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "943b4c8e756cd15cdd8ed8b1",
             "_tpl": "5f60cd6cf2bcbb675b00dac6",
             "parentId": "hideout",
@@ -3137,7 +3517,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7c6afdd5e9bafc1e9e546d9f",
             "_tpl": "5cadc190ae921500103bb3b6",
             "parentId": "hideout",
@@ -3148,42 +3529,50 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "da51efda5c4873d3220bfbc6",
             "_tpl": "5cadc1c6ae9215000f2775a4",
             "parentId": "7c6afdd5e9bafc1e9e546d9f",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "f28fefcfdf8fda274acbfa72",
             "_tpl": "5cadc390ae921500126a77f1",
             "parentId": "da51efda5c4873d3220bfbc6",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "af79ffeef3e7a87afbe75bdd",
             "_tpl": "5cadc431ae921500113bb8d5",
             "parentId": "7c6afdd5e9bafc1e9e546d9f",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "c4b8988b1fb92ae99fca94a4",
             "_tpl": "5cadc55cae921500103bb3be",
             "parentId": "7c6afdd5e9bafc1e9e546d9f",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "ea0acf27cfe4fbfafbf4af9c",
             "_tpl": "5cadd940ae9215051e1c2316",
             "parentId": "c4b8988b1fb92ae99fca94a4",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "5bfe14c7fafe1bb8c0e4badb",
             "_tpl": "5cadd919ae921500126a77f3",
             "parentId": "c4b8988b1fb92ae99fca94a4",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "1afde0fcf7c97ea8bdc3f054",
             "_tpl": "5cadc2e0ae9215051e1c21e7",
             "parentId": "7c6afdd5e9bafc1e9e546d9f",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "274abdae1feb2ac1add7fafd",
             "_tpl": "579204f224597773d619e051",
             "parentId": "hideout",
@@ -3194,27 +3583,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d45",
             "_tpl": "5448c12b4bdc2d02308b456f",
             "parentId": "274abdae1feb2ac1add7fafd",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d46",
             "_tpl": "6374a822e629013b9c0645c8",
             "parentId": "274abdae1feb2ac1add7fafd",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d47",
             "_tpl": "63c6adcfb4ba094317063742",
             "parentId": "6670e6bb622e80dbf3056d46",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d48",
             "_tpl": "6374a7e7417239a7bf00f042",
             "parentId": "274abdae1feb2ac1add7fafd",
             "slotId": "mod_pistolgrip"
-        }, {
+        },
+        {
             "_id": "aa0de437e1a4dfaa7f4e8bc6",
             "_tpl": "571a12c42459771f627b58a0",
             "parentId": "hideout",
@@ -3225,22 +3619,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "210e30dce8abe6d10ebfa5c6",
             "_tpl": "571a26d524597720680fbe8a",
             "parentId": "aa0de437e1a4dfaa7f4e8bc6",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "0efe2ef5bc47c9eebc2e9a28",
             "_tpl": "571a282c2459771fb2755a69",
             "parentId": "aa0de437e1a4dfaa7f4e8bc6",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "9d2d59694fcdd24d0b6aeccf",
             "_tpl": "571a29dc2459771fb2755a6a",
             "parentId": "aa0de437e1a4dfaa7f4e8bc6",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "6d88bd83d9eadaf199fe607e",
             "_tpl": "571a29dc2459771fb2755a6a",
             "parentId": "hideout",
@@ -3251,7 +3649,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e5dddfb1dfaf5efd25d66bb5",
             "_tpl": "5448c12b4bdc2d02308b456f",
             "parentId": "hideout",
@@ -3262,7 +3661,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "75bb11b0c4fc1dcc8e7de05f",
             "_tpl": "5cadc2e0ae9215051e1c21e7",
             "parentId": "hideout",
@@ -3273,7 +3673,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "df3bca39d57fb7dd5ad84bae",
             "_tpl": "576a581d2459771e7b1bc4f1",
             "parentId": "hideout",
@@ -3284,17 +3685,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7515cefbcdb420ebf3a6c9e4",
             "_tpl": "576a5ed62459771e9c2096cb",
             "parentId": "df3bca39d57fb7dd5ad84bae",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "eea7a6e95e92ff7aac039ba1",
             "_tpl": "576a63cd2459771e796e0e11",
             "parentId": "df3bca39d57fb7dd5ad84bae",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "f7cafc93ff48d56f7864b5dd",
             "_tpl": "5a7ae0c351dfba0017554310",
             "parentId": "hideout",
@@ -3305,32 +3709,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a9e271ebe0691bb6ab5021ce",
             "_tpl": "5a6b5f868dc32e000a311389",
             "parentId": "f7cafc93ff48d56f7864b5dd",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "c9b4b6c0238cb5f0ba3de95c",
             "_tpl": "5a6f5d528dc32e00094b97d9",
             "parentId": "acfa0e23a24e4bbe9c1ff10d",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "4fc8f6a5cc11622ab08bd0dd",
             "_tpl": "5a6f58f68dc32e000a311390",
             "parentId": "acfa0e23a24e4bbe9c1ff10d",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "acfa0e23a24e4bbe9c1ff10d",
             "_tpl": "5a6f5e048dc32e00094b97da",
             "parentId": "f7cafc93ff48d56f7864b5dd",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "daf3f9a638fccb061b9dc5ff",
             "_tpl": "5a718b548dc32e000d46d262",
             "parentId": "f7cafc93ff48d56f7864b5dd",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "cdbae4551d855b106e710592",
             "_tpl": "56d59856d2720bd8418b456a",
             "parentId": "hideout",
@@ -3341,37 +3751,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bb0a8f977bcac81bdf15efe5",
             "_tpl": "56d5a1f7d2720bb3418b456a",
             "parentId": "cdbae4551d855b106e710592",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "58ee58dc404baddccb9df07f",
             "_tpl": "56d5a2bbd2720bb8418b456a",
             "parentId": "cdbae4551d855b106e710592",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "4bbe1edcd1cea8cee0cee15a",
             "_tpl": "56d5a77ed2720b90418b4568",
             "parentId": "cda553b8dbd1afe1c9e8ee2d",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "43bf9d2fa5ba4f74b0f9224f",
             "_tpl": "56d5a661d2720bd8418b456b",
             "parentId": "cda553b8dbd1afe1c9e8ee2d",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "cda553b8dbd1afe1c9e8ee2d",
             "_tpl": "56d5a407d2720bb3418b456b",
             "parentId": "cdbae4551d855b106e710592",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "67be4d1bafac3b9ae5c7500d",
             "_tpl": "56d59948d2720bb7418b4582",
             "parentId": "cdbae4551d855b106e710592",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "cc4bbc4118a8e9df8fbba40f",
             "_tpl": "576a5ed62459771e9c2096cb",
             "parentId": "hideout",
@@ -3382,7 +3799,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "1e8aa11dffada086c5068dc8",
             "_tpl": "56d59948d2720bb7418b4582",
             "parentId": "hideout",
@@ -3393,7 +3811,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7cfec9cc8a48b1f4e1d55208",
             "_tpl": "5a718b548dc32e000d46d262",
             "parentId": "hideout",
@@ -3404,7 +3823,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7e2bf94e29cf707e7f0b5ad8",
             "_tpl": "5f36a0e5fbf956000b716b65",
             "parentId": "hideout",
@@ -3415,52 +3835,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "dcf2de83c9dec72f85fcf5fe",
             "_tpl": "5f3e7801153b8571434a924c",
             "parentId": "7e2bf94e29cf707e7f0b5ad8",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "9de2edd1e92c1f6f1956dae5",
             "_tpl": "5f3e778efcd9b651187d7201",
             "parentId": "7e2bf94e29cf707e7f0b5ad8",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "8eb0e67a2bdeb2ed78d5ed65",
             "_tpl": "5f3e7823ddc4f03b010e2045",
             "parentId": "7e2bf94e29cf707e7f0b5ad8",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "27ddcdeca6fed2c3eddfcda0",
             "_tpl": "5f3e7897ddc4f03b010e204a",
             "parentId": "8eb0e67a2bdeb2ed78d5ed65",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "0b4ae2e71acd65cdd3acec1b",
             "_tpl": "5f3e78a7fbf956000b716b8e",
             "parentId": "8eb0e67a2bdeb2ed78d5ed65",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "03a00baf5de13002a0732e91",
             "_tpl": "5f3e77b26cda304dcc634057",
             "parentId": "7e2bf94e29cf707e7f0b5ad8",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "4eab8df33c075cec5b9caedc",
             "_tpl": "5f3e772a670e2a7b01739a52",
             "parentId": "7e2bf94e29cf707e7f0b5ad8",
             "slotId": "mod_trigger"
-        }, {
+        },
+        {
             "_id": "cba70583c5dacaea3a2bbb1f",
             "_tpl": "5f3e76d86cda304dcc634054",
             "parentId": "7e2bf94e29cf707e7f0b5ad8",
             "slotId": "mod_hammer"
-        }, {
+        },
+        {
             "_id": "f5d04441fed5b937f0cb9b33",
             "_tpl": "5f3e777688ca2d00ad199d25",
             "parentId": "7e2bf94e29cf707e7f0b5ad8",
             "slotId": "mod_catch"
-        }, {
+        },
+        {
             "_id": "aaaa7a8a7368208a87fabaa7",
             "_tpl": "6193a720f8ee7e52e42109ed",
             "parentId": "hideout",
@@ -3471,57 +3901,68 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "fe8c3f1e8abb478eef9da321",
             "_tpl": "6194efe07c6c7b169525f11b",
             "parentId": "aaaa7a8a7368208a87fabaa7",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "e7bcb15cafbfff7a8b5bca47",
             "_tpl": "6194f1f918a3974e5e7421e4",
             "parentId": "fe8c3f1e8abb478eef9da321",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "032d5eb22640a6d41ed7f17d",
             "_tpl": "6194f41f9fb0c665d5490e75",
             "parentId": "aaaa7a8a7368208a87fabaa7",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "4f8fa5b09bec8ab50c0a41cc",
             "_tpl": "6194f2df645b5d229654ad77",
             "parentId": "032d5eb22640a6d41ed7f17d",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "e7fcb508fb713f0127d69a1d",
             "_tpl": "6194f3286db0f2477964e67d",
             "parentId": "032d5eb22640a6d41ed7f17d",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "ccc30bdcca1bfe2066fabb71",
             "_tpl": "6193d3149fb0c665d5490e32",
             "parentId": "aaaa7a8a7368208a87fabaa7",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "72926eb1acbc8d8cccd7dc8b",
             "_tpl": "6193d3cded0429009f543e6a",
             "parentId": "aaaa7a8a7368208a87fabaa7",
             "slotId": "mod_trigger"
-        }, {
+        },
+        {
             "_id": "a3d43a04e83ca0b70fde1c12",
             "_tpl": "6193d3be7c6c7b169525f0da",
             "parentId": "aaaa7a8a7368208a87fabaa7",
             "slotId": "mod_hammer"
-        }, {
+        },
+        {
             "_id": "8fc119d84a36bfb93115eefb",
             "_tpl": "6193d5d4f8ee7e52e4210a1b",
             "parentId": "aaaa7a8a7368208a87fabaa7",
             "slotId": "mod_catch"
-        }, {
+        },
+        {
             "_id": "05fd21344a52dafc795ad58a",
             "_tpl": "6196255558ef8c428c287d1c",
             "parentId": "aaaa7a8a7368208a87fabaa7",
             "slotId": "mod_mount_000"
-        }, {
+        },
+        {
             "_id": "d01a690a010ef47f25eed3f5",
             "_tpl": "5a17f98cfcdbcb0980087290",
             "parentId": "hideout",
@@ -3532,27 +3973,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "edd4aaad55ecadcbb0dba96c",
             "_tpl": "5a17fb03fcdbcbcae668728f",
             "parentId": "d01a690a010ef47f25eed3f5",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "7bbc4fbebae7b0d8cefbaf7f",
             "_tpl": "5a17fc70fcdbcb0176308b3d",
             "parentId": "d01a690a010ef47f25eed3f5",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "db0b0216eb9dbacc4cdd93d3",
             "_tpl": "5aba62f8d8ce87001943946b",
             "parentId": "d01a690a010ef47f25eed3f5",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "7a8c2aed9448f34b5bd5efb5",
             "_tpl": "5aba637ad8ce87001773e17f",
             "parentId": "d01a690a010ef47f25eed3f5",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "7381a6f08346819bccccac84",
             "_tpl": "602a9740da11d6478d5a06dc",
             "parentId": "hideout",
@@ -3563,32 +4009,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f57c6cd5bf8da81bd4fce6eb",
             "_tpl": "602a95edda11d6478d5a06da",
             "parentId": "7381a6f08346819bccccac84",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "b74810dcefdac62d7fb30aaf",
             "_tpl": "60228924961b8d75ee233c32",
             "parentId": "7381a6f08346819bccccac84",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "de5bdcf99b0aaaeae7ddbe46",
             "_tpl": "60229948cacb6b0506369e27",
             "parentId": "b74810dcefdac62d7fb30aaf",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "d3d3fb57c51c0cbfca41a034",
             "_tpl": "60228a76d62c9b14ed777a66",
             "parentId": "b74810dcefdac62d7fb30aaf",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "f88574377cbbe2fd781ce1dc",
             "_tpl": "602286df23506e50807090c6",
             "parentId": "7381a6f08346819bccccac84",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "4fdabd5c10fababd592cceac",
             "_tpl": "5e81c4ca763d9f754677befa",
             "parentId": "hideout",
@@ -3599,7 +4051,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "dfbdd6cbc2fbc48576e8f8d9",
             "_tpl": "5f3e77b26cda304dcc634057",
             "parentId": "hideout",
@@ -3610,7 +4063,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "dd2bb0afe4e2ba47debab11c",
             "_tpl": "5a17fb03fcdbcbcae668728f",
             "parentId": "hideout",
@@ -3621,7 +4075,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "aabcec9052e82ab98e259acf",
             "_tpl": "602286df23506e50807090c6",
             "parentId": "hideout",
@@ -3632,7 +4087,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f6f8094cc6edeaff15378dfd",
             "_tpl": "6193d338de3cdf1d2614a6fc",
             "parentId": "hideout",
@@ -3643,7 +4099,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "beb9f3ffaeadabfa84bd63c7",
             "_tpl": "5d3eb3b0a4b93615055e84d2",
             "parentId": "hideout",
@@ -3654,32 +4111,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ceda1534de69e167d46eddee",
             "_tpl": "5d3eb5b6a4b9361eab311902",
             "parentId": "beb9f3ffaeadabfa84bd63c7",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "e4be2c4e0dc5a743baa8ccbd",
             "_tpl": "5d3eb44aa4b93650d64e4979",
             "parentId": "beb9f3ffaeadabfa84bd63c7",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "cdaf17abc3f33c3791aed617",
             "_tpl": "5d3eb4aba4b93650d64e497d",
             "parentId": "e4be2c4e0dc5a743baa8ccbd",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "3edcabaaae5d2cd8d8710ee3",
             "_tpl": "5d3eb536a4b9363b1f22f8e2",
             "parentId": "e4be2c4e0dc5a743baa8ccbd",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "596fb2f637f2b898df3f4fd9",
             "_tpl": "5d3eb5eca4b9363b1f22f8e4",
             "parentId": "beb9f3ffaeadabfa84bd63c7",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "b98cdb4c21f84340dc0eecec",
             "_tpl": "5b1fa9b25acfc40018633c01",
             "parentId": "hideout",
@@ -3690,32 +4153,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7caeadffee0222a8a3a2791d",
             "_tpl": "5b1fa9ea5acfc40018633c0a",
             "parentId": "b98cdb4c21f84340dc0eecec",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "8b2cecf81fe3aa3c52c2c072",
             "_tpl": "5b1faa0f5acfc40dc528aeb5",
             "parentId": "b98cdb4c21f84340dc0eecec",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "de4f96d3ebbadbfe48999ad9",
             "_tpl": "5a6f5d528dc32e00094b97d9",
             "parentId": "8b2cecf81fe3aa3c52c2c072",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "a47cbaadfaa74cb44f387f9b",
             "_tpl": "5a6f58f68dc32e000a311390",
             "parentId": "8b2cecf81fe3aa3c52c2c072",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "b4eff2ebc24e1c9eeaed33f6",
             "_tpl": "5a718b548dc32e000d46d262",
             "parentId": "b98cdb4c21f84340dc0eecec",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "937e5a4cf8ecc4218ce9bedc",
             "_tpl": "59f98b4986f7746f546d2cef",
             "parentId": "hideout",
@@ -3726,12 +4195,14 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "6b9e1a5512472bf5ed1aaf1e",
             "_tpl": "59f99a7d86f7745b134aa97b",
             "parentId": "937e5a4cf8ecc4218ce9bedc",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "fb783eba01beec33bcdcdb2b",
             "_tpl": "5d3eb5eca4b9363b1f22f8e4",
             "parentId": "hideout",
@@ -3742,7 +4213,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "189b44fcb7eeab81cee03fec",
             "_tpl": "59f99a7d86f7745b134aa97b",
             "parentId": "hideout",
@@ -3753,7 +4225,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c9b1a0fc5d3eaceffe1b74fe",
             "_tpl": "5cadc190ae921500103bb3b6",
             "parentId": "hideout",
@@ -3764,42 +4237,50 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ab5cdbdd12a4faa0eceadcdc",
             "_tpl": "5cadc1c6ae9215000f2775a4",
             "parentId": "c9b1a0fc5d3eaceffe1b74fe",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "331d4ce41b81a5fd0b84ccfb",
             "_tpl": "5cadc390ae921500126a77f1",
             "parentId": "ab5cdbdd12a4faa0eceadcdc",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "a35e5bc8ccf266727515af71",
             "_tpl": "5cadc431ae921500113bb8d5",
             "parentId": "c9b1a0fc5d3eaceffe1b74fe",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "4121f3cbeb458d78bc18f48c",
             "_tpl": "5cadc55cae921500103bb3be",
             "parentId": "c9b1a0fc5d3eaceffe1b74fe",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "b4fd3b21dffd9a75fe2b2b62",
             "_tpl": "5cadd940ae9215051e1c2316",
             "parentId": "4121f3cbeb458d78bc18f48c",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "4ffe7da64e219ff9ad7efda0",
             "_tpl": "5cadd919ae921500126a77f3",
             "parentId": "4121f3cbeb458d78bc18f48c",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "e560991cf8defede9a72db87",
             "_tpl": "5cadc2e0ae9215051e1c21e7",
             "parentId": "c9b1a0fc5d3eaceffe1b74fe",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "fbe55784d196ee9d82b8dda3",
             "_tpl": "579204f224597773d619e051",
             "parentId": "hideout",
@@ -3810,27 +4291,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d51",
             "_tpl": "5448c12b4bdc2d02308b456f",
             "parentId": "fbe55784d196ee9d82b8dda3",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d52",
             "_tpl": "6374a822e629013b9c0645c8",
             "parentId": "fbe55784d196ee9d82b8dda3",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d53",
             "_tpl": "63c6adcfb4ba094317063742",
             "parentId": "6670e6bb622e80dbf3056d52",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d54",
             "_tpl": "6374a7e7417239a7bf00f042",
             "parentId": "fbe55784d196ee9d82b8dda3",
             "slotId": "mod_pistolgrip"
-        }, {
+        },
+        {
             "_id": "3a9cb7a0affcffd85acd25f8",
             "_tpl": "5448bd6b4bdc2dfc2f8b4569",
             "parentId": "hideout",
@@ -3841,27 +4327,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d3a",
             "_tpl": "5448c12b4bdc2d02308b456f",
             "parentId": "3a9cb7a0affcffd85acd25f8",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d3b",
             "_tpl": "6374a822e629013b9c0645c8",
             "parentId": "3a9cb7a0affcffd85acd25f8",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d3c",
             "_tpl": "63c6adcfb4ba094317063742",
             "parentId": "6670e6bb622e80dbf3056d3b",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "6670e6bb622e80dbf3056d3d",
             "_tpl": "6374a7e7417239a7bf00f042",
             "parentId": "3a9cb7a0affcffd85acd25f8",
             "slotId": "mod_pistolgrip"
-        }, {
+        },
+        {
             "_id": "d3644926fee7bda253bcb1a5",
             "_tpl": "56e0598dd2720bb5668b45a6",
             "parentId": "hideout",
@@ -3872,22 +4363,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "88ac8f0c7b60d1bf21f56ad3",
             "_tpl": "5448c12b4bdc2d02308b456f",
             "parentId": "d3644926fee7bda253bcb1a5",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "b39a4bf8ddecbaa41ced2bfb",
             "_tpl": "56e05b06d2720bb2668b4586",
             "parentId": "d3644926fee7bda253bcb1a5",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "bbaa9ebd66bdb20c53e41fc6",
             "_tpl": "56e05a6ed2720bd0748b4567",
             "parentId": "d3644926fee7bda253bcb1a5",
             "slotId": "mod_pistolgrip"
-        }, {
+        },
+        {
             "_id": "820211af1bb0cce1ecb026b2",
             "_tpl": "571a12c42459771f627b58a0",
             "parentId": "hideout",
@@ -3898,22 +4393,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "48acad9f2a2b9bbfc966f2ca",
             "_tpl": "571a26d524597720680fbe8a",
             "parentId": "820211af1bb0cce1ecb026b2",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "1cb5acdfd6acc7f9a71bdb5f",
             "_tpl": "571a282c2459771fb2755a69",
             "parentId": "820211af1bb0cce1ecb026b2",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "7bbdffaa9e020a0b69aca41b",
             "_tpl": "571a29dc2459771fb2755a6a",
             "parentId": "820211af1bb0cce1ecb026b2",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "5b0def9296a9f2ef8ecbca8c",
             "_tpl": "5b3b713c5acfc4330140bd8d",
             "parentId": "hideout",
@@ -3924,22 +4423,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "14ae613d9828dec76ad591f2",
             "_tpl": "5b3baf8f5acfc40dc5296692",
             "parentId": "5b0def9296a9f2ef8ecbca8c",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "eb0ebb4dfa9e2cbf8f5e3cde",
             "_tpl": "5b3cadf35acfc400194776a0",
             "parentId": "5b0def9296a9f2ef8ecbca8c",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "5f6d56c9aa2a1deea4badada",
             "_tpl": "571a29dc2459771fb2755a6a",
             "parentId": "5b0def9296a9f2ef8ecbca8c",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "ee565bb7e3ecda6bcafbd514",
             "_tpl": "576a581d2459771e7b1bc4f1",
             "parentId": "hideout",
@@ -3950,17 +4453,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "5ffb53e9a049bda75dd2de2f",
             "_tpl": "576a5ed62459771e9c2096cb",
             "parentId": "ee565bb7e3ecda6bcafbd514",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "950f4eaddfb25c5ab4fa7d9a",
             "_tpl": "576a63cd2459771e796e0e11",
             "parentId": "ee565bb7e3ecda6bcafbd514",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "cfadc6fbf3d488abda498fdb",
             "_tpl": "5a7ae0c351dfba0017554310",
             "parentId": "hideout",
@@ -3971,32 +4477,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "af5aadde9c6de56eba2ba8dc",
             "_tpl": "5a6b5f868dc32e000a311389",
             "parentId": "cfadc6fbf3d488abda498fdb",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "981cfcca93af4bd03ea4cdb2",
             "_tpl": "5a6f5d528dc32e00094b97d9",
             "parentId": "fe5fd3b4e22950bff35e987b",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "4a0ccd9292eeaafc139d56d3",
             "_tpl": "5a6f58f68dc32e000a311390",
             "parentId": "fe5fd3b4e22950bff35e987b",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "fe5fd3b4e22950bff35e987b",
             "_tpl": "5a6f5e048dc32e00094b97da",
             "parentId": "cfadc6fbf3d488abda498fdb",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "1db8da3defe52950facea2be",
             "_tpl": "5a718b548dc32e000d46d262",
             "parentId": "cfadc6fbf3d488abda498fdb",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "eeeda5e0c30acab2387b89db",
             "_tpl": "56d59856d2720bd8418b456a",
             "parentId": "hideout",
@@ -4007,37 +4519,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "dbabaeabf92d0352c4fce93f",
             "_tpl": "56d5a1f7d2720bb3418b456a",
             "parentId": "eeeda5e0c30acab2387b89db",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "fee4ef2cba9e9bedefff9247",
             "_tpl": "56d5a2bbd2720bb8418b456a",
             "parentId": "eeeda5e0c30acab2387b89db",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "ed4aaae97ec775482f09894c",
             "_tpl": "56d5a77ed2720b90418b4568",
             "parentId": "b93adfe9bca1e5c1b74a5cf0",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "fe0ad0102ebca6deb2954d0f",
             "_tpl": "56d5a661d2720bd8418b456b",
             "parentId": "b93adfe9bca1e5c1b74a5cf0",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "b93adfe9bca1e5c1b74a5cf0",
             "_tpl": "56d5a407d2720bb3418b456b",
             "parentId": "eeeda5e0c30acab2387b89db",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "81bcefef5a4d5edbfa6370b6",
             "_tpl": "56d59948d2720bb7418b4582",
             "parentId": "eeeda5e0c30acab2387b89db",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "8e3ffa1c2a1bb3e7eb1543ab",
             "_tpl": "5f36a0e5fbf956000b716b65",
             "parentId": "hideout",
@@ -4048,52 +4567,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "c1adeedacaed103dec1b4d6a",
             "_tpl": "5f3e7801153b8571434a924c",
             "parentId": "8e3ffa1c2a1bb3e7eb1543ab",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "8ae3b91cfb91d93db2427d60",
             "_tpl": "5f3e778efcd9b651187d7201",
             "parentId": "8e3ffa1c2a1bb3e7eb1543ab",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "d0c6bd64d696371b4ffdfbfb",
             "_tpl": "5f3e7823ddc4f03b010e2045",
             "parentId": "8e3ffa1c2a1bb3e7eb1543ab",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "d275e2fa6c6fc2bdfd999daf",
             "_tpl": "5f3e7897ddc4f03b010e204a",
             "parentId": "d0c6bd64d696371b4ffdfbfb",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "28532d760731cbffdcd18207",
             "_tpl": "5f3e78a7fbf956000b716b8e",
             "parentId": "d0c6bd64d696371b4ffdfbfb",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "24f40bbf15cfc53bcddcd86f",
             "_tpl": "5f3e77b26cda304dcc634057",
             "parentId": "8e3ffa1c2a1bb3e7eb1543ab",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "47edab1c71c42feb2f5d4a5e",
             "_tpl": "5f3e772a670e2a7b01739a52",
             "parentId": "8e3ffa1c2a1bb3e7eb1543ab",
             "slotId": "mod_trigger"
-        }, {
+        },
+        {
             "_id": "3cc0ff9ec8ab6a474e7d1417",
             "_tpl": "5f3e76d86cda304dcc634054",
             "parentId": "8e3ffa1c2a1bb3e7eb1543ab",
             "slotId": "mod_hammer"
-        }, {
+        },
+        {
             "_id": "ffe27ca19c6ce73babc00cdb",
             "_tpl": "5f3e777688ca2d00ad199d25",
             "parentId": "8e3ffa1c2a1bb3e7eb1543ab",
             "slotId": "mod_catch"
-        }, {
+        },
+        {
             "_id": "8edbdea1febb00cf69e6e324",
             "_tpl": "5e81c3cbac2bb513793cdc75",
             "parentId": "hideout",
@@ -4104,52 +4633,62 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "94bef44fd20389e2fdd68f83",
             "_tpl": "5e81c519cb2b95385c177551",
             "parentId": "8edbdea1febb00cf69e6e324",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "afdcc1f4c1ea8d5cceb95b9b",
             "_tpl": "5e81c6bf763d9f754677beff",
             "parentId": "8edbdea1febb00cf69e6e324",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "ab95dfd3ca82ebb2d8a91db2",
             "_tpl": "5e81edc13397a21db957f6a1",
             "parentId": "8edbdea1febb00cf69e6e324",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "ffb17abb39cbf0eecd33838f",
             "_tpl": "5e81ee4dcb2b95385c177582",
             "parentId": "ab95dfd3ca82ebb2d8a91db2",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "46dcaadff40ba1f3a91b95e9",
             "_tpl": "5e81ee213397a21db957f6a6",
             "parentId": "ab95dfd3ca82ebb2d8a91db2",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "19cda7d4fb65ccf7eaea4bce",
             "_tpl": "5e81c4ca763d9f754677befa",
             "parentId": "8edbdea1febb00cf69e6e324",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "abaa1983649b1a856b6cc3e0",
             "_tpl": "5e81c6a2ac2bb513793cdc7f",
             "parentId": "8edbdea1febb00cf69e6e324",
             "slotId": "mod_trigger"
-        }, {
+        },
+        {
             "_id": "bbea479ec825bec6adf59ad5",
             "_tpl": "5e81c550763d9f754677befd",
             "parentId": "8edbdea1febb00cf69e6e324",
             "slotId": "mod_hammer"
-        }, {
+        },
+        {
             "_id": "2073a48c1cfdfa05d5af00cd",
             "_tpl": "5e81c539cb2b95385c177553",
             "parentId": "8edbdea1febb00cf69e6e324",
             "slotId": "mod_catch"
-        }, {
+        },
+        {
             "_id": "82943a8a8b5b8e8386735044",
             "_tpl": "6193a720f8ee7e52e42109ed",
             "parentId": "hideout",
@@ -4160,57 +4699,68 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "26e8ff23e571bad4dbe6ff65",
             "_tpl": "6194efe07c6c7b169525f11b",
             "parentId": "82943a8a8b5b8e8386735044",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "827b3b714d763e2c52fdd4a2",
             "_tpl": "6194f1f918a3974e5e7421e4",
             "parentId": "26e8ff23e571bad4dbe6ff65",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "16c0edadaea6c7ef7ecaaeec",
             "_tpl": "6194f41f9fb0c665d5490e75",
             "parentId": "82943a8a8b5b8e8386735044",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "cbbb7c83dc8daface9f9e3cc",
             "_tpl": "6194f2df645b5d229654ad77",
             "parentId": "16c0edadaea6c7ef7ecaaeec",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "22e1ab2a7629c8421ea6a0b2",
             "_tpl": "6194f3286db0f2477964e67d",
             "parentId": "16c0edadaea6c7ef7ecaaeec",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "3bac47c730ad5efba6fdf8bb",
             "_tpl": "6193d3149fb0c665d5490e32",
             "parentId": "82943a8a8b5b8e8386735044",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "ad37db1fed87c217ec2a7a5c",
             "_tpl": "6193d3cded0429009f543e6a",
             "parentId": "82943a8a8b5b8e8386735044",
             "slotId": "mod_trigger"
-        }, {
+        },
+        {
             "_id": "cc50d0bc9df6bd6066cac713",
             "_tpl": "6193d3be7c6c7b169525f0da",
             "parentId": "82943a8a8b5b8e8386735044",
             "slotId": "mod_hammer"
-        }, {
+        },
+        {
             "_id": "5efeaa4ea6315f23cddeeba5",
             "_tpl": "6193d5d4f8ee7e52e4210a1b",
             "parentId": "82943a8a8b5b8e8386735044",
             "slotId": "mod_catch"
-        }, {
+        },
+        {
             "_id": "2fbfeb1f67f573ce17c89a14",
             "_tpl": "6196255558ef8c428c287d1c",
             "parentId": "82943a8a8b5b8e8386735044",
             "slotId": "mod_mount_000"
-        }, {
+        },
+        {
             "_id": "a7fd9e6901ff9f0a95b106a8",
             "_tpl": "5a17f98cfcdbcb0980087290",
             "parentId": "hideout",
@@ -4221,27 +4771,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f117294ddfdd7d5e262ebafb",
             "_tpl": "5a17fb03fcdbcbcae668728f",
             "parentId": "a7fd9e6901ff9f0a95b106a8",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "2897e96b66bf170da6e5be94",
             "_tpl": "5a17fc70fcdbcb0176308b3d",
             "parentId": "a7fd9e6901ff9f0a95b106a8",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "e9f92f9a0d1a2db690ce5ea5",
             "_tpl": "5aba62f8d8ce87001943946b",
             "parentId": "a7fd9e6901ff9f0a95b106a8",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "1b762d3ad383abbd415e1e89",
             "_tpl": "5aba637ad8ce87001773e17f",
             "parentId": "a7fd9e6901ff9f0a95b106a8",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "ba4167fb2272ac9af2ca104b",
             "_tpl": "5abccb7dd8ce87001773e277",
             "parentId": "hideout",
@@ -4252,37 +4807,44 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "dfcf9adcce522cbfcced69fa",
             "_tpl": "5a17fb03fcdbcbcae668728f",
             "parentId": "ba4167fb2272ac9af2ca104b",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "cafcef992b57350fc0940a23",
             "_tpl": "5a17fb9dfcdbcbcae6687291",
             "parentId": "ba4167fb2272ac9af2ca104b",
             "slotId": "mod_stock"
-        }, {
+        },
+        {
             "_id": "96abfae916a42bec9aea66f0",
             "_tpl": "5a17fc70fcdbcb0176308b3d",
             "parentId": "ba4167fb2272ac9af2ca104b",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "6cfbe2fefd239783deabbf5c",
             "_tpl": "5aba62f8d8ce87001943946b",
             "parentId": "ba4167fb2272ac9af2ca104b",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "61ebb18d923afccb3b17b6dc",
             "_tpl": "5aba639ed8ce8700182ece67",
             "parentId": "ba4167fb2272ac9af2ca104b",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "fa4c23302e813b7df1b09396",
             "_tpl": "5abcc328d8ce8700194394f3",
             "parentId": "ba4167fb2272ac9af2ca104b",
             "slotId": "mod_muzzle"
-        }, {
+        },
+        {
             "_id": "b6acdfe7eaa7cdb2bfa2af5e",
             "_tpl": "602a9740da11d6478d5a06dc",
             "parentId": "hideout",
@@ -4293,32 +4855,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "6fdd2c985edda9181eb29ac5",
             "_tpl": "602a95edda11d6478d5a06da",
             "parentId": "b6acdfe7eaa7cdb2bfa2af5e",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "af64cd6dbd9ffcedcdb9ba82",
             "_tpl": "60228924961b8d75ee233c32",
             "parentId": "b6acdfe7eaa7cdb2bfa2af5e",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "c5bcbbbd744fa0fc9e257632",
             "_tpl": "60229948cacb6b0506369e27",
             "parentId": "af64cd6dbd9ffcedcdb9ba82",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "3a8daa58442077b2a62adfb4",
             "_tpl": "60228a76d62c9b14ed777a66",
             "parentId": "af64cd6dbd9ffcedcdb9ba82",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "97ac04c2bf581b6af49aa9f3",
             "_tpl": "602286df23506e50807090c6",
             "parentId": "b6acdfe7eaa7cdb2bfa2af5e",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "8cbab7ee081cbd50f3ee9bbd",
             "_tpl": "5d3eb3b0a4b93615055e84d2",
             "parentId": "hideout",
@@ -4329,32 +4897,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ad8f3e9afb2cfb2abdcfcbcf",
             "_tpl": "5d3eb5b6a4b9361eab311902",
             "parentId": "8cbab7ee081cbd50f3ee9bbd",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "efbb6829ffe8ff38ffb14efd",
             "_tpl": "5d3eb44aa4b93650d64e4979",
             "parentId": "8cbab7ee081cbd50f3ee9bbd",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "c5aaac2c8fe9ace6a55f5c8c",
             "_tpl": "5d3eb4aba4b93650d64e497d",
             "parentId": "efbb6829ffe8ff38ffb14efd",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "c288220b80a69aa5fadb7829",
             "_tpl": "5d3eb536a4b9363b1f22f8e2",
             "parentId": "efbb6829ffe8ff38ffb14efd",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "a0fea8cd9c03fc3b9a34bc11",
             "_tpl": "5d3eb5eca4b9363b1f22f8e4",
             "parentId": "8cbab7ee081cbd50f3ee9bbd",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "cb6b0fad2e612f6354f9e2b2",
             "_tpl": "5d67abc1a4b93614ec50137f",
             "parentId": "hideout",
@@ -4365,32 +4939,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bac2fec01dead7af3a95a707",
             "_tpl": "5d3eb5b6a4b9361eab311902",
             "parentId": "cb6b0fad2e612f6354f9e2b2",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "3add8e40729761c2c9eb73f9",
             "_tpl": "5d3eb44aa4b93650d64e4979",
             "parentId": "cb6b0fad2e612f6354f9e2b2",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "ffc8af4febdfb12e3c8c8be4",
             "_tpl": "5d3eb4aba4b93650d64e497d",
             "parentId": "3add8e40729761c2c9eb73f9",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "d0afe19e3c2aeb252dc31301",
             "_tpl": "5d3eb536a4b9363b1f22f8e2",
             "parentId": "3add8e40729761c2c9eb73f9",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "97aeedb19d48fd2fdf0db84c",
             "_tpl": "5d3eb5eca4b9363b1f22f8e4",
             "parentId": "cb6b0fad2e612f6354f9e2b2",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "1d22a09a952d0371e416dacc",
             "_tpl": "5b1fa9b25acfc40018633c01",
             "parentId": "hideout",
@@ -4401,32 +4981,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "cb8a99c84e30eea86bab5d9d",
             "_tpl": "5b1fa9ea5acfc40018633c0a",
             "parentId": "1d22a09a952d0371e416dacc",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "750a55cdfdaedc07d5639da3",
             "_tpl": "5b1faa0f5acfc40dc528aeb5",
             "parentId": "1d22a09a952d0371e416dacc",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "f781add6bfa66fc68ed1a5bf",
             "_tpl": "5a6f5d528dc32e00094b97d9",
             "parentId": "750a55cdfdaedc07d5639da3",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "2d3ef9d8cc0ef4ae6a0eef4b",
             "_tpl": "5a6f58f68dc32e000a311390",
             "parentId": "750a55cdfdaedc07d5639da3",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "f68f40f7d6bcf8ecae95d108",
             "_tpl": "5a718b548dc32e000d46d262",
             "parentId": "1d22a09a952d0371e416dacc",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "3e7f422c138ef7375ffe785c",
             "_tpl": "59f98b4986f7746f546d2cef",
             "parentId": "hideout",
@@ -4437,12 +5023,14 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "e92e4b346bb869dff4aa4aad",
             "_tpl": "59f99a7d86f7745b134aa97b",
             "parentId": "3e7f422c138ef7375ffe785c",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "bbcc98abb8cf958dff59dabf",
             "_tpl": "62330b3ed4dc74626d570b95",
             "parentId": "hideout",
@@ -4453,7 +5041,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a826dd99cc0fc4fa7aaefc60",
             "_tpl": "62330b3ed4dc74626d570b95",
             "parentId": "hideout",
@@ -4464,7 +5053,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "dd2c394a33df33a9ab02d4ba",
             "_tpl": "62330bfadc5883093563729b",
             "parentId": "hideout",
@@ -4475,7 +5065,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "bcfeebcba4bcc6a76c73ed27",
             "_tpl": "62330bfadc5883093563729b",
             "parentId": "hideout",
@@ -4486,7 +5077,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "0f4dd0176004f90d09f9fec7",
             "_tpl": "62330c18744e5e31df12f516",
             "parentId": "hideout",
@@ -4497,7 +5089,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ca3cc8458daeb8e42a44bedc",
             "_tpl": "62330c18744e5e31df12f516",
             "parentId": "hideout",
@@ -4508,7 +5101,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "9f2b65add7a7286acdd6c5f5",
             "_tpl": "62330c40bdd19b369e1e53d1",
             "parentId": "hideout",
@@ -4519,7 +5113,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "dcbce2cd8d82cade6ab01a75",
             "_tpl": "62330c40bdd19b369e1e53d1",
             "parentId": "hideout",
@@ -4530,7 +5125,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f9aae57fcbece367d1736061",
             "_tpl": "6576f4708ca9c4381d16cd9d",
             "parentId": "hideout",
@@ -4541,7 +5137,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7ca7aa12aeb5d9eac16762e5",
             "_tpl": "6576f4708ca9c4381d16cd9d",
             "parentId": "hideout",
@@ -4552,7 +5149,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ecc7c755adf0faa2eecd3aee",
             "_tpl": "6576f93989f0062e741ba952",
             "parentId": "hideout",
@@ -4563,7 +5161,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "ae684f0007f84bc01b82f9ca",
             "_tpl": "6576f93989f0062e741ba952",
             "parentId": "hideout",
@@ -4574,7 +5173,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "931ad09dd17e74913aa1cbed",
             "_tpl": "628e4e576d783146b124c64d",
             "parentId": "hideout",
@@ -4585,7 +5185,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "f202753efa000776a00fca31",
             "_tpl": "628e4e576d783146b124c64d",
             "parentId": "hideout",
@@ -4596,7 +5197,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "7b5cacfc5ce7cef9b86d5dc7",
             "_tpl": "63088377b5cd696784087147",
             "parentId": "hideout",
@@ -4607,32 +5209,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "0f4cbe425a1e599def3abc6f",
             "_tpl": "630764fea987397c0816d219",
             "parentId": "7b5cacfc5ce7cef9b86d5dc7",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "fd2bcbefd22979cd185ec3fa",
             "_tpl": "63075cc5962d0247b029dc2a",
             "parentId": "7b5cacfc5ce7cef9b86d5dc7",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "9f15cea6a85de41d3e1fa749",
             "_tpl": "630765cb962d0247b029dc45",
             "parentId": "fd2bcbefd22979cd185ec3fa",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "c5cffcfafad5deafafca9e3a",
             "_tpl": "630765777d50ff5e8a1ea718",
             "parentId": "fd2bcbefd22979cd185ec3fa",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "90a8dbde1c6ba4dada7efa06",
             "_tpl": "63076701a987397c0816d21b",
             "parentId": "7b5cacfc5ce7cef9b86d5dc7",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "b15a058dfddeaca379a4dd9d",
             "_tpl": "61a4c8884f95bc3b2c5dc96f",
             "parentId": "hideout",
@@ -4643,27 +5251,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d5dbaefe72e128f3b2f68368",
             "_tpl": "619f54a1d25cbd424731fb99",
             "parentId": "b15a058dfddeaca379a4dd9d",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "9ab1bb8a7d2109ebf65edd76",
             "_tpl": "619f4cee4c58466fe1228435",
             "parentId": "b15a058dfddeaca379a4dd9d",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "eabe07bbcb280ea8e9c6abb7",
             "_tpl": "619f4d304c58466fe1228437",
             "parentId": "b15a058dfddeaca379a4dd9d",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "1fec8cec76c56d2b545a4fda",
             "_tpl": "619f4bffd25cbd424731fb97",
             "parentId": "b15a058dfddeaca379a4dd9d",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "0fb0f7f6c18e8694b0d1c2f3",
             "_tpl": "624c2e8614da335f1e034d8c",
             "parentId": "hideout",
@@ -4674,22 +5287,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "d5ca7c002ba6e51cfab37f63",
             "_tpl": "624c3074dbbd335e8e6becf3",
             "parentId": "0fb0f7f6c18e8694b0d1c2f3",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "ee9e0e12ee098b6bdc5e1be9",
             "_tpl": "619f4d304c58466fe1228437",
             "parentId": "0fb0f7f6c18e8694b0d1c2f3",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "cd81becd52d0f8e4e0d16f4b",
             "_tpl": "619f4bffd25cbd424731fb97",
             "parentId": "0fb0f7f6c18e8694b0d1c2f3",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "cc0e369bad5bddf6ecff95bc",
             "_tpl": "633ec7c2a6918cb895019c6c",
             "parentId": "hideout",
@@ -4700,17 +5317,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "85a35ea1119af827c255aeea",
             "_tpl": "633ec6ee025b096d320a3b15",
             "parentId": "cc0e369bad5bddf6ecff95bc",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "daeadea6bdf767a7a25e02fd",
             "_tpl": "633ec8e4025b096d320a3b1e",
             "parentId": "cc0e369bad5bddf6ecff95bc",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "97fcb8491d0c7a8ed026c9ab",
             "_tpl": "63088377b5cd696784087147",
             "parentId": "hideout",
@@ -4721,32 +5341,38 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "014ead47f53a349df9ad51fa",
             "_tpl": "630764fea987397c0816d219",
             "parentId": "97fcb8491d0c7a8ed026c9ab",
             "slotId": "mod_barrel"
-        }, {
+        },
+        {
             "_id": "ef1b14d0b39abefeb41bcd9c",
             "_tpl": "63075cc5962d0247b029dc2a",
             "parentId": "97fcb8491d0c7a8ed026c9ab",
             "slotId": "mod_reciever"
-        }, {
+        },
+        {
             "_id": "c2dcd3978e1e26b64fab2221",
             "_tpl": "630765cb962d0247b029dc45",
             "parentId": "ef1b14d0b39abefeb41bcd9c",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "f7f45abe1d5afabc89cb2a56",
             "_tpl": "630765777d50ff5e8a1ea718",
             "parentId": "ef1b14d0b39abefeb41bcd9c",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "df4fd6ce1fad66fa9ee80690",
             "_tpl": "63076701a987397c0816d21b",
             "parentId": "97fcb8491d0c7a8ed026c9ab",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "e967ded978ed55ad21c2b969",
             "_tpl": "61a4c8884f95bc3b2c5dc96f",
             "parentId": "hideout",
@@ -4757,27 +5383,32 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "a8da09fbe83c9da4ad8bedee",
             "_tpl": "619f54a1d25cbd424731fb99",
             "parentId": "e967ded978ed55ad21c2b969",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "36dfb6fafad51baef6ad815e",
             "_tpl": "619f4cee4c58466fe1228435",
             "parentId": "e967ded978ed55ad21c2b969",
             "slotId": "mod_sight_rear"
-        }, {
+        },
+        {
             "_id": "d5af761c3c4dda48f8665eeb",
             "_tpl": "619f4d304c58466fe1228437",
             "parentId": "e967ded978ed55ad21c2b969",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "54e6cccd3b10baa605ffdff2",
             "_tpl": "619f4bffd25cbd424731fb97",
             "parentId": "e967ded978ed55ad21c2b969",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "cfeefce853c48bd197474d5c",
             "_tpl": "624c2e8614da335f1e034d8c",
             "parentId": "hideout",
@@ -4788,22 +5419,26 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "cb26eafc6decdeab0cd30a1a",
             "_tpl": "624c3074dbbd335e8e6becf3",
             "parentId": "cfeefce853c48bd197474d5c",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "ce20615dd3c1e5642feac1fd",
             "_tpl": "619f4d304c58466fe1228437",
             "parentId": "cfeefce853c48bd197474d5c",
             "slotId": "mod_sight_front"
-        }, {
+        },
+        {
             "_id": "1e9be9d32d52d2bc8b8f0ce0",
             "_tpl": "619f4bffd25cbd424731fb97",
             "parentId": "cfeefce853c48bd197474d5c",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "621cc07ca2f746f925a8c14a",
             "_tpl": "633ec7c2a6918cb895019c6c",
             "parentId": "hideout",
@@ -4814,17 +5449,20 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "32a7fd921ba0ebd8faa85cf9",
             "_tpl": "633ec6ee025b096d320a3b15",
             "parentId": "621cc07ca2f746f925a8c14a",
             "slotId": "mod_magazine"
-        }, {
+        },
+        {
             "_id": "98cfbf822ebc0b5becaaa649",
             "_tpl": "633ec8e4025b096d320a3b1e",
             "parentId": "621cc07ca2f746f925a8c14a",
             "slotId": "mod_pistol_grip"
-        }, {
+        },
+        {
             "_id": "03b702156dbdd4bd86b91cef",
             "_tpl": "63076701a987397c0816d21b",
             "parentId": "hideout",
@@ -4835,7 +5473,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "2281fcc678f0cd6fc510cddd",
             "_tpl": "630769c4962d0247b029dc60",
             "parentId": "hideout",
@@ -4846,7 +5485,8 @@
                 "BuyRestrictionMax": "30000",
                 "BuyRestrictionCurrent": 0
             }
-        }, {
+        },
+        {
             "_id": "b763aacb3415f3ae25e6cb89",
             "_tpl": "630767c37d50ff5e8a1ea71a",
             "parentId": "hideout",


### PR DESCRIPTION
Currently any ammopack bought from a questmaniac trader contains only one cartridge. This should fix this issue. I did not add any new ammo packs, but Tarkov has added quite a few over the last patches so the new ones should be added at some time.
Sadly my autoformatter formats jsons differently than they were before so this is quite a huge diff across the board.
